### PR TITLE
Handle EL2 virt interrupt for DT build

### DIFF
--- a/pal/uefi_acpi/src/pal_timer_wd.c
+++ b/pal/uefi_acpi/src/pal_timer_wd.c
@@ -51,11 +51,6 @@ pal_timer_platform_override(TIMER_INFO_TABLE *TimerTable)
       TimerTable->gt_info[0].gsiv[0] = PLATFORM_OVERRIDE_PLATFORM_TIMER_GSIV;
   }
 
-  //GTDT does not have this information yet.
-  if (PLATFORM_OVERRIDE_EL2_VIR_TIMER_GSIV) {
-      TimerTable->header.el2_virt_timer_gsiv = PLATFORM_OVERRIDE_EL2_VIR_TIMER_GSIV;
-  }
-
 }
 
 /**
@@ -149,12 +144,8 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
       virtualpl2 = &(gGtdtHdr->PlatformTimerOffset);
       TimerTable->header.el2_virt_timer_gsiv = *(++virtualpl2);
       TimerTable->header.el2_virt_timer_flag = *(++virtualpl2);
-      if (TimerTable->header.el2_virt_timer_gsiv == 0) {
+      if (TimerTable->header.el2_virt_timer_gsiv == 0)
          acs_print(ACS_PRINT_DEBUG, L"  GTDT don't have el2 virt timer info\n");
-         acs_print(ACS_PRINT_DEBUG, L"  using bsa recommended value 28\n");
-         TimerTable->header.el2_virt_timer_gsiv = PLATFORM_OVERRIDE_EL2_VIR_TIMER_GSIV;
-      }
-
   }
   else
       pal_timer_platform_override(TimerTable);


### PR DESCRIPTION
- Added support to derive the EL2 virtual interrupt ID for BSA-DT from the device tree.
- Removed fallback logic that overrides PE timer interrupt values when missing in DT or ACPI, to ensure such errors are detected instead of silently bypassed.
 
 Fixes https://github.com/ARM-software/bsa-acs/issues/490

 


