### PR TITLE
drop BOOLEAN typedef to fix build with GCC 15

### DIFF
--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -100,7 +100,6 @@
   typedef UINT64  uint64_t;
   typedef UINT64  addr_t;
   typedef UINT64  dma_addr_t;
-  typedef BOOLEAN bool;
 
   #define MAX_SID  32
   #define MMU_PGT_IAS    48


### PR DESCRIPTION
sysarch-acs/val/include/pal_interface.h:103:3: error: useless type name in empty declaration [-Werror]
  103 |   typedef BOOLEAN bool;
      |   ^~~~~~~
cc1: all warnings being treated as errors

Closes: #73