### PR TITLE
Fix for panic during SVE2 BSA test

### DIFF
--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -108,6 +108,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
   /* Get SMBIOS Protocol Handler */
   Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&SmbiosProtocol);
   if (EFI_ERROR(Status)) {
+    SmbiosTable->slot_count = 0;
     return;
   }
 


### PR DESCRIPTION
-  Set SMBIOS table slot_count to 0 if protocol does not exist