### PR TITLE
Guard HCR_EL2 access with exception level check

### DIFF
--- a/val/include/acs_pe.h
+++ b/val/include/acs_pe.h
@@ -198,7 +198,6 @@ typedef enum {
 uint64_t ArmReadMpidr(void);
 uint64_t ArmReadIdPfr0(void);
 uint64_t ArmReadIdPfr1(void);
-uint64_t ArmReadHcr(void);
 uint64_t AA64ReadMmfr0(void);
 uint64_t AA64ReadMmfr1(void);
 uint64_t AA64ReadMmfr2(void);

--- a/val/src/AArch64/PeRegSysSupport.S
+++ b/val/src/AArch64/PeRegSysSupport.S
@@ -55,7 +55,6 @@ GCC_ASM_EXPORT (AA64ReadSctlr1)
 GCC_ASM_EXPORT (AA64ReadPmcr)
 GCC_ASM_EXPORT (AA64ReadIdDfr0)
 GCC_ASM_EXPORT (AA64ReadIdDfr1)
-GCC_ASM_EXPORT (ArmReadHcr)
 GCC_ASM_EXPORT (AA64ReadCurrentEL)
 GCC_ASM_EXPORT (AA64ReadIdMdrar)
 GCC_ASM_EXPORT (AA64ReadMdcr2)
@@ -216,11 +215,6 @@ ASM_PFX(AA64ReadIdDfr0):
 
 ASM_PFX(AA64ReadIdDfr1):
   mrs   x0, id_aa64dfr1_el1
-  ret
-
-// UINTN ArmReadHcr(VOID)
-ASM_PFX(ArmReadHcr):
-  mrs   x0, hcr_el2
   ret
 
 ASM_PFX(AA64ReadCurrentEL):

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -23,7 +23,7 @@
 #include "include/pal_interface.h"
 #include "include/val_interface.h"
 #include "include/acs_std_smc.h"
-
+#include "include/acs_timer_support.h"
 
 /**
   @brief   Pointer to the memory location of the PE Information table
@@ -219,7 +219,7 @@ val_pe_reg_read(uint32_t reg_id)
        case TRCIDR5:
           return AA64ReadTrcidr5();
        case HCR_EL2:
-          return ArmReadHcr();
+          return ArmReadHcrEl2();
        case VTCR_EL2:
           return AA64ReadVtcr();
       default:
@@ -422,7 +422,7 @@ uint32_t val_pe_reg_read_tcr(uint32_t ttbr1, PE_TCR_BF *tcr)
         return ACS_STATUS_ERR;
 
     if (el == AARCH64_EL2)
-        e2h = ArmReadHcr() & AARCH64_HCR_E2H_MASK;
+        e2h = ArmReadHcrEl2() & AARCH64_HCR_E2H_MASK;
 
     if (el == AARCH64_EL1 || (el == AARCH64_EL2 && e2h))
     {

--- a/val/src/acs_timer_support.c
+++ b/val/src/acs_timer_support.c
@@ -18,6 +18,7 @@
 #include "include/acs_val.h"
 #include "include/acs_timer_support.h"
 #include "include/acs_common.h"
+#include "include/acs_pe.h"
 
 /**
   @brief This API is used to get the effective HCR_EL2.E2H
@@ -25,6 +26,13 @@
 uint8_t get_effective_e2h(void)
 {
   uint32_t effective_e2h;
+
+  /* if EL2 is not present, effective E2H will be 0 */
+  if (val_pe_reg_read(CurrentEL) == AARCH64_EL1) {
+    val_print(ACS_PRINT_DEBUG, "\n       CurrentEL: AARCH64_EL1", 0);
+    return 0;
+  }
+
   uint32_t hcr_e2h = VAL_EXTRACT_BITS(ArmReadHcrEl2(), 34, 34);
   uint32_t feat_vhe = VAL_EXTRACT_BITS(ArmReadAA64MMFR1EL1(), 8, 11);
   uint32_t e2h0 = VAL_EXTRACT_BITS(ArmReadAA64MMFR4EL1(), 24, 27);


### PR DESCRIPTION
 - HCR_EL2 values are RES0 if EL2 is not present
 - Remove the duplicate defination of HCR_EL2 reg read

 Change-Id: I07c6bcd1d30f67ecb8b48a30ecad73520335bf67