### PR TITLE
pal: Enhance pal_mem_alloc_at_address() to scan for free memory within range

### DIFF
--- a/pal/baremetal/target/RDN2/src/pal_bsa.c
+++ b/pal/baremetal/target/RDN2/src/pal_bsa.c
@@ -1073,10 +1073,12 @@ pal_mem_free_aligned (void *Buffer)
 void *
 pal_mem_alloc_at_address (
   uint64_t mem_base,
+  uint64_t mem_len,
   uint64_t Size
   )
 {
   (void) mem_base;
+  (void) mem_len;
   (void) Size;
   return (void*) NULL;
 }

--- a/test_pool/mpam/intr003.c
+++ b/test_pool/mpam/intr003.c
@@ -63,6 +63,7 @@ void payload(void)
     uint32_t status;
     uint64_t buf_size;
     uint64_t base;
+    uint64_t size;
     uint32_t data;
     uint64_t nrdy_timeout;
     void *src_buf = 0;
@@ -138,8 +139,9 @@ void payload(void)
             /* Create 1 MB buffers sufficient to cretae overflow for this memory channel */
             buf_size = 1 * SIZE_1M;
             base = val_mpam_memory_get_base(msc_index, rsrc_index);
-            src_buf = (void *)val_mem_alloc_at_address(base, buf_size);
-            dest_buf = (void *)val_mem_alloc_at_address(base + buf_size, buf_size);
+            size = val_mpam_memory_get_size(msc_index, rsrc_index);
+            src_buf = (void *)val_mem_alloc_at_address(base, size, buf_size);
+            dest_buf = (void *)val_mem_alloc_at_address(base + buf_size, size, buf_size);
 
             if ((src_buf == NULL) || (dest_buf == NULL)) {
                 val_print(ACS_PRINT_ERR, "\n       Mem allocation for buffers failed", 0x0);

--- a/test_pool/mpam/mem001.c
+++ b/test_pool/mpam/mem001.c
@@ -250,8 +250,9 @@ void payload(void)
                     return;
                 }
 
-                src_buf = (void *)val_mem_alloc_at_address(addr_base, buf_size);
-                dest_buf = (void *)val_mem_alloc_at_address(addr_base + buf_size, buf_size);
+                src_buf = (void *)val_mem_alloc_at_address(addr_base, addr_len, buf_size);
+                dest_buf = (void *)val_mem_alloc_at_address(addr_base + buf_size,
+                                                            addr_len, buf_size);
 
                 if ((src_buf == NULL) || (dest_buf == NULL)) {
                     val_print(ACS_PRINT_ERR, "\n       Memory allocation of buffers failed", 0);

--- a/test_pool/mpam/mem002.c
+++ b/test_pool/mpam/mem002.c
@@ -313,6 +313,7 @@ payload_primary(void)
                 /* Create a shared memcopy buffer from this memory node */
                 alloc_status = val_alloc_shared_memcpybuf(
                                                     val_mpam_memory_get_base(msc_index, rsrc_index),
+                                                    val_mpam_memory_get_size(msc_index, rsrc_index),
                                                     buf_size,
                                                     num_pe_cont);
 

--- a/test_pool/mpam/mem003.c
+++ b/test_pool/mpam/mem003.c
@@ -249,8 +249,9 @@ void payload(void)
                     return;
                 }
 
-                src_buf = (void *)val_mem_alloc_at_address(addr_base, buf_size);
-                dest_buf = (void *)val_mem_alloc_at_address(addr_base + buf_size, buf_size);
+                src_buf = (void *)val_mem_alloc_at_address(addr_base, addr_len, buf_size);
+                dest_buf = (void *)val_mem_alloc_at_address(addr_base + buf_size,
+                                                            addr_len, buf_size);
 
                 if ((src_buf == NULL) || (dest_buf == NULL)) {
                     val_print(ACS_PRINT_ERR, "\n       Memory allocation of buffers failed", 0);

--- a/test_pool/mpam/mpam003.c
+++ b/test_pool/mpam/mpam003.c
@@ -124,8 +124,9 @@ static void payload(void)
                 }
 
 
