### PR TITLE
fix(iovirt): Add support for SMMU address mapping

### DIFF
--- a/pal/baremetal/target/RDN2/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_fvp.h
@@ -788,6 +788,9 @@
 #define IOVIRT_NAMED_COMP1_NUM_MAP    9
 #define IOVIRT_MAX_NUM_MAP            33
 
+/* Size used to Map the SMMU Register Space, if not mapped */
+#define SMMU_MAP_SIZE                 0x20000 //2*64 KB
+
 /* DMA platform config parameters */
 #define PLATFORM_OVERRIDE_DMA_CNT   0
 

--- a/pal/include/platform_override.h
+++ b/pal/include/platform_override.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2022-2025 Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2025, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,9 @@
 /* Change OVERRIDE_SMMU_BASE to non-zero value for this to take effect */
 #define PLATFORM_OVERRIDE_SMMU_BASE        0x0 //0x2B400000
 #define PLATFORM_OVERRIDE_SMMU_ARCH_MAJOR  3
+
+/* Size used to Map the SMMU Register Space, if not mapped */
+#define PLATFORM_OVERRIDE_SMMU_MAP_SIZE    0x20000 //2*64 KB
 
 extern UINT32 g_pcie_p2p;
 extern UINT32 g_pcie_cache_present;

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -111,6 +111,9 @@
 /* Max SID Size in SMMU is 32 */
 #define MAX_SID  32
 
+/* Size used to Map the SMMU Register Space, if not mapped */
+#define SMMU_MAP_SIZE        PLATFORM_OVERRIDE_SMMU_MAP_SIZE
+
 #if PLATFORM_OVERRIDE_TIMEOUT
     #define TIMEOUT_LARGE    PLATFORM_OVERRIDE_TIMEOUT_LARGE
     #define TIMEOUT_MEDIUM   PLATFORM_OVERRIDE_TIMEOUT_MEDIUM

--- a/val/src/acs_iovirt.c
+++ b/val/src/acs_iovirt.c
@@ -19,6 +19,7 @@
 #include "include/acs_common.h"
 #include "include/acs_iovirt.h"
 #include "include/acs_smmu.h"
+#include "include/acs_mmu.h"
 
 IOVIRT_INFO_TABLE *g_iovirt_info_table;
 uint32_t g_num_smmus;
@@ -268,6 +269,7 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 {
   uint32_t i, smmu_ver;
   uint32_t smmu_minor;
+  uint64_t smmu_base = 0;
 
   if (iovirt_info_table == NULL)
   {
@@ -284,6 +286,17 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
   val_print(ACS_PRINT_TEST,
             " SMMU_INFO: Number of SMMU CTRL       :    %d\n", g_num_smmus);
   for (i = 0; i < g_num_smmus; i++) {
+
+    smmu_base = val_smmu_get_info(SMMU_CTRL_BASE, i);
+    val_print(ACS_PRINT_DEBUG, "\n   SMMU index %x, ", i);
+    val_print(ACS_PRINT_DEBUG, "Base : 0x%llx", smmu_base);
+
+#ifndef TARGET_LINUX
+    val_print(ACS_PRINT_DEBUG, "\n   Check for SMMU index %x entry in memmap", i);
+    if (val_mmu_update_entry(smmu_base, SMMU_MAP_SIZE))
+      val_print(ACS_PRINT_WARN, "\n   Adding SMMU index %x entry failed", i);
+#endif
+
     smmu_ver = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, i);
     val_print(ACS_PRINT_TEST,
             " SMMU_INFO: SMMU index %.2d ", i);


### PR DESCRIPTION
Check if the SMMU base address is already mapped and map it if not. By default, 128 KB is mapped from the base. A platform override define is introduced to allow larger mappings if needed.

Fixes: #27