### PR TITLE
fix(p002): skip ECAM checks for virtual functions

### DIFF
--- a/val/include/acs_pcie.h
+++ b/val/include/acs_pcie.h
@@ -29,7 +29,15 @@
                                     (PCIE_EXTRACT_BDF_DEV(bdf) << 3) | \
                                     (PCIE_EXTRACT_BDF_BUS(bdf) << 8)
 
-#define PCIE_CREATE_BDF(seg, bus, dev, func) ((seg << 24) | ((bus & 0xFF) << 16) | ((dev & 0xFF) << 8) | func)
+#define PCIE_CREATE_BDF(seg, bus, dev, func) ((seg << 24) | ((bus & 0xFF) << 16) | \
+                                             ((dev & 0xFF) << 8) | func)
+
+
+#define PCIE_CREATE_BDF_FROM_PACKED(seg, rid)  (((seg) << 24) | \
+                                               (((rid) >> 8) << 16) | \
+                                               ((((rid) >> 3) & 0x1F) << 8) | \
+                                               ((rid) & 0x7))
+
 
 #define GET_DEVICE_ID(bus, dev, func) ((bus << 8) | (dev << 3) | func)
 

--- a/val/include/acs_pcie_spec.h
+++ b/val/include/acs_pcie_spec.h
@@ -199,6 +199,7 @@
 #define ECID_ACS       0x000D
 #define ECID_ARICS     0x000E
 #define ECID_ATS       0x000F
+#define ECID_SRIOV     0x0010
 #define ECID_PRI       0x0013
 #define ECID_SPCIECS   0x0019
 #define ECID_PASID     0x001B
@@ -225,6 +226,15 @@
 #define DS_UNCORR_MASK 0x6
 #define DS_CORR_MASK   0x1
 #define ACSCTRL_SHIFT  0x0F
+
+/* SR-IOV Capability struct offsets and shifts*/
+#define SRIOV_VF_COUNT         0x0C
+#define SRIOV_VF_OFF_STR       0x14
+#define SRIOV_STRIDE_SHIFT     16
+#define SRIOV_NUM_VF_SHIFT     16
+#define SRIOV_FIRST_VF_SHIFT   0xFFFF
+#define SRIOV_STRIDE_MASK      0xFFFF
+#define SRIOV_NUM_VF_MASK      0xFFFF
 
 /* DPC Capability struct offsets and shifts */
 #define DPC_CTRL_OFFSET        0x4


### PR DESCRIPTION
- Add support in PCIe test p002 to detect and skip SR-IOV VFs during ECAM region accessibility checks.
- Define helper macros for VF BDF derivation and SR-IOV capability parsing.
- Use val_memory_set for reset handling.
- Fixes #22 

Change-Id: I3f898914c1e55fa4bc8f5a59f528a20ad2c9a4a1