### PR TITLE
Add cortex a78 pmu compatible string and align the secondary PE stack ptr to 16b

### DIFF
--- a/pal/uefi_dt/include/pal_uefi.h
+++ b/pal/uefi_dt/include/pal_uefi.h
@@ -55,6 +55,10 @@ extern UINT32 g_pcie_cache_present;
 #define BAR_MT_SHIFT    3
 #define BAR_BASE_SHIFT  4
 
+/* smbios defines */
+#define SMBIOS_OBTAIN_PROCESSOR_FAMILY2 0xFE
+#define SMBIOS_OBTAIN_CORE_COUNT2       0xFF
+
 typedef enum {
   MMIO = 0,
   IO = 1

--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -30,7 +30,6 @@
 #include "include/pal_dt.h"
 #include "include/pal_dt_spec.h"
 
-static   EFI_ACPI_6_1_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER *gMadtHdr;
 UINT8   *gSecondaryPeStack;
 UINT64  gMpidrMax;
 static UINT32 g_num_pe;
@@ -40,6 +39,7 @@ pal_strncmp(CHAR8 *str1, CHAR8 *str2, UINT32 len);
 
 static char pmu_dt_arr[][PMU_COMPATIBLE_STR_LEN] = {
     "arm,armv8-pmuv3",
+    "arm,cortex-a78-pmu",
     "arm,cortex-a76-pmu",
     "arm,cortex-a73-pmu",
     "arm,cortex-a72-pmu",
@@ -104,11 +104,11 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
   }
 
   Type4Entry = SmbiosTable->type4_info;
+  SmbiosTable->slot_count = 0;
 
   /* Get SMBIOS Protocol Handler */
   Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&SmbiosProtocol);
   if (EFI_ERROR(Status)) {
-    SmbiosTable->slot_count = 0;
     return;
   }
 
@@ -119,13 +119,14 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
       return;
     }
 
-    acs_print(ACS_PRINT_DEBUG, L" Smbios type %d\n", Record->Type);
     /* Check of record if of type 4 */
     if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
+      acs_print(ACS_PRINT_DEBUG, L" Smbios type %d found\n", Record->Type);
+
       Type4Record = (SMBIOS_TABLE_TYPE4 *)Record;
 
       /* Save Processor family type */
-      if (Type4Record->ProcessorFamily == 0xFE)
+      if (Type4Record->ProcessorFamily == SMBIOS_OBTAIN_PROCESSOR_FAMILY2)
         Type4Entry->processor_family = Type4Record->ProcessorFamily2;
       else
         Type4Entry->processor_family = Type4Record->ProcessorFamily;
@@ -133,7 +134,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
       acs_print(ACS_PRINT_DEBUG, L"  Processor Family 0x%x\n", Type4Entry->processor_family);
 
       /* Save Processor core count */
-      if (Type4Record->CoreCount == 0xFF)
+      if (Type4Record->CoreCount == SMBIOS_OBTAIN_CORE_COUNT2)
         Type4Entry->core_count = Type4Record->CoreCount2;
       else
         Type4Entry->core_count = Type4Record->CoreCount;
