### PR TITLE
MdePkg: migrate from fdtlib to BaseFdtLib and update edk2 to stable202508

### DIFF
--- a/.github/workflows/sysarch_ci.yml
+++ b/.github/workflows/sysarch_ci.yml
@@ -12,7 +12,7 @@ on:
         description: "edk2 ref/branch/tag to checkout"
         required: false
         type: string
-        default: "edk2-stable202505"
+        default: "edk2-stable202508"
       run-uefi:
         description: "Run UEFI builds"
         required: false

--- a/.github/workflows/sysarch_commit.yml
+++ b/.github/workflows/sysarch_commit.yml
@@ -11,7 +11,7 @@ jobs:
   run:
     uses: ./.github/workflows/sysarch_ci.yml
     with:
-      edk2-ref: edk2-stable202505
+      edk2-ref: edk2-stable202508
       toolchain: arm-toolchain,gcc
       run-uefi: true
       run-baremetal: true

--- a/.github/workflows/sysarch_daily.yml
+++ b/.github/workflows/sysarch_daily.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     uses: ./.github/workflows/sysarch_ci.yml
     with:
-      edk2-ref: edk2-stable202505
+      edk2-ref: edk2-stable202508
       toolchain: arm-toolchain
       run-uefi: true
       run-baremetal: true

--- a/pal/uefi_dt/UnifiedPalLib.inf
+++ b/pal/uefi_dt/UnifiedPalLib.inf
@@ -63,7 +63,7 @@
   ShellCEntryLib
   UefiBootServicesTableLib
   UefiRuntimeServicesTableLib
-  FdtLib
+  BaseFdtLib
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                     ## CONSUMES
@@ -81,5 +81,5 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
-  GCC:*_*_*_CC_FLAGS   =  -O0 -I${ACS_PATH}/pal/baremetal/target/RDN2/include/
+  GCC:*_*_*_CC_FLAGS   =  -O0 -I${ACS_PATH}/pal/baremetal/target/RDN2/include/ -I$(WORKSPACE)/MdePkg/Library/BaseFdtLib/libfdt/libfdt
 

--- a/pal/uefi_dt/src/pal_dt.c
+++ b/pal/uefi_dt/src/pal_dt.c
@@ -23,7 +23,7 @@
 #include <Library/PrintLib.h>
 #include <Library/DtPlatformDtbLoaderLib.h>
 
-#include <Include/libfdt.h>
+#include <libfdt.h>
 #include "Include/Guid/Acpi.h"
 #include <Protocol/AcpiTable.h>
 #include "Include/IndustryStandard/Acpi61.h"

--- a/pal/uefi_dt/src/pal_gic.c
+++ b/pal/uefi_dt/src/pal_gic.c
@@ -22,7 +22,7 @@
 
 #include "Include/IndustryStandard/Acpi61.h"
 #include <Protocol/AcpiTable.h>
-#include <Include/libfdt.h>
+#include <libfdt.h>
 #include <Protocol/HardwareInterrupt.h>
 #include <Protocol/HardwareInterrupt2.h>
 

--- a/pal/uefi_dt/src/pal_iovirt.c
+++ b/pal/uefi_dt/src/pal_iovirt.c
@@ -22,7 +22,7 @@
 
 #include <Protocol/AcpiTable.h>
 #include <Protocol/HardwareInterrupt.h>
-#include <Include/libfdt.h>
+#include <libfdt.h>
 #include "Include/IndustryStandard/Acpi61.h"
 
 #include "../include/platform_override.h"

--- a/pal/uefi_dt/src/pal_pcie.c
+++ b/pal/uefi_dt/src/pal_pcie.c
@@ -30,7 +30,7 @@
 #include <Protocol/PciIo.h>
 #include <Protocol/PciRootBridgeIo.h>
 
-#include <Include/libfdt.h>
+#include <libfdt.h>
 #include "../include/platform_override.h"
 #include "include/pal_uefi.h"
 #include "include/bsa_pcie_enum.h"

