### PR TITLE
Add SBSA NIST ACS build support

### DIFF
--- a/.github/workflows/acs_build_check.yml
+++ b/.github/workflows/acs_build_check.yml
@@ -346,6 +346,49 @@ jobs:
           path: /home/runner/work/sysarch-acs/linux-pcbsa/*
           if-no-files-found: error
 
+  build_sbsa_nist:
+      name: SBSA-ACS NIST UEFI build for ACPI target
+      runs-on: ubuntu-22.04
+
+      steps:
+        - name: Install dependencies
+          run: sudo apt-get update && sudo apt-get install -y git build-essential nasm
+
+        - name: Download edk2 and its submodules
+          run: |
+            git clone --recursive https://github.com/tianocore/edk2
+            cd edk2
+            git checkout edk2-stable202505
+            cd ..
+            git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
+
+        - name: Checkout sysarch-acs repository
+          uses: actions/checkout@v4
+          with:
+            path: 'edk2/ShellPkg/Application/sysarch-acs'
+
+        - name: Download Arm GCC cross-compiler
+          run: |
+            mkdir -p /opt/cross
+            cd /opt/cross
+            wget https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
+            tar -xf arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
+
+        - name: Set up EDK2 environment and build SbsaNist.efi
+          run: |
+            cd edk2
+            export GCC49_AARCH64_PREFIX=/opt/cross/arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+            export PACKAGES_PATH=$PWD/edk2-libc
+            source edksetup.sh
+            make -C BaseTools/Source/C
+            source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh nist
+        - name: Save SbsaNist.efi as an artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: Sbsa_Nist_acpi_target.efi
+            path: edk2/Build/Shell/DEBUG_GCC49/AARCH64/SbsaNist.efi
+            if-no-files-found: error
+
   build_pcbsa:
       name: PCBSA-ACS UEFI build for ACPI target
       runs-on: ubuntu-22.04

--- a/.github/workflows/acs_daily_build_check.yml
+++ b/.github/workflows/acs_daily_build_check.yml
@@ -342,6 +342,49 @@ jobs:
           path: /home/runner/work/sysarch-acs/linux-pcbsa/*
           if-no-files-found: error
 
+  build_sbsa_nist:
+      name: SBSA-ACS NIST UEFI build for ACPI target
+      runs-on: ubuntu-22.04
+
+      steps:
+        - name: Install dependencies
+          run: sudo apt-get update && sudo apt-get install -y git build-essential nasm
+
+        - name: Download edk2 and its submodules
+          run: |
+            git clone --recursive https://github.com/tianocore/edk2
+            cd edk2
+            git checkout edk2-stable202505
+            cd ..
+            git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
+
+        - name: Checkout sysarch-acs repository
+          uses: actions/checkout@v4
+          with:
+            path: 'edk2/ShellPkg/Application/sysarch-acs'
+
+        - name: Download Arm GCC cross-compiler
+          run: |
+            mkdir -p /opt/cross
+            cd /opt/cross
+            wget https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
+            tar -xf arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
+
+        - name: Set up EDK2 environment and build SbsaNist.efi
+          run: |
+            cd edk2
+            export GCC49_AARCH64_PREFIX=/opt/cross/arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+            export PACKAGES_PATH=$PWD/edk2-libc
+            source edksetup.sh
+            make -C BaseTools/Source/C
+            source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh nist
+        - name: Save SbsaNist.efi as an artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: Sbsa_Nist_acpi_target.efi
+            path: edk2/Build/Shell/DEBUG_GCC49/AARCH64/SbsaNist.efi
+            if-no-files-found: error
+
   build_pcbsa:
       name: PCBSA-ACS UEFI build for ACPI target
       runs-on: ubuntu-22.04

--- a/patches/edk2_sbsa_nist.patch
+++ b/patches/edk2_sbsa_nist.patch
@@ -1,0 +1,76 @@
+diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
+index 7e985f8280..ae19e5b070 100644
+--- a/ShellPkg/ShellPkg.dsc
++++ b/ShellPkg/ShellPkg.dsc
+@@ -66,6 +66,9 @@
+   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+ 
+   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
++  SbsaNistLib|ShellPkg/Application/sysarch-acs/test_pool/nist_sts/SbsaNistLib.inf
++  SbsaValNistLib|ShellPkg/Application/sysarch-acs/val/SbsaValNistLib.inf
++  SbsaPalNistLib|ShellPkg/Application/sysarch-acs/pal/uefi_acpi/SbsaPalNistLib.inf
+ 
+ [PcdsFixedAtBuild]
+   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0xFF
+@@ -93,6 +96,7 @@
+   ShellPkg/Library/UefiShellDebug1CommandsLib/UefiShellDebug1CommandsLib.inf
+   ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
+   ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.inf
++  ShellPkg/Application/sysarch-acs/apps/uefi/SbsaNist.inf
+ 
+   ShellPkg/Application/Shell/Shell.inf {
+     <PcdsFixedAtBuild>
+@@ -157,4 +161,10 @@
+   ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyApp.inf
+ 
+ [BuildOptions]
+-  *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES
++
++!ifdef $(ENABLE_NIST)
++        *_*_*_CC_FLAGS = -DENABLE_NIST -DTARGET_UEFI
++!else
++       *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES
++!endif
++!include edk2-libc/StdLib/StdLib.inc
+diff --git a/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c b/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c
+index e3b595e..cc12b38 100644
+--- a/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c
++++ b/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c
+@@ -38,13 +38,14 @@ __RCSID("$NetBSD: flt_rounds.c,v 1.3 2006/02/25 00:58:35 wiz Exp $");
+ 
+ #include <sys/types.h>
+ //#include <ieeefp.h>
+-
++#if 0
+ static const int map[] = {
+   1,  /* round to nearest */
+   2,  /* round to positive infinity */
+   3,  /* round to negative infinity */
+   0   /* round to zero */
+ };
++#endif
+ 
+ /*
+  * Return the current FP rounding mode
+diff --git a/edk2-libc/StdLib/LibC/Main/Main.c b/edk2-libc/StdLib/LibC/Main/Main.c
+index b203d15..8c9618e 100644
+--- a/edk2-libc/StdLib/LibC/Main/Main.c
++++ b/edk2-libc/StdLib/LibC/Main/Main.c
+@@ -31,7 +31,7 @@
+ #include  <MainData.h>
+ #include  <unistd.h>
+ 
+-extern int main( int, char**);
++extern int ShellAppMainsbsa( int, char**);
+ extern int __sse2_available;
+ 
+ struct  __MainData  *gMD;
+@@ -179,7 +179,7 @@ ShellAppMain (
+     else {
+       if( setjmp(gMD->MainExit) == 0) {
+         errno   = 0;    // Clean up any "scratch" values from startup.
+-        ExitVal = (INTN)main( (int)Argc, gMD->NArgV);
++        ExitVal = (INTN)ShellAppMainsbsa( (int)Argc, gMD->NArgV);
+         exitCleanup(ExitVal);
+       }
+       /* You reach here if:

--- a/tools/scripts/acsbuild.sh
+++ b/tools/scripts/acsbuild.sh
@@ -69,6 +69,12 @@ function build_with_NIST()
     fi
     cd -
 
+
+    git checkout ShellPkg/ShellPkg.dsc
+    cd edk2-libc/
+    git checkout StdLib/LibC/Main/Arm/flt_rounds.c
+    git checkout StdLib/LibC/Main/Main.c
+    cd ../
     git apply ShellPkg/Application/sysarch-acs/patches/edk2_sbsa_nist.patch
     build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/SbsaNist.inf -D ENABLE_NIST -D SBSA
     status=$?


### PR DESCRIPTION
- Add patch for SBSA NIST ACS
- Update README to reflect latest changes
- Enable workflow with SBSA NIST build option
- Fixes #68 

