### PR TITLE
SMBIOS: Handle 1024 cpu cores.

### DIFF
--- a/apps/uefi/acs.h
+++ b/apps/uefi/acs.h
@@ -84,7 +84,7 @@
                                        /*[72 B Each + 16 B Header]*/
 #define PCIE_INFO_TBL_SZ        1024   /*Supports max 40 RC's    */
                                        /*[24 B Each + 4 B Header]*/
-#define SMBIOS_INFO_TBL_SZ      1024   /*Supports max 16 Processor Slots/Sockets*/
+#define SMBIOS_INFO_TBL_SZ      65536  /*Supports max 1024 Processor Slots/Sockets*/
                                        /*[64 B Each]*/
 #define PMU_INFO_TBL_SZ         20496  /*Supports maximum 512 PMUs*/
                                        /*[40 B Each + 4 B Header]*/

--- a/pal/uefi_acpi/src/pal_pe.c
+++ b/pal/uefi_acpi/src/pal_pe.c
@@ -33,7 +33,7 @@ UINT64  gMpidrMax;
 static UINT32 g_num_pe;
 extern INT32 gPsciConduit;
 
-#define MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED  16
+#define MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED  1024
 #define SIZE_STACK_SECONDARY_PE  0x100      //256 bytes per core
 #define UPDATE_AFF_MAX(src,dest,mask)  ((dest & mask) > (src & mask) ? (dest & mask) : (src & mask))
 

--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -66,7 +66,7 @@ static char psci_dt_arr[][PSCI_COMPATIBLE_STR_LEN] = {
 };
 
 
-#define MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED  16
+#define MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED  1024
 #define SIZE_STACK_SECONDARY_PE  0x100                //256 bytes per core
 #define UPDATE_AFF_MAX(src,dest,mask)  ((dest & mask) > (src & mask) ? (dest & mask) : (src & mask))
 


### PR DESCRIPTION
There are machines out there with more than 16 cpu cores. Test 16 fails on them:

       PE Index = 63
       Processor Family Not Found in SMBIOS Table
       Skipped on PE -   17
       B_PE_14
       Checkpoint --  2                           : Result:  SKIPPED

This change bumps amount of supported cores to 1024. Should be enough for a while.

Closes: #77