### PR TITLE
Align IOVIRT_BLOCK to the correct length

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -598,7 +598,7 @@ typedef union {
   ID_MAP map;
 }NODE_DATA_MAP;
 
-#define MAX_NAMED_COMP_LENGTH 150
+#define MAX_NAMED_COMP_LENGTH 256
 
 typedef struct {
   uint64_t smmu_base;                  /* SMMU base to which component is attached, else NULL */

--- a/pal/baremetal/target/RDN2/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_struct.h
@@ -100,7 +100,7 @@ typedef struct {
   uint64_t smmu_base;
 } PLATFORM_OVERRIDE_IOVIRT_PMCG_INFO_BLOCK;
 
-#define MAX_NAMED_COMP_LENGTH 150
+#define MAX_NAMED_COMP_LENGTH 256
 typedef struct {
         uint32_t its_count;
         uint32_t identifiers[1];     /* GIC ITS identifier arrary */

--- a/pal/uefi_acpi/include/pal_uefi.h
+++ b/pal/uefi_acpi/include/pal_uefi.h
@@ -334,7 +334,7 @@ typedef union {
   ID_MAP map;
 }NODE_DATA_MAP;
 
-#define MAX_NAMED_COMP_LENGTH 150
+#define MAX_NAMED_COMP_LENGTH 256
 
 typedef struct {
   UINT64 smmu_base;                     /* SMMU base to which component is attached, else NULL */

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -22,7 +22,7 @@
 #include <linux/slab.h>
 #endif
 
-#define MAX_NAMED_COMP_LENGTH 150
+#define MAX_NAMED_COMP_LENGTH 256
 
 #ifdef TARGET_BM_BOOT
 


### PR DESCRIPTION
Migrated from https://github.com/ARM-software/bsa-acs/pull/503

This PR fixes a bug for GET_SMMU_INFO. Currently there are two definitions of MAX_NAMED_COMP_LENGTH: 150 and 256, this will cause inconsistent IOVIRT_BLOCK size and trigger warning to block the SMMU test. Set all MAX_NAMED_COMP_LENGTH to 150 to fix it.

```
 SMMU_INFO: Number of SMMU CTRL       :    2
 SMMU_INFO: SMMU index 00 version     :    v3.1
GET_SMMU_INFO: Index (1) is greater than num of SMMU
 SMMU_INFO: SMMU index 01 version     :    v0
```