### PR TITLE
fix(mpam): fix for typo in MPAM test prints

### DIFF
--- a/test_pool/mpam/mpam002.c
+++ b/test_pool/mpam/mpam002.c
@@ -81,7 +81,7 @@ static void payload(void)
         rsrc_node_cnt = val_mpam_get_info(MPAM_MSC_RSRC_COUNT, msc_index, 0);
 
         val_print(ACS_PRINT_DEBUG, "\n       msc index  = %d", msc_index);
-        val_print(ACS_PRINT_DEBUG, "\n       Resource count %d = ", rsrc_node_cnt);
+        val_print(ACS_PRINT_DEBUG, "\n       Resource count = %d", rsrc_node_cnt);
 
         for (rsrc_index = 0; rsrc_index < rsrc_node_cnt; rsrc_index++) {
 

--- a/test_pool/mpam/mpam003.c
+++ b/test_pool/mpam/mpam003.c
@@ -87,7 +87,7 @@ static void payload(void)
         rsrc_node_cnt = val_mpam_get_info(MPAM_MSC_RSRC_COUNT, msc_index, 0);
 
         val_print(ACS_PRINT_DEBUG, "\n       msc index  = %d", msc_index);
-        val_print(ACS_PRINT_DEBUG, "\n       Resource count %d = ", rsrc_node_cnt);
+        val_print(ACS_PRINT_DEBUG, "\n       Resource count = %d", rsrc_node_cnt);
 
         for (rsrc_index = 0; rsrc_index < rsrc_node_cnt; rsrc_index++) {
 

--- a/test_pool/mpam/mpam004.c
+++ b/test_pool/mpam/mpam004.c
@@ -66,7 +66,7 @@ static void payload(void)
         rsrc_node_cnt = val_mpam_get_info(MPAM_MSC_RSRC_COUNT, msc_index, 0);
 
         val_print(ACS_PRINT_DEBUG, "\n       msc index  = %d", msc_index);
-        val_print(ACS_PRINT_DEBUG, "\n       Resource count %d = ", rsrc_node_cnt);
+        val_print(ACS_PRINT_DEBUG, "\n       Resource count = %d", rsrc_node_cnt);
 
         for (rsrc_index = 0; rsrc_index < rsrc_node_cnt; rsrc_index++) {
 

--- a/test_pool/mpam/mpam006.c
+++ b/test_pool/mpam/mpam006.c
@@ -161,7 +161,7 @@ static void payload(void)
         rsrc_node_cnt = val_mpam_get_info(MPAM_MSC_RSRC_COUNT, msc_index, 0);
 
         val_print(ACS_PRINT_DEBUG, "\n       msc index  = %d", msc_index);
-        val_print(ACS_PRINT_DEBUG, "\n       Resource count %d = ", rsrc_node_cnt);
+        val_print(ACS_PRINT_DEBUG, "\n       Resource count = %d", rsrc_node_cnt);
 
         for (rsrc_index = 0; rsrc_index < rsrc_node_cnt; rsrc_index++) {
 


### PR DESCRIPTION
 - Corrected typos in the print statements across multiple MPAM tests