### PR TITLE
BSA: Fix for bug related to 32/64 bit access in pal_exerciser

### DIFF
--- a/test_pool/exerciser/e007.c
+++ b/test_pool/exerciser/e007.c
@@ -70,11 +70,11 @@ uint32_t test_sequence2(void *dram_buf1_virt, void *dram_buf1_phys, uint32_t ins
   val_pe_cache_clean_invalidate_range((uint64_t)dram_buf2_virt, (uint64_t)dma_len);
 
   /* Perform DMA OUT to copy contents of dram_buf2 to exerciser memory */
-  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf2_phys, dma_len, instance);
+  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf2_phys, (uint64_t)dma_len, instance);
   val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance);
 
   /* Perform DMA IN to copy content back from exerciser memory to dram_buf1 */
-  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf1_phys, dma_len, instance);
+  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf1_phys, (uint64_t)dma_len, instance);
   val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance);
 
   /* Invalidate dram_buf1 and dram_buf2 contents present in CPU caches */
@@ -109,11 +109,11 @@ uint32_t test_sequence1(void *dram_buf1_virt, void *dram_buf1_phys, uint32_t ins
   val_memory_set(dram_buf1_virt, dma_len, NEW_DATA);
 
   /* Perform DMA OUT to copy contents of dram_buf1 to exerciser memory */
-  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf1_phys, dma_len, instance);
+  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf1_phys, (uint64_t)dma_len, instance);
   val_exerciser_ops(START_DMA, EDMA_TO_DEVICE, instance);
 
   /* Perform DMA IN to copy the content from exerciser memory to dram_buf1 */
-  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf1_phys, dma_len, instance);
+  val_exerciser_set_param(DMA_ATTRIBUTES, (uint64_t)dram_buf1_phys, (uint64_t)dma_len, instance);
   val_exerciser_ops(START_DMA, EDMA_FROM_DEVICE, instance);
 
   /* Write dram_buf2 with NEW_DATA to compare dram_buf1 content */


### PR DESCRIPTION
 - Replaced pal_mmio_write with multiple pal_mmio_writes to write 64bit DMA_BUS_ADDR register
 - Replaced pal_mmio_read with multiple pal_mmio_read to read 64bit DMA_BUS_ADDR register