### PR TITLE
fix(exerciser): avoid overwriting MSI control register

### DIFF
--- a/pal/baremetal/target/RDN2/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_fvp.h
@@ -838,6 +838,7 @@
 #define FATAL_SHIFT            31
 #define ERROR_INJECT_BIT       17
 
+#define MSICTL_ID_MASK      ((1u << 11) - 1)
 #define MSI_GENERATION_MASK (1 << 31)
 
 #define NO_SNOOP_START_MASK 0x20

--- a/pal/baremetal/target/RDN2/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDN2/src/pal_exerciser.c
@@ -548,7 +548,11 @@ uint32_t pal_exerciser_ops(EXERCISER_OPS Ops, uint64_t Param, uint32_t Bdf)
 
     case GENERATE_MSI:
         /* Param is the msi_index */
-        pal_mmio_write( Base + MSICTL ,(pal_mmio_read(Base + MSICTL) | (MSI_GENERATION_MASK) | (Param)));
+        data = pal_mmio_read(Base + MSICTL);
+        /* Clear the MSICTLID[10:0] and MSICTLTRG[31] bits while preserving the reserved bits */
+        data &= ~(MSI_GENERATION_MASK | MSICTL_ID_MASK);
+        data |= ((Param & MSICTL_ID_MASK) | MSI_GENERATION_MASK);
+        pal_mmio_write(Base + MSICTL, data);
         return 0;
 
     case GENERATE_L_INTR:

--- a/pal/baremetal/target/RDV3/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3/include/platform_override_fvp.h
@@ -783,6 +783,7 @@
 #define ERROR_INJECT_BIT       17
 #define ERR_CODE_SHIFT         20
 #define FATAL_SHIFT            31
+#define MSICTL_ID_MASK         ((1u << 11) - 1)
 #define MSI_GENERATION_MASK    (1 << 31)
 #define NO_SNOOP_START_MASK    0x20
 #define NO_SNOOP_STOP_MASK     0xFFFFFFDF

--- a/pal/baremetal/target/RDV3/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3/src/pal_exerciser.c
@@ -538,8 +538,11 @@ uint32_t pal_exerciser_ops(EXERCISER_OPS Ops, uint64_t Param, uint32_t Bdf)
 
   case GENERATE_MSI:
         /* Param is the msi_index */
-        pal_mmio_write(Base + MSICTL, (pal_mmio_read(Base + MSICTL) |
-                                                                (MSI_GENERATION_MASK) | (Param)));
+        data = pal_mmio_read(Base + MSICTL);
+        /* Clear the MSICTLID[10:0] and MSICTLTRG[31] bits while preserving the reserved bits */
+        data &= ~(MSI_GENERATION_MASK | MSICTL_ID_MASK);
+        data |= ((Param & MSICTL_ID_MASK) | MSI_GENERATION_MASK);
+        pal_mmio_write(Base + MSICTL, data);
         return 0;
 
   case GENERATE_L_INTR:

--- a/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
@@ -719,6 +719,7 @@
 #define ERROR_INJECT_BIT       17
 #define ERR_CODE_SHIFT         20
 #define FATAL_SHIFT            31
+#define MSICTL_ID_MASK         ((1u << 11) - 1)
 #define MSI_GENERATION_MASK    (1 << 31)
 #define NO_SNOOP_START_MASK    0x20
 #define NO_SNOOP_STOP_MASK     0xFFFFFFDF

--- a/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
@@ -538,8 +538,11 @@ uint32_t pal_exerciser_ops(EXERCISER_OPS Ops, uint64_t Param, uint32_t Bdf)
 
   case GENERATE_MSI:
         /* Param is the msi_index */
-        pal_mmio_write(Base + MSICTL, (pal_mmio_read(Base + MSICTL) |
-                                                                (MSI_GENERATION_MASK) | (Param)));
+        data = pal_mmio_read(Base + MSICTL);
+        /* Clear the MSICTLID[10:0] and MSICTLTRG[31] bits while preserving the reserved bits */
+        data &= ~(MSI_GENERATION_MASK | MSICTL_ID_MASK);
+        data |= ((Param & MSICTL_ID_MASK) | MSI_GENERATION_MASK);
+        pal_mmio_write(Base + MSICTL, data);
         return 0;
 
   case GENERATE_L_INTR:


### PR DESCRIPTION
- Resolves: #105  
- update exerciser MSI generation to clear and set only ID/trigger bits, preserving reserved MSICTL bits
 - this change prevents accidental misconfiguration to the MSI-X vector index

Change-Id: If7eba3b6f62f163b0300e81807ff1767c4ce5b57