-                src_buf = (void *)val_mem_alloc_at_address(addr_base, BUFFER_SIZE);
-                dest_buf = (void *)val_mem_alloc_at_address(addr_base + BUFFER_SIZE, BUFFER_SIZE);
+                src_buf = (void *)val_mem_alloc_at_address(addr_base, addr_len, BUFFER_SIZE);
+                dest_buf = (void *)val_mem_alloc_at_address(addr_base + BUFFER_SIZE,
+                                                            addr_len, BUFFER_SIZE);
 
                 if ((src_buf == NULL) || (dest_buf == NULL)) {
                     val_print(ACS_PRINT_ERR, "\n       Memory allocation of buffers failed", 0);

--- a/test_pool/pmu/pmu004.c
+++ b/test_pool/pmu/pmu004.c
@@ -35,8 +35,8 @@ static PMU_EVENT_TYPE_e config_events[NUM_PMU_MON] = {PMU_EVENT_IB_TOTAL_BW,
                                                PMU_EVENT_IB_WRITE_BW};
 
 /* Generates Inbound read/write traffic at memory interface */
-static uint32_t generate_inbound_traffic(uint32_t node_index, uint64_t base_addr, uint32_t size,
-                             uint64_t *value)
+static uint32_t generate_inbound_traffic(uint32_t node_index, uint64_t base_addr,
+                                         uint64_t addr_len, uint32_t size, uint64_t *value)
 {
     uint32_t  i;
     void *src_buf = 0;
@@ -44,8 +44,8 @@ static uint32_t generate_inbound_traffic(uint32_t node_index, uint64_t base_addr
     /* Generate inbound traffic for given size*/
 
     /* Allocate memory for 4 Megabytes */
-    src_buf = (void *)val_mem_alloc_at_address(base_addr, BUFFER_SIZE);
-    dest_buf = (void *)val_mem_alloc_at_address(base_addr + BUFFER_SIZE, BUFFER_SIZE);
+    src_buf = (void *)val_mem_alloc_at_address(base_addr, addr_len, BUFFER_SIZE);
+    dest_buf = (void *)val_mem_alloc_at_address(base_addr + BUFFER_SIZE, addr_len, BUFFER_SIZE);
 
     if ((src_buf == NULL) || (dest_buf == NULL))
         return 1;
@@ -181,7 +181,8 @@ static void payload(void)
             val_pmu_enable_monitor(node_index, i);
 
         /* Generate first memory traffic for 2 MB */
-        status = generate_inbound_traffic(node_index, prox_base_addr, BUFFER_SIZE / 2, bandwidth1);
+        status = generate_inbound_traffic(node_index, prox_base_addr,
+                                          addr_len, BUFFER_SIZE / 2, bandwidth1);
 
         if (status) {
             val_print(ACS_PRINT_ERR, "\n       Memory allocation failed", node_index);
@@ -196,7 +197,8 @@ static void payload(void)
         }
 
         /* Generate second memory traffic for 4 MB */
-        status = generate_inbound_traffic(node_index, prox_base_addr, BUFFER_SIZE, bandwidth2);
+        status = generate_inbound_traffic(node_index, prox_base_addr,
+                                          addr_len, BUFFER_SIZE, bandwidth2);
 
         if (status) {
             val_print(ACS_PRINT_ERR, "\n       Memory allocation failed", node_index);

--- a/test_pool/pmu/pmu005.c
+++ b/test_pool/pmu/pmu005.c
@@ -137,8 +137,9 @@ static void payload(void)
         }
 
         //* Allocate memory for 4 Megabytes */
-        src_buf = (void *)val_mem_alloc_at_address(prox_base_addr, BUFFER_SIZE);
-        dest_buf = (void *)val_mem_alloc_at_address(prox_base_addr + BUFFER_SIZE, BUFFER_SIZE);
+        src_buf = (void *)val_mem_alloc_at_address(prox_base_addr, addr_len, BUFFER_SIZE);
+        dest_buf = (void *)val_mem_alloc_at_address(prox_base_addr + BUFFER_SIZE,
+                                                    addr_len, BUFFER_SIZE);
 
         if ((src_buf == NULL) || (dest_buf == NULL)) {
             val_print(ACS_PRINT_ERR, "\n       Memory allocation of buffers failed", 0);

--- a/test_pool/pmu/pmu008.c
+++ b/test_pool/pmu/pmu008.c
@@ -71,8 +71,9 @@ static uint32_t generate_traffic(uint64_t prox_domain, uint32_t size, void (*rem
     }
 
     /* Allocate memory for 4 Megabytes */
-    src_buf = (void *)val_mem_alloc_at_address(prox_base_addr, BUFFER_SIZE);
-    dest_buf = (void *)val_mem_alloc_at_address(prox_base_addr + BUFFER_SIZE, BUFFER_SIZE);
+    src_buf = (void *)val_mem_alloc_at_address(prox_base_addr, addr_len, BUFFER_SIZE);
+    dest_buf = (void *)val_mem_alloc_at_address(prox_base_addr + BUFFER_SIZE,
+                                                addr_len, BUFFER_SIZE);
 
     if ((src_buf == NULL) || (dest_buf == NULL))
         return 1;

--- a/test_pool/ras/ras006.c
+++ b/test_pool/ras/ras006.c
@@ -42,6 +42,7 @@ payload()
   uint64_t err_rec_impl_bitmap;
   uint64_t err_rec_addrmode_bitmap;
   uint64_t data;
+  uint64_t addr_len;
 
   uint32_t status;
   uint32_t fail_cnt = 0, test_skip = 0;
@@ -117,6 +118,7 @@ payload()
           /* fetch base addr of the proximity domain to inject an error in platform
              defined method */
           prox_base_addr = val_srat_get_info(SRAT_MEM_BASE_ADDR, mc_prox_domain);
+          addr_len = val_srat_get_info(SRAT_MEM_ADDR_LEN, mc_prox_domain);
           if (prox_base_addr == SRAT_INVALID_INFO) {
               val_print(ACS_PRINT_ERR,
                         "\n       Invalid base address for proximity domain : 0x%lx",
@@ -126,7 +128,8 @@ payload()
           }
 
           /* check if the address accessible to PE by trying to allocate the address */
-          err_inj_addr = (uint64_t)val_mem_alloc_at_address(prox_base_addr, ONE_BYTE_BUFFER);
+          err_inj_addr = (uint64_t)val_mem_alloc_at_address(prox_base_addr,
+                                                            addr_len, ONE_BYTE_BUFFER);
 
           if (err_inj_addr == 0) {
               val_print(ACS_PRINT_ERR,

--- a/test_pool/ras/ras009.c
+++ b/test_pool/ras/ras009.c
@@ -54,6 +54,7 @@ payload()
   uint64_t node_type;
   uint64_t err_inj_addr;
   uint64_t prox_base_addr;
+  uint64_t addr_len;
 
   uint32_t status;
   uint32_t fail_cnt = 0, test_skip = 0;
@@ -104,6 +105,7 @@ payload()
 
     /* Get base addr for proximity domain to inject error in platform defined method */
     prox_base_addr = val_srat_get_info(SRAT_MEM_BASE_ADDR, mc_prox_domain);
+    addr_len = val_srat_get_info(SRAT_MEM_ADDR_LEN, mc_prox_domain);
     if (prox_base_addr == SRAT_INVALID_INFO) {
       val_print(ACS_PRINT_ERR, "\n       Invalid base for prox domain : 0x%lx", mc_prox_domain);
       fail_cnt++;
@@ -111,7 +113,7 @@ payload()
     }
 
     /* check if the address accessible to PE by trying to allocate the address */
-    err_inj_addr = (uint64_t)val_mem_alloc_at_address(prox_base_addr, ONE_BYTE_BUFFER);
+    err_inj_addr = (uint64_t)val_mem_alloc_at_address(prox_base_addr, addr_len, ONE_BYTE_BUFFER);
     val_print(ACS_PRINT_ERR, "\n       err_inj_addr : 0x%lx", err_inj_addr);
     if (err_inj_addr == 0) {
       val_print(ACS_PRINT_ERR, "\n       Unable to allocate address in prox domain : 0x%lx",

--- a/val/include/acs_mpam.h
+++ b/val/include/acs_mpam.h
@@ -99,9 +99,10 @@ uint64_t val_mpam_memory_mbwumon_read_count(uint32_t msc_index);
 uint32_t val_mpam_get_msc_count(void);
 uint32_t val_mpam_get_max_ris_count(uint32_t msc_index);
 void val_mpam_memory_mbwumon_reset(uint32_t msc_index);
-void *val_mem_alloc_at_address (uint64_t mem_base, uint64_t size);
-void val_mem_free_at_address (uint64_t mem_base, uint64_t size);
-uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t buffer_size, uint32_t pe_count);
+void *val_mem_alloc_at_address (uint64_t mem_base, uint64_t mem_len, uint64_t size);
+void val_mem_free_at_address(uint64_t mem_base, uint64_t size);
+uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t mem_len,
+                                uint64_t buffer_size, uint32_t pe_count);
 uint64_t val_get_shared_memcpybuf(uint32_t pe_index);
 void val_mem_free_shared_memcpybuf(uint32_t num_pe);
 uint32_t val_mpam_get_csumon_count(uint32_t msc_index);

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -1171,7 +1171,7 @@ typedef struct {
 } MPAM_INFO_TABLE;
 
 void pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable);
-void *pal_mem_alloc_at_address(uint64_t mem_base, uint64_t size);
+void *pal_mem_alloc_at_address(uint64_t mem_base, uint64_t mem_len, uint64_t size);
 void pal_mem_free_at_address(uint64_t mem_base, uint64_t size);
 
 /* Platform Communication Channel (PCC) info table */

--- a/val/src/acs_mpam.c
+++ b/val/src/acs_mpam.c
@@ -781,9 +781,9 @@ val_mpam_memory_mbwumon_reset(uint32_t msc_index)
   @return  Buffer address if SUCCESSFUL, else NULL
 **/
 void *
-val_mem_alloc_at_address(uint64_t mem_base, uint64_t size)
+val_mem_alloc_at_address(uint64_t mem_base, uint64_t mem_len, uint64_t size)
 {
-  return pal_mem_alloc_at_address(mem_base, size);
+  return pal_mem_alloc_at_address(mem_base, mem_len, size);
 }
 
 /**
@@ -1640,7 +1640,8 @@ void val_mem_free_shared_memcpybuf(uint32_t num_pe)
  *
  * @result  status      1 for success, 0 for failure
  */
-uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t buffer_size, uint32_t pe_count)
+uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t mem_len,
+                                    uint64_t buffer_size, uint32_t pe_count)
 {
   void *buffer;
   uint32_t pe_index;
@@ -1660,6 +1661,7 @@ uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t buffer_size, uin
   for (pe_index = 0; pe_index < pe_count; pe_index++) {
       g_shared_memcpy_buffer[pe_index] = (uint8_t *) val_mem_alloc_at_address (
                                                     mem_base + (pe_index * buffer_size),
+                                                    mem_len,
                                                     buffer_size);
 
       if (g_shared_memcpy_buffer[pe_index] == NULL) {


### PR DESCRIPTION
The original implementation of pal_mem_alloc_at_address() attempted to allocate memory strictly at the specified base address. This could fail if the address is already occupied by UEFI, causing tests like MPAM003 to incorrectly fail.

This patch improves the allocation strategy by scanning the entire memory range [mem_base, mem_base + mem_len] in 4KB-aligned steps to find a usable subrange for allocation. This ensures allocations occur within the MPAM proximity domain while avoiding conflicts with UEFI-reserved memory.

If no suitable region is found, the function gracefully returns NULL.


Change-Id: Iab457cdb0dc029a3e14faa0b47317292ceaa5089