--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -20,7 +20,7 @@
 #include <Library/UefiLib.h>
 
 #include "Include/IndustryStandard/Acpi61.h"
-#include <Include/libfdt.h>
+#include <libfdt.h>
 #include <Protocol/AcpiTable.h>
 #include <Protocol/Cpu.h>
 #include "Include/IndustryStandard/SmBios.h"

--- a/pal/uefi_dt/src/pal_peripherals.c
+++ b/pal/uefi_dt/src/pal_peripherals.c
@@ -23,7 +23,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DxeServicesTableLib.h>
 
-#include <Include/libfdt.h>
+#include <libfdt.h>
 
 #include <Protocol/AcpiTable.h>
 #include "Include/IndustryStandard/Acpi61.h"

--- a/pal/uefi_dt/src/pal_timer_wd.c
+++ b/pal/uefi_dt/src/pal_timer_wd.c
@@ -23,7 +23,7 @@
 #include <Protocol/AcpiTable.h>
 #include "Include/IndustryStandard/Acpi61.h"
 
-#include <Include/libfdt.h>
+#include <libfdt.h>
 #include "../include/platform_override.h"
 #include "include/pal_uefi.h"
 #include "include/pal_dt.h"

--- a/patches/edk2_bsa_dt.patch
+++ b/patches/edk2_bsa_dt.patch
@@ -1,5 +1,5 @@
 diff --git a/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c b/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
-index f0a8b9f..e41e0de 100644
+index f0a8b9fe62..e41e0de3e0 100644
 --- a/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
 +++ b/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
 @@ -90,8 +90,8 @@ UefiHiiServicesLibConstructor (
@@ -14,14 +14,14 @@ index f0a8b9f..e41e0de 100644
    //
    // Retrieve the pointer to the optional UEFI HII Font Protocol
 diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
-index 7e985f8..6ea22f8 100644
+index 94d95de0eb..797d6abe16 100644
 --- a/ShellPkg/ShellPkg.dsc
 +++ b/ShellPkg/ShellPkg.dsc
 @@ -66,6 +66,9 @@
    ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
  
    SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
-+  FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
++  BaseFdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
 +  UnifiedValLib|ShellPkg/Application/sysarch-acs/val/UnifiedValLib.inf
 +  UnifiedPalLib|ShellPkg/Application/sysarch-acs/pal/uefi_dt/UnifiedPalLib.inf
  

--- a/patches/edk2_pfdi.patch
+++ b/patches/edk2_pfdi.patch
@@ -1,5 +1,5 @@
 diff --git a/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c b/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
-index f0a8b9f..e41e0de 100644
+index f0a8b9fe62..e41e0de3e0 100644
 --- a/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
 +++ b/MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
 @@ -90,8 +90,8 @@ UefiHiiServicesLibConstructor (
@@ -14,14 +14,14 @@ index f0a8b9f..e41e0de 100644
    //
    // Retrieve the pointer to the optional UEFI HII Font Protocol
 diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
-index 7e985f8..5ea90eb 100644
+index 94d95de0eb..dbd4453044 100644
 --- a/ShellPkg/ShellPkg.dsc
 +++ b/ShellPkg/ShellPkg.dsc
 @@ -66,6 +66,9 @@
    ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
  
    SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
-+  FdtLib|EmbeddedPkg/Library/FdtLib/FdtLib.inf
++  BaseFdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
 +  UnifiedValLib|ShellPkg/Application/sysarch-acs/val/UnifiedValLib.inf
 +  UnifiedPalLib|ShellPkg/Application/sysarch-acs/pal/uefi_dt/UnifiedPalLib.inf
  


### PR DESCRIPTION
Migrate MdePkg from the deprecated fdtlib in EmbeddedPkg to BaseFdtLib in MdePkg
as recommended by edk2 maintainers. This ensures compatibility with the latest
edk2 release.

Also updated the edk2 version to edk2-stable202508 in sysarch_ci.yml to align
with the current upstream baseline.