### PR TITLE
Prevent tests from running on -h/-help

### DIFF
--- a/apps/uefi/acs.h
+++ b/apps/uefi/acs.h
@@ -120,4 +120,8 @@ unsigned long __stack_chk_fail =  0xBAAFAAAD;
 
 uint32_t command_init(void);
 
+#ifndef ACS_PARSE_SKIP_RUN
+#define ACS_PARSE_SKIP_RUN 1
+#endif
+
 #endif

--- a/apps/uefi/app.c
+++ b/apps/uefi/app.c
@@ -37,7 +37,11 @@ ShellAppMain (
   IN CHAR16 **Argv
   )
 {
-  command_init();
-  execute_tests();
-  return 0;
+  UINT32 CommandInitReturn = command_init();
+
+  if (CommandInitReturn != 0) {
+    return 0;        // do NOT run tests, prints HelpMsg()
+  }
+
+  return (INTN)execute_tests();
 }

--- a/apps/uefi/bsa_main.c
+++ b/apps/uefi/bsa_main.c
@@ -185,7 +185,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed\n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -351,7 +351,7 @@ command_init ()
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Flags
@@ -375,7 +375,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -414,7 +414,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */

--- a/apps/uefi/drtm_main.c
+++ b/apps/uefi/drtm_main.c
@@ -132,7 +132,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed \n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -178,7 +178,7 @@ command_init ()
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Values
@@ -198,7 +198,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed \n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -237,7 +237,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed \n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */

--- a/apps/uefi/mem_test_main.c
+++ b/apps/uefi/mem_test_main.c
@@ -190,7 +190,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed\n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -356,7 +356,7 @@ command_init ()
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Flags
@@ -380,7 +380,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -419,7 +419,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */

--- a/apps/uefi/mpam_main.c
+++ b/apps/uefi/mpam_main.c
@@ -239,7 +239,7 @@ command_init ()
         if (EFI_ERROR(Status))
         {
           Print(L"Allocate memory for -skip failed\n", 0);
-          return 0;
+          return ACS_PARSE_SKIP_RUN;
         }
 
         g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -294,7 +294,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -332,7 +332,7 @@ command_init ()
             if (EFI_ERROR(Status))
             {
                 Print(L"Allocate memory for -m failed\n", 0);
-                return 0;
+                return ACS_PARSE_SKIP_RUN;
             }
 
             /* Check if the first value to -m is a decimal character. */
@@ -357,7 +357,7 @@ command_init ()
     /* Options with Values */
     if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))) {
         HelpMsg();
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
     }
 
     /* Initialize global counters */

--- a/apps/uefi/pc_bsa_main.c
+++ b/apps/uefi/pc_bsa_main.c
@@ -289,7 +289,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed\n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -381,7 +381,7 @@ command_init ()
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) ||
      (ShellCommandLineGetFlag (ParamPackage, L"-h"))) {
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Values
@@ -401,7 +401,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -440,7 +440,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */

--- a/apps/uefi/sbsa_main.c
+++ b/apps/uefi/sbsa_main.c
@@ -386,7 +386,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed\n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -478,7 +478,7 @@ command_init ()
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Values
@@ -498,7 +498,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -537,7 +537,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */

--- a/apps/uefi/sbsa_nist_main.c
+++ b/apps/uefi/sbsa_nist_main.c
@@ -387,7 +387,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed\n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -479,7 +479,7 @@ command_init ()
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Values
@@ -499,7 +499,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -538,7 +538,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */

--- a/apps/uefi/unified_main.c
+++ b/apps/uefi/unified_main.c
@@ -215,7 +215,7 @@ command_init ()
       if (EFI_ERROR(Status))
       {
         Print(L"Allocate memory for -skip failed\n", 0);
-        return 0;
+        return ACS_PARSE_SKIP_RUN;
       }
 
       g_skip_test_num[0] = StrDecimalToUintn((CONST CHAR16 *)(CmdLineArg+0));
@@ -417,7 +417,7 @@ command_init ()
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-help")) || (ShellCommandLineGetFlag (ParamPackage, L"-h"))){
      HelpMsg();
-     return 0;
+     return ACS_PARSE_SKIP_RUN;
   }
 
   // Options with Flags
@@ -441,7 +441,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -t failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -t is a decimal character. */
@@ -480,7 +480,7 @@ command_init ()
           if (EFI_ERROR(Status))
           {
               Print(L"Allocate memory for -m failed\n", 0);
-              return 0;
+              return ACS_PARSE_SKIP_RUN;
           }
 
           /* Check if the first value to -m is a decimal character. */


### PR DESCRIPTION
fix(uefi): prevent tests from running on -h/-help
- Ensure `-h` and `-help` options only display usage help without triggering test execution.
- Replace ambiguous return codes with `ACS_PARSE_SKIP_RUN` for consistent command parsing behavior.
- Standardize handling of invalid parameters across all UEFI test apps

Fixes: #75 