### PR TITLE
fix(gic) : Type mismatch in pal_gic_install_isr and cast ISR to HARDWARE_INTERRUPT_HANDLER

### DIFF
--- a/pal/uefi_acpi/src/pal_gic.c
+++ b/pal/uefi_acpi/src/pal_gic.c
@@ -199,7 +199,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   @return Status of the operation
 **/
 UINT32
-pal_gic_install_isr(UINT32 int_id,  VOID (*isr)())
+pal_gic_install_isr(UINT32 int_id,  VOID (*isr)(void))
 {
 
   EFI_STATUS  Status;
@@ -214,10 +214,12 @@ pal_gic_install_isr(UINT32 int_id,  VOID (*isr)())
   gInterrupt->DisableInterruptSource(gInterrupt, int_id);
 
   //Register our handler
-  Status = gInterrupt->RegisterInterruptSource (gInterrupt, int_id, isr);
+  Status = gInterrupt->RegisterInterruptSource (gInterrupt, int_id,
+                                            (HARDWARE_INTERRUPT_HANDLER)(VOID *)(isr));
   if (EFI_ERROR(Status)) {
     Status =  gInterrupt->RegisterInterruptSource (gInterrupt, int_id, NULL);  //Deregister existing handler
-    Status = gInterrupt->RegisterInterruptSource (gInterrupt, int_id, isr);  //register our Handler.
+    Status = gInterrupt->RegisterInterruptSource (gInterrupt, int_id,
+                        (HARDWARE_INTERRUPT_HANDLER)(VOID *)(isr));  //register our Handler.
     //Even if this fails. there is nothing we can do in UEFI mode
   }
 


### PR DESCRIPTION
- Updated ISR function pointer declaration to use explicit void parameter: `VOID (*isr)(void)`
- Fixed type mismatch by explicitly casting `isr` to `HARDWARE_INTERRUPT_HANDLER` during registration
- Ensures compatibility with expected interrupt handler signature in the EFI interrupt protocol

Fixes : #12 #49 
Change-Id: Ie03ceeba46b92c60c4b139dd7b83cad9f141033c