### PR TITLE
fix(ras005): Initialize intr_pending for every node

### DIFF
--- a/test_pool/ras/ras005.c
+++ b/test_pool/ras/ras005.c
@@ -105,6 +105,7 @@ payload()
     if (test_skip == 0) {
 
       int_id = (fhi_id) ? fhi_id : eri_id;
+      intr_pending = 1;
 
       /* Get Error Record number for this Node */
       status = val_ras_get_info(RAS_INFO_START_INDEX, node_index, &rec_index);


### PR DESCRIPTION
- Prevents false error detection in subsequent loops
- intr_pending was not being reset to 1, leading to incorrect interrupt reporting
- Ensures accurate interrupt validation for each Node


Change-Id: I5a87d8233e42f565068aa19c92e9b3b161d9bd24