### PR TITLE
docs: add README for ACS prebuilt images and legacy access

### DIFF
--- a/prebuilt_images/README.md
+++ b/prebuilt_images/README.md
@@ -1,0 +1,29 @@
+# ACS Prebuilt Images and Legacy Access
+
+This repository provides **prebuilt ACS images** for partners and users for each release version.
+
+---
+
+## Current Prebuilt Images
+The latest **unified prebuilt binaries** for all ACS suites supported under `sysarch-acs` are available here:
+
+👉 [sysarch-acs/prebuilt_images](https://github.com/ARM-software/sysarch-acs/tree/main/prebuilt_images)
+
+This is the single location for downloading prebuilt images for BSA, SBSA, PC-BSA, and other ACS supported in `sysarch-acs`.
+
+---
+
+## Legacy Prebuilt Images
+For historical builds (prior to the consolidation into `sysarch-acs`), prebuilt binaries remain available:
+
+- **BSA prebuilt images**: [bsa-acs/prebuilt_images](https://github.com/ARM-software/bsa-acs/tree/main/prebuilt_images)  
+- **SBSA prebuilt images**: [sbsa-acs/prebuilt_images](https://github.com/ARM-software/sbsa-acs/tree/master/prebuilt_images)
+
+These are preserved only for reference and backward compatibility.
+
+---
+
+## Going Forward
+- All new ACS builds will be published in the [sysarch-acs](https://github.com/ARM-software/sysarch-acs) repository.  
+- Prebuilt binaries from future specifications will be integrated and made available in the unified prebuilt location.  
+- Partners should use the `sysarch-acs` prebuilt images for the most up-to-date and supported releases.


### PR DESCRIPTION
- Added README section for ACS prebuilt images
- Pointed partners to the unified prebuilt images under sysarch-acs
- Linked legacy prebuilt images for BSA and SBSA for backward compatibility
- Documented that all future ACS prebuilt binaries will be consolidated in sysarch-acs