@@ -145,8 +146,9 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
       if (SmbiosTable->slot_count >= MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED) {
         acs_print(ACS_PRINT_WARN, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
-        acs_print(ACS_PRINT_WARN, L"\n Number of SMBIOS Slots greater than %d",
+        acs_print(ACS_PRINT_WARN, L" Number of SMBIOS Slots greater than %d\n",
                         MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
+        SmbiosTable->slot_count = MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED;
         return;
       }
     }
@@ -255,7 +257,8 @@ VOID
 PalAllocateSecondaryStack(UINT64 mpidr)
 {
   EFI_STATUS Status;
-  UINT32 NumPe, Aff0, Aff1, Aff2, Aff3;
+  UINT8 *Buffer;
+  UINT32 NumPe, Aff0, Aff1, Aff2, Aff3, StackSize;
 
   Aff0 = ((mpidr & 0x00000000ff) >>  0);
   Aff1 = ((mpidr & 0x000000ff00) >>  8);
@@ -265,13 +268,31 @@ PalAllocateSecondaryStack(UINT64 mpidr)
   NumPe = ((Aff3+1) * (Aff2+1) * (Aff1+1) * (Aff0+1));
 
   if (gSecondaryPeStack == NULL) {
+      // AllocatePool guarantees 8b alignment, but stack pointers must be 16b
+      // aligned for aarch64. Pad the size with an extra 8b so that we can
+      // force-align the returned buffer to 16b. We store the original address
+      // returned if we do have to align we still have the proper address to
+      // free.
+
+      StackSize = (NumPe * SIZE_STACK_SECONDARY_PE) + CPU_STACK_ALIGNMENT;
       Status = gBS->AllocatePool ( EfiBootServicesData,
-                    (NumPe * SIZE_STACK_SECONDARY_PE),
-                    (VOID **) &gSecondaryPeStack);
+                    StackSize,
+                    (VOID **) &Buffer);
       if (EFI_ERROR(Status)) {
           acs_print(ACS_PRINT_ERR, L"\n FATAL - Allocation for Seconday stack failed %x\n", Status);
       }
-      pal_pe_data_cache_ops_by_va((UINT64)&gSecondaryPeStack, CLEAN_AND_INVALIDATE);
+      pal_pe_data_cache_ops_by_va((UINT64)&Buffer, CLEAN_AND_INVALIDATE);
+
+      // Check if we need alignment
+      if ((UINT8 *)(((UINTN) Buffer) & (0xFll))) {
+        // Needs alignment, so just store the original address and return +1
+        ((UINTN *)Buffer)[0] = (UINTN)Buffer;
+        gSecondaryPeStack = (UINT8 *)(((UINTN *)Buffer)+1);
+      } else {
+        // None needed. Just store the address with padding and return.
+        ((UINTN *)Buffer)[1] = (UINTN)Buffer;
+        gSecondaryPeStack = (UINT8 *)(((UINTN *)Buffer)+2);
+      }
   }
 
 }
@@ -287,62 +308,13 @@ PalAllocateSecondaryStack(UINT64 mpidr)
 VOID
 pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 {
-  EFI_ACPI_6_1_GIC_STRUCTURE    *Entry = NULL;
-  PE_INFO_ENTRY                 *Ptr = NULL;
-  UINT32                        TableLength = 0;
-  UINT32                        Length = 0;
-  UINT64                        MpidrAff0Max = 0, MpidrAff1Max = 0, MpidrAff2Max = 0, MpidrAff3Max = 0;
-
-
   if (PeTable == NULL) {
     acs_print(ACS_PRINT_ERR, L" Input PE Table Pointer is NULL. Cannot create PE INFO\n");
     return;
   }
+  PeTable->header.num_of_pe = 0;
   pal_pe_create_info_table_dt(PeTable);
   return;
-
-  gMadtHdr = (EFI_ACPI_6_1_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER *) pal_get_madt_ptr();
-
-  if (gMadtHdr != NULL) {
-    TableLength =  gMadtHdr->Header.Length;
-    acs_print(ACS_PRINT_INFO, L"  MADT is at %x and length is %x\n", gMadtHdr, TableLength);
-  }
-
-  PeTable->header.num_of_pe = 0;
-
-  Entry = (EFI_ACPI_6_1_GIC_STRUCTURE *) (gMadtHdr + 1);
-  Length = sizeof (EFI_ACPI_6_1_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER);
-  Ptr = PeTable->pe_info;
-
-  do {
-
-    if (Entry->Type == EFI_ACPI_6_1_GIC) {
-      //Fill in the cpu num and the mpidr in pe info table
-      Ptr->mpidr    = Entry->MPIDR;
-      Ptr->pe_num   = PeTable->header.num_of_pe;
-      Ptr->pmu_gsiv = Entry->PerformanceInterruptGsiv;
-      acs_print(ACS_PRINT_DEBUG, L"  MPIDR %x PE num %d\n", Ptr->mpidr, Ptr->pe_num);
-      pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
-      Ptr++;
-      PeTable->header.num_of_pe++;
-
-      MpidrAff0Max = UPDATE_AFF_MAX(MpidrAff0Max, Entry->MPIDR, 0x000000ff);
-      MpidrAff1Max = UPDATE_AFF_MAX(MpidrAff1Max, Entry->MPIDR, 0x0000ff00);
-      MpidrAff2Max = UPDATE_AFF_MAX(MpidrAff2Max, Entry->MPIDR, 0x00ff0000);
-      MpidrAff3Max = UPDATE_AFF_MAX(MpidrAff3Max, Entry->MPIDR, 0xff00000000);
-    }
-
-    Length += Entry->Length;
-    Entry = (EFI_ACPI_6_1_GIC_STRUCTURE *) ((UINT8 *)Entry + (Entry->Length));
-
-  }while(Length < TableLength);
-
-  gMpidrMax = MpidrAff0Max | MpidrAff1Max | MpidrAff2Max | MpidrAff3Max;
-  g_num_pe = PeTable->header.num_of_pe;
-  pal_pe_data_cache_ops_by_va((UINT64)PeTable, CLEAN_AND_INVALIDATE);
-  pal_pe_data_cache_ops_by_va((UINT64)&gMpidrMax, CLEAN_AND_INVALIDATE);
-  PalAllocateSecondaryStack(gMpidrMax);
-
 }
 
 /**


### PR DESCRIPTION
Add cortex a78 pmu compatible string and align the secondary PE stack pointer to 16b for aarch64

 Integrates some fixes from the ACPI version of this file.
 Removes some unreachable ACPI code
 Add support for an addition cortex pmu compatible string

 Reference BSA PR: https://github.com/ARM-software/bsa-acs/pull/489

Contributor @jbrasen