### PR TITLE
docs: clarify the intent of # used in testcase checklist

### DIFF
--- a/docs/bsa/arm_bsa_testcase_checklist.rst
+++ b/docs/bsa/arm_bsa_testcase_checklist.rst
@@ -262,4 +262,6 @@ The below table provides the following details
 |1539   |PCIe Normal Memory access check             |L1   |PCI_MM_03                                                   |No   |No   |No   |Yes  |Yes       |No   |Yes                |
 +-------+--------------------------------------------+-----+------------------------------------------------------------+-----+-----+-----+-----+----------+-----+-------------------+
 
+# - Tests that are ported from Linux to the UEFI environment and can be executed once the UEFI PAL layer is implemented. They are recommended to run at Pre-Silicon.
+
 For running tests on a bare-metal environment, integration of ACS with platform boot code is required. See `arm BSA Bare-metal User Guide <arm_bsa_architecture_compliance_bare-metal_user_guide.pdf>`_

--- a/docs/sbsa/arm_sbsa_testcase_checklist.rst
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.rst
@@ -434,5 +434,7 @@ The below table provides the following details
 |PMU app|Latency events                              |L7   |PMU_EV_10                                           |Yes             |No  |No        |Yes  |No                 |
 +-------+--------------------------------------------+-----+----------------------------------------------------+----------------+----+----------+-----+-------------------+
 
+# - Tests that are ported from Linux to the UEFI environment and can be executed once the UEFI PAL layer is implemented. They are recommended to run at Pre-Silicon.
+
 For running tests on a bare-metal environment, integration of ACS with platform boot code is required. See `arm SBSA Bare-metal User Guide <arm_sbsa_architecture_compliance_bare-metal_user_guide.pdf>`_
 


### PR DESCRIPTION
- Fixes : #147  
- add a note to clarify the intent of # used in BSA and SBSA testcase checklist documents