### PR TITLE
Validate ARI forwarding and AFE writes

### DIFF
--- a/test_pool/exerciser/e015.c
+++ b/test_pool/exerciser/e015.c
@@ -112,16 +112,6 @@ payload(void)
           continue;
       }
 
-      /* Enable the ARI forwarding enable bit in Exerciser */
-      if (val_pcie_find_capability(e_bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
-          val_print(ACS_PRINT_DEBUG, "\n       PCIe Express Capability not present ", 0);
-          continue;
-      }
-      val_pcie_read_cfg(e_bdf, cap_base + DCTL2R_OFFSET, &reg_value);
-      reg_value &= DCTL2R_MASK;
-      reg_value |= (DCTL2R_AFE_MASK << DCTL2R_AFE_SHIFT);
-      val_pcie_write_cfg(e_bdf, cap_base + DCTL2R_OFFSET, reg_value);
-
       /* Read the secondary, subordinate bus and segment number */
       val_pcie_read_cfg(erp_bdf, TYPE1_PBN, &bus_value);
       sec_bus = ((bus_value >> SECBN_SHIFT) & SECBN_MASK);

--- a/val/include/acs_pcie.h
+++ b/val/include/acs_pcie.h
@@ -202,6 +202,7 @@ uint32_t val_pcie_scan_bridge_devices_and_check_memtype(uint32_t bdf);
 uint32_t val_pcie_get_atomicop_requester_capable(uint32_t bdf);
 uint32_t val_pcie_get_cap_ptr(uint32_t bdf);
 uint32_t val_pcie_get_bist(uint32_t bdf);
+uint32_t val_pcie_ari_forwarding_support(uint32_t bdf);
 
 uint32_t p001_entry(uint32_t num_pe);
 uint32_t p002_entry(uint32_t num_pe);

--- a/val/include/acs_pcie_spec.h
+++ b/val/include/acs_pcie_spec.h
@@ -366,7 +366,8 @@
 #define DCTL2R_AFE_SHIFT  5
 
 /* Device Control 2 reg mask */
-#define DCTL2R_AFE_MASK  0x1
+#define DCTL2R_AFE_MASK   0x1
+#define DCTL2R_AFE_SHIFT  5
 #define DCTL2R_AFE_NORMAL 0xFFDF
 
 /* Link Capabilities 2 reg mask and shift */

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -2457,3 +2457,32 @@ uint32_t val_pcie_get_bist(uint32_t bdf)
 
   return reg_value;
 }
+
+/**
+    @brief   Check if a PCIe Function supports ARI Forwarding.
+    @param   bdf  - Bus/Dev/Func in PCIE_CREATE_BDF format
+    @return  1 -> ARI Forwarding supported
+             0 -> Not supported or capability not present
+             NOT_IMPLEMENTED -> If PCIe Capability structure not found or error in reading register
+**/
+uint32_t val_pcie_ari_forwarding_support(uint32_t bdf)
+{
+    uint32_t cap_base;
+    uint32_t reg_value;
+
+    /* Locate PCI Express Capability */
+    if (val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base) != PCIE_SUCCESS) {
+        val_print(ACS_PRINT_ERR, "\n       PCI Capability not found for bdf 0x%x", bdf);
+        return NOT_IMPLEMENTED;
+    }
+
+    /* Read Device Capabilities 2 register (offset 0x24 from PCIe Cap base) */
+    if (val_pcie_read_cfg(bdf, cap_base + DCAP2R_OFFSET, &reg_value)) {
+        val_print(ACS_PRINT_ERR,
+                    "\n       Failed to read Device Capabilities 2 register for bdf 0x%x", bdf);
+        return NOT_IMPLEMENTED;
+    }
+
+    /* Return ARI Forwarding Supported bit status (bit 5) */
+    return ((reg_value >> DCAP2R_AFS_SHIFT) & DCAP2R_AFS_MASK);
+}


### PR DESCRIPTION
- Resolves #113 
- Enable/disable DCTL2.AFE and read back; fail if write doesn’t take effect.
- Bug fixes and enhancements