### PR TITLE
refactor(p008): align ECAM access checks with MCFG-defined range

### DIFF
--- a/test_pool/pcie/p008.c
+++ b/test_pool/pcie/p008.c
@@ -24,64 +24,21 @@
 #define TEST_RULE  "PCI_IN_16"
 #define TEST_DESC  "Check all 1's for out of range        "
 
-/* Returns the maximum bdf value for that segment from bdf table */
-static uint32_t get_max_bdf(uint32_t segment, uint32_t end_bus)
+static void *branch_to_test;
+
+static
+void
+esr(uint64_t interrupt_type, void *context)
 {
-  pcie_device_bdf_table *bdf_tbl_ptr;
-  uint32_t seg_num;
-  uint32_t bus_num;
-  uint32_t bdf;
-  uint32_t tbl_index = 0;
-  uint32_t max_bdf = 0;
+  uint32_t pe_index;
 
-  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
-  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
-  {
-      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
-      seg_num = PCIE_EXTRACT_BDF_SEG(bdf);
-      bus_num = PCIE_EXTRACT_BDF_BUS(bdf);
+  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-      if ((segment == seg_num) && (bus_num <= end_bus))
-          max_bdf = bdf;
-  }
+  /* Update the ELR to return to test specified address */
+  val_pe_update_elr(context, (uint64_t)branch_to_test);
 
-  val_print(ACS_PRINT_DEBUG, "\n max bdf 0x%x", max_bdf);
-  return max_bdf;
-}
-
-/* Returns the maximum subordinate bus value for that segment from the RP's in the BDF table */
-static uint32_t get_max_bus(uint32_t segment, uint32_t end_bus)
-{
-  pcie_device_bdf_table *bdf_tbl_ptr;
-  uint32_t seg_num;
-  uint32_t bdf, dp_type;
-  uint32_t rp_bdf, sub_bus, bus_num;
-  uint32_t reg_value;
-  uint32_t tbl_index = 0;
-  uint32_t max_sub_bus = 0;
-
-  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
-  for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
-  {
-      bdf = bdf_tbl_ptr->device[tbl_index].bdf;
-      dp_type = val_pcie_device_port_type(bdf);
-
-      /* Since RCEC or RCiEP has no RP. Skip for them. */
-      if ((dp_type == RCEC) || (dp_type == RCiEP))
-          continue;
-
-      rp_bdf = bdf_tbl_ptr->device[tbl_index].rp_bdf;
-      seg_num = PCIE_EXTRACT_BDF_SEG(rp_bdf);
-      bus_num = PCIE_EXTRACT_BDF_BUS(rp_bdf);
-
-      val_pcie_read_cfg(rp_bdf, TYPE1_PBN, &reg_value);
-      sub_bus = ((reg_value >> SUBBN_SHIFT) & SUBBN_MASK);
-      if ((segment == seg_num) && (bus_num <= end_bus) && (max_sub_bus < sub_bus))
-          max_sub_bus = sub_bus;
-  }
-
-  val_print(ACS_PRINT_DEBUG, "\n Maximum sub bus %x", max_sub_bus);
-  return max_sub_bus;
+  val_print(ACS_PRINT_INFO, "\n       Received exception of type: %d", interrupt_type);
+  val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 01));
 }
 
 static
@@ -89,86 +46,84 @@ void
 payload(void)
 {
 
-  uint32_t reg_value;
-  uint32_t pe_index;
-  uint32_t ecam_index;
+  uint32_t data;
   uint32_t num_ecam;
-  uint32_t end_bus_max = 255;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t bdf = 0;
+  uint32_t bus, segment;
   uint32_t end_bus;
-  uint32_t sub_bus;
-  uint32_t cfg_addr;
   uint32_t bus_index;
   uint32_t dev_index;
   uint32_t func_index;
-  uint32_t bdf;
-  uint32_t segment = 0;
-  addr_t   ecam_base = 0;
+  uint32_t ret;
+  uint32_t status;
 
-  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  /* Install sync and async handlers to handle exceptions.*/
+  status = val_pe_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
+  status |= val_pe_install_esr(EXCEPT_AARCH64_SERROR, esr);
+  if (status)
+  {
+      val_print(ACS_PRINT_ERR, "\n       Failed in installing the exception handler", 0);
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 01));
+      return;
+  }
+
+  branch_to_test = &&exception_return;
+
   num_ecam = val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
 
-  for (ecam_index = 0; ecam_index < num_ecam; ecam_index++)
-  {
-      /* Get the maximum bus value from PCIe info table */
-      end_bus = val_pcie_get_info(PCIE_INFO_END_BUS, ecam_index);
-      segment = val_pcie_get_info(PCIE_INFO_SEGMENT, ecam_index);
-      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 1));
+  if (num_ecam == 0) {
+      val_print(ACS_PRINT_DEBUG, "\n       No ECAM in MCFG. Skipping test               ", 0);
+      val_set_status(index, RESULT_SKIP(TEST_NUM, 01));
+      return;
+  }
 
