### PR TITLE
fix(pcie): move next_bdf label to avoid array out of bound

### DIFF
--- a/test_pool/pcie/p038.c
+++ b/test_pool/pcie/p038.c
@@ -52,9 +52,9 @@ payload(void)
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
+next_bdf:
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
-      next_bdf:
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
 
@@ -81,7 +81,7 @@ payload(void)
               if (ecam_base == rp_ecam_base && segment == rp_segment)
               {
                   val_print(ACS_PRINT_DEBUG,
-                            "\n       ECAM base 0x%x matches with RPs base address ", ecam_base);
+                            "\n       ECAM base 0x%llx matches with RPs base address ", ecam_base);
                   goto next_bdf;
               }
 

--- a/test_pool/pcie/p073.c
+++ b/test_pool/pcie/p073.c
@@ -53,9 +53,9 @@ payload(void)
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
+next_bdf:
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
-      next_bdf:
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
 
@@ -82,7 +82,7 @@ payload(void)
               if (ecam_base == rp_ecam_base && segment == rp_segment)
               {
                   val_print(ACS_PRINT_DEBUG,
-                            "\n       ECAM base 0x%x matches with RPs base address ", ecam_base);
+                            "\n       ECAM base 0x%llx matches with RPs base address ", ecam_base);
                   goto next_bdf;
               }
 


### PR DESCRIPTION
 - Fixes: #28
 - Having jump label inside loop bypassed the check for bounds.
 - Moved it outside to prevent the sceanrio.


Change-Id: I5b64d03ec96703f26df79565a46c1e69dcabb2c7