### PR TITLE
fix(exerciser): remove silent alignment of mmio reads

### DIFF
--- a/pal/baremetal/base/src/pal_misc.c
+++ b/pal/baremetal/base/src/pal_misc.c
@@ -184,11 +184,6 @@ void
 pal_mmio_write(uint64_t addr, uint32_t data)
 {
 
-  if (addr & 0x3) {
-      print(ACS_PRINT_WARN, "\n  Error-Input address is not aligned. Masking the last 2 bits\n");
-      addr = addr & ~(0x3);  //make sure addr is aligned to 4 bytes
-  }
-
   if (g_print_mmio || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_write Address = %8x  Data = %x\n", addr, data);
 

--- a/pal/uefi_acpi/src/pal_misc.c
+++ b/pal/uefi_acpi/src/pal_misc.c
@@ -155,10 +155,6 @@ pal_mmio_read(UINT64 addr)
 {
   UINT32 data;
 
-  if (addr & 0x3) {
-      acs_print(ACS_PRINT_WARN, L"\n  Error-Input address is not aligned. Masking the last 2 bits\n");
-      addr = addr & ~(0x3);  //make sure addr is aligned to 4 bytes
-  }
   data = (*(volatile UINT32 *)addr);
 
   if (g_print_mmio || (g_curr_module & g_enable_module))

--- a/pal/uefi_dt/src/pal_misc.c
+++ b/pal/uefi_dt/src/pal_misc.c
@@ -157,10 +157,6 @@ pal_mmio_read(UINT64 addr)
 {
   UINT32 data;
 
-  if (addr & 0x3) {
-      acs_print(ACS_PRINT_WARN, L"\n  Error-Input address is not aligned. Masking the last 2 bits\n");
-      addr = addr & ~(0x3);  //make sure addr is aligned to 4 bytes
-  }
   data = (*(volatile UINT32 *)addr);
 
   if (g_print_mmio || (g_curr_module & g_enable_module))

--- a/test_pool/exerciser/e039.c
+++ b/test_pool/exerciser/e039.c
@@ -56,6 +56,7 @@ payload(void)
   uint32_t bdf;
   uint32_t status;
   uint32_t instance;
+  bool     test_skip = 1;
   exerciser_data_t e_data;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -95,6 +96,9 @@ payload(void)
     /* Do additional checks if the BAR is pcie prefetchable mmio space */
     if (e_data.bar_space.type == MMIO_PREFETCHABLE) {
 
+        /* test runs on atleast one device */
+        test_skip = 0;
+
         /* Map the mmio space to ARM normal memory in MMU page tables */
         for (idx = 0; idx < sizeof(ARM_NORMAL_MEM_ARRAY)/sizeof(ARM_NORMAL_MEM_ARRAY[0]); idx++) {
             baseptr = (char *)val_memory_ioremap((void *)e_data.bar_space.base_addr,
@@ -121,6 +125,13 @@ payload(void)
             val_memory_unmap(baseptr);
         }
     }
+  }
+
+  if (test_skip) {
+      val_print(ACS_PRINT_DEBUG,
+                "\n       No exerciser with prefetchable mmio space, Skipping test", 0);
+      val_set_status(pe_index, RESULT_SKIP(TEST_NUM, 01));
+      return;
   }
 
   val_set_status(pe_index, RESULT_PASS(TEST_NUM, 01));


### PR DESCRIPTION
 - incase of unaligned address acceses, only reads are silently aligned but not the writes
 - this will lead to incorrect data read back
 - also includes bug fixes for test e039


Change-Id: Ief19cc6b4bcb20532da7774dd94f2541b48f87e5