### PR TITLE
val: add missing new lines

### DIFF
--- a/val/src/acs_mmu.c
+++ b/val/src/acs_mmu.c
@@ -208,7 +208,7 @@ uint32_t val_mmu_update_entry(uint64_t address, uint32_t size)
 
   /* If entry is already present return success */
   if (!val_mmu_check_for_entry(address)) {
-      val_print(ACS_PRINT_DEBUG, "\n   Address is already mapped", 0);
+      val_print(ACS_PRINT_DEBUG, "\n   Address is already mapped\n", 0);
       return 0;
   }
 

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -261,7 +261,7 @@ val_peripheral_dump_info(void)
   }
 
 
-  val_print(ACS_PRINT_DEBUG, " Peripheral: Num of Network ctrl      :    %d\n", ntwk);
+  val_print(ACS_PRINT_DEBUG, "\n Peripheral: Num of Network ctrl      :    %d\n", ntwk);
   val_print(ACS_PRINT_DEBUG, " Peripheral: Num of Storage ctrl      :    %d\n", strg);
   val_print(ACS_PRINT_DEBUG, " Peripheral: Num of Display ctrl      :    %d\n", dply);
 

--- a/val/src/acs_timer_support.c
+++ b/val/src/acs_timer_support.c
@@ -40,7 +40,7 @@ uint8_t get_effective_e2h(void)
   else
     effective_e2h = hcr_e2h;
 
-  val_print(ACS_PRINT_DEBUG, "\n       effective e2h : 0x%x", effective_e2h);
+  val_print(ACS_PRINT_DEBUG, "\n       effective e2h : 0x%x\n", effective_e2h);
   return effective_e2h;
 }
 


### PR DESCRIPTION
When verbose mode is enables some messages got joined with previous ones:

```
       effective e2h : 0x0 TIMER_INFO: System Counter frequency :    1000 MHz
   Address is already mapped SMMU_INFO: SMMU index 00 version     :    v3.1
 Class code is 3800002 Peripheral: Num of Network ctrl      :    1
```
Now they are clean:

```
       effective e2h : 0x0
 TIMER_INFO: System Counter frequency :    1000 MHz

   Address is already mapped
 SMMU_INFO: SMMU index 00 version     :    v3.1

 Class code is 3800002
 Peripheral: Num of Network ctrl      :    1
```