-      /* Get the highest BDF value for that segment */
-      bdf = get_max_bdf(segment, end_bus);
+  while (num_ecam) {
+      num_ecam--;
+      segment = val_pcie_get_info(PCIE_INFO_SEGMENT, num_ecam);
+      bus = val_pcie_get_info(PCIE_INFO_START_BUS, num_ecam);
+      end_bus = val_pcie_get_info(PCIE_INFO_END_BUS, num_ecam);
 
-      /* Get the maximum subordinate bus for that segment */
-      sub_bus = get_max_bus(segment, end_bus);
+      /* Accessing the BDF PCIe config range */
+      for (bus_index = bus; bus_index <= end_bus; bus_index++) {
+        for (dev_index = 0; dev_index < PCIE_MAX_DEV; dev_index++) {
+          for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++) {
 
-      /* Get the least highest of max bus number */
-      bus_index = (PCIE_EXTRACT_BDF_BUS(bdf) < end_bus) ? sub_bus:end_bus;
-      bus_index += 1;
-      val_print(ACS_PRINT_INFO, "\n       Maximum bus value is 0x%x", bus_index);
+               bdf = PCIE_CREATE_BDF(segment, bus_index, dev_index, func_index);
+               ret = val_pcie_read_cfg(bdf, TYPE01_VIDR, &data);
 
-      /* Bus value must not exceed 255 */
-      if (bus_index > end_bus_max) {
-          val_print(ACS_PRINT_DEBUG, "\n       Bus index exceeded END_BUS Number", 0);
-          val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 2));
-          return;
-      }
-
-      for (dev_index = 0; dev_index < PCIE_MAX_DEV; dev_index++)
-      {
-          for (func_index = 0; func_index < PCIE_MAX_FUNC; func_index++)
-          {
-              /* Form bdf using seg, bus, device, function numbers.
-               * This BDF does not fall into the secondary and subordinate
-               * bus of any of the rootports because the bus value is one
-               * greater than the higest bus value. This BDF also doesn't
-               * match any of the existing BDF.
-               */
-              bdf = PCIE_CREATE_BDF(segment, bus_index, dev_index, func_index);
-              ecam_base = val_pcie_get_info(PCIE_INFO_ECAM, ecam_index);
-
-              if (ecam_base == 0) {
-                  val_print(ACS_PRINT_ERR, "\n       ECAM Base is zero ", 0);
-                  val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 1));
+               //If this is really PCIe CFG space, Device ID and Vendor ID cannot be 0
+               if (ret == PCIE_NO_MAPPING || (data == 0)) {
+                  val_print(ACS_PRINT_ERR, "\n       Incorrect data at ECAM Base %4x    ", data);
+                  val_print(ACS_PRINT_ERR, "\n       BDF is  %x    ", bdf);
+                  val_set_status(index, RESULT_FAIL(TEST_NUM,
+                                  (bus_index << PCIE_BUS_SHIFT)|dev_index));
                   return;
-              }
+               }
 
-              /* There are 8 functions / device, 32 devices / Bus and each has a 4KB config space */
-              cfg_addr = (bus_index * PCIE_MAX_DEV * PCIE_MAX_FUNC * 4096) + \
-                         (dev_index * PCIE_MAX_FUNC * 4096) + (func_index * 4096);
+               /* Access the start and end of the config space for PCIe devices whose
+                  device ID and vendor ID are all FF's */
+               if (data == PCIE_UNKNOWN_RESPONSE)
+               {
+                  val_pcie_read_cfg(bdf, PCIE_ECAP_START, &data);
 
-              val_print(ACS_PRINT_INFO, "\n       Calculated config address is %lx",
-                                                  ecam_base + cfg_addr + TYPE01_VIDR);
-              reg_value = pal_mmio_read(ecam_base + cfg_addr + TYPE01_VIDR);
-              if (reg_value != PCIE_UNKNOWN_RESPONSE)
-              {
-                  val_print(ACS_PRINT_ERR, "\n       Failed for BDF: 0x%x", bdf);
-                  val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 2));
-                  return;
-              }
-
-              val_set_status(pe_index, RESULT_PASS(TEST_NUM, 1));
+                  /* Returned data must be FF's, otherwise the test must fail */
+                  if (data != PCIE_UNKNOWN_RESPONSE) {
+                     val_print(ACS_PRINT_ERR, "\n       Incorrect data for Bdf 0x%x    ", bdf);
+                     val_set_status(index, RESULT_FAIL(TEST_NUM,
+                                     (bus_index << PCIE_BUS_SHIFT)|dev_index));
+                     return;
+                  }
+               }
           }
+        }
       }
   }
+
+  val_set_status(index, RESULT_PASS(TEST_NUM, 01));
+
+exception_return:
+  return;
 }
 
 uint32_t


### PR DESCRIPTION
- Update test to avoid probing beyond the EndBusNumber specified in MCFG, as behavior outside that range is undefined.
- The test now ensuring that accesses to non-existent BDFs within the ECAM-mapped region do not inadvertently hit valid functions or Root Ports.
- Such accesses are expected to return all 1s.
- Adds exception handler to catch SError or sync faults gracefully and ensures the test does not falsely fail due to platform-specific ECAM handling.
- Fixes #89


Change-Id: I362de3f5bc2e74163183a7bd84162da70415c7eb