### PR TITLE
fix(exerciser): ATS check is only for RCiEP

### DIFF
--- a/val/include/acs_exerciser.h
+++ b/val/include/acs_exerciser.h
@@ -69,6 +69,7 @@
 typedef struct {
     uint32_t bdf;
     uint32_t initialized;
+    uint32_t rc_index;
 } EXERCISER_INFO_BLOCK;
 
 typedef struct {
@@ -118,6 +119,7 @@ uint32_t val_exerciser_get_state(EXERCISER_STATE *state, uint32_t instance);
 uint32_t val_exerciser_ops(EXERCISER_OPS ops, uint64_t param, uint32_t instance);
 uint32_t val_exerciser_get_data(EXERCISER_DATA_TYPE type, exerciser_data_t *data, uint32_t instance);
 uint32_t val_exerciser_get_bdf(uint32_t instance);
+uint32_t val_exerciser_get_exerciser_instance(uint32_t rc_index);
 uint32_t val_get_exerciser_err_info(EXERCISER_ERROR_CODE type);
 void     val_exerciser_disable_rp_pio_register(uint32_t bdf);
 uint32_t val_exerciser_check_poison_data_forwarding_support(void);

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -93,6 +93,8 @@ uint32_t val_exerciser_create_info_table(void)
       if (pal_is_bdf_exerciser(Bdf))
       {
           g_exerciser_info_table.e_info[num_exerciser_info].bdf = Bdf;
+          g_exerciser_info_table.e_info[num_exerciser_info].rc_index =
+                                               val_iovirt_get_rc_index(PCIE_EXTRACT_BDF_SEG(Bdf));
           g_exerciser_info_table.e_info[num_exerciser_info++].initialized = 0;
           vendor_id = (reg_value >> TYPE01_VIDR_SHIFT) & TYPE01_VIDR_MASK;
           vendor_name = lookup_vendor_name(vendor_id);
@@ -152,6 +154,25 @@ uint32_t val_exerciser_get_bdf(uint32_t instance)
 {
     return g_exerciser_info_table.e_info[instance].bdf;
 }
+
+/**
+  @brief   This API returns the instance of the PCIe bdf
+  @param  rc_index  - RC index of the BDF Number
+  @return instance  - Stimulus hardware instance number
+**/
+uint32_t val_exerciser_get_exerciser_instance(uint32_t rc_index)
+{
+    uint32_t instance;
+    uint32_t num_exercisers;
+
+    num_exercisers = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+    for (instance = 0; instance < num_exercisers; ++instance) {
+      if (g_exerciser_info_table.e_info[instance].rc_index == rc_index)
+          return instance;
+    }
+    return ACS_INVALID_INDEX;
+}
+
 /**
   @brief   This API reads the configuration parameters of the PCIe stimulus generation hardware
   @param   type         - Parameter type that needs to be read from the stimulus hadrware


### PR DESCRIPTION
- Add port type validation for Exerciser instances in tests e019 and e020.
- Changed the rule id that the test verifies to RE_SMU_1
- Ensure tests only run on RCiEP-type devices and skip gracefully if none are found, improving test reliability and correctness.
- Introduce val_exerciser_get_exerciser_instance to retrieve the exerciser instance that matches the rc of BDF
- Fixes #18


Change-Id: Ib9015d8fd3945f228902a58a4207d4d90fe8519b