### PR TITLE
fix(pcie): skip Display controllers during FLR tests

### DIFF
--- a/test_pool/pcie/p035.c
+++ b/test_pool/pcie/p035.c
@@ -94,7 +94,8 @@ payload(void)
        * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (g_pcie_skip_dp_nic_ms && ((base_cc == MAS_CC) || (base_cc == CNTRL_CC)))
+      if (g_pcie_skip_dp_nic_ms &&
+          ((base_cc == MAS_CC) || (base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC)))
       {
           val_print(ACS_PRINT_DEBUG, "\n       Skipping for BDF - 0x%x ", bdf);
           val_print(ACS_PRINT_DEBUG, " Classcode is : 0x%x ", base_cc);

--- a/test_pool/pcie/p063.c
+++ b/test_pool/pcie/p063.c
@@ -104,7 +104,8 @@ payload(void *arg)
        * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (g_pcie_skip_dp_nic_ms && ((base_cc == MAS_CC) || (base_cc == CNTRL_CC)))
+      if (g_pcie_skip_dp_nic_ms &&
+          ((base_cc == MAS_CC) || (base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC)))
       {
           val_print(ACS_PRINT_DEBUG, "\n       Skipping for BDF - 0x%x ", bdf);
           val_print(ACS_PRINT_DEBUG, " Classcode is : 0x%x ", base_cc);


### PR DESCRIPTION
- Update p035 and p063 to skip VGA Controllers when g_pcie_skip_dp_nic_ms is set. This avoids unintended side effects from FLR operations on display controllers


Change-Id: Id6ebd799c852f5dc72c99e6f1b0db0d84e909a9b