### PR TITLE
Move to edk2-stable202505 build tag for acs builds

### DIFF
--- a/.github/workflows/acs_build_check.yml
+++ b/.github/workflows/acs_build_check.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           git clone --recursive https://github.com/tianocore/edk2
           cd edk2
-          git checkout edk2-stable202411
+          git checkout edk2-stable202505
           cd ..
           git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 
@@ -65,7 +65,7 @@ jobs:
         run: |
           git clone --recursive https://github.com/tianocore/edk2
           cd edk2
-          git checkout edk2-stable202411
+          git checkout edk2-stable202505
           cd ..
           git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 
@@ -108,7 +108,7 @@ jobs:
         run: |
           git clone --recursive https://github.com/tianocore/edk2
           cd edk2
-          git checkout edk2-stable202411
+          git checkout edk2-stable202505
           cd ..
           git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 
@@ -152,7 +152,7 @@ jobs:
         run: |
           git clone --recursive https://github.com/tianocore/edk2
           cd edk2
-          git checkout edk2-stable202411
+          git checkout edk2-stable202505
           cd ..
           git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 
@@ -195,7 +195,7 @@ jobs:
         run: |
           git clone --recursive https://github.com/tianocore/edk2
           cd edk2
-          git checkout edk2-stable202411
+          git checkout edk2-stable202505
           cd ..
           git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 


### PR DESCRIPTION
- Moved the github workflows to use edk2-stable202505 tag
- Readme updated to recommended the same tag

Fixes #40 