### PR TITLE
(fix): Ensure correct submodule sync for edk2 checkout

### DIFF
--- a/.github/workflows/sysarch_ci.yml
+++ b/.github/workflows/sysarch_ci.yml
@@ -114,9 +114,10 @@ jobs:
 
       - name: Download edk2 and its submodules
         run: |
-          git clone --recursive https://github.com/tianocore/edk2
+          git clone https://github.com/tianocore/edk2
           cd edk2
           git checkout "${{ inputs.edk2-ref }}"
+          git submodule update --init --recursive
           cd ..
           git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 


### PR DESCRIPTION
This update corrects the EDK2 repository cloning workflow to ensure submodules are aligned with the checked-out stable branch.

Previously, cloning with `--recursive` fetched submodules from the default branch (typically 'master'), which could result in mismatched submodule revisions after switching to `edk2stable2025`.

The revised sequence:
    git clone https://github.com/tianocore/edk2
    cd edk2
    git checkout edk2stable2025
    git submodule update --init --recursive

ensures all submodules (e.g., BaseTools, CryptoPkg, ArmPkg) are synced to the commit hashes referenced by the `edk2stable2025` branch, enabling a consistent and reproducible build environment.