### PR TITLE
fix: correct RAS feature bit check for patrol scrub

### DIFF
--- a/pal/uefi_acpi/src/pal_ras.c
+++ b/pal/uefi_acpi/src/pal_ras.c
@@ -389,8 +389,8 @@ VOID pal_ras2_fill_mem_pcct_info(
        context */
       ras2_pcc_shared_mem = (RAS2_PCC_SHARED_MEMORY_REGION * )pcct_subspace->BaseAddress;
       /* check if memory instance supports PATROL_SCRUB RAS feature */
-      /* RasFeatures[1] is lower 64bits in 128bits member */
-      if (ras2_pcc_shared_mem->RasFeatures[1] & RAS2_PLATFORM_FEATURE_PATROL_SCRUB_BITMASK)
+      /* RasFeatures[0] is lower 64bits in 128bits member */
+      if (ras2_pcc_shared_mem->RasFeatures[0] & RAS2_PLATFORM_FEATURE_PATROL_SCRUB_BITMASK)
           curr_block->block_info.mem_feat_info.patrol_scrub_support = 1;
       return;
     }


### PR DESCRIPTION
- Update RAS2 feature check for Patrol Scrub to use RasFeatures[0] instead of RasFeatures[1], as the lower 64 bits are stored in index 0.