### PR TITLE
Fix : PE index boundary check in val_get_pe_architecture

### DIFF
--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -559,7 +559,7 @@ val_get_pe_architecture(uint32_t index)
   while (num_slots > 0) {
     num_slots--;
     cur_pe_count += type4_entry->core_count;
-    if (index > cur_pe_count) {
+    if (index >= cur_pe_count) {
       type4_entry++;
       continue;
     }


### PR DESCRIPTION
Replace > with >= when comparing index to cur_pe_count so boundary indices advance to the next slot, preventing incorrect results or unintended ACS_STATUS_ERR.