### PR TITLE
Align IOVIRT_BLOCK size by unifying MAX_NAMED_COMP_LENGTH

### DIFF
--- a/pal/uefi_dt/include/pal_uefi.h
+++ b/pal/uefi_dt/include/pal_uefi.h
@@ -321,7 +321,7 @@ typedef union {
   ID_MAP map;
 }NODE_DATA_MAP;
 
-#define MAX_NAMED_COMP_LENGTH 256
+#define MAX_NAMED_COMP_LENGTH 150
 
 typedef struct {
   UINT64 smmu_base;                     /* SMMU base to which component is attached, else NULL */


### PR DESCRIPTION
.
-Resolved inconsistency in MAX_NAMED_COMP_LENGTH definition to prevent
 SMMU test failure due to mismatched IOVIRT_BLOCK size.
 
 Fix for BSA PR Raised by partner: https://github.com/ARM-software/bsa-acs/pull/503
 Sysarch-ACS PR Raised by partner: https://github.com/ARM-software/sysarch-acs/pull/7

