### PR TITLE
Errata 852: Add new rule for breakpoints numbering

### DIFF
--- a/apps/uefi/Bsa.inf
+++ b/apps/uefi/Bsa.inf
@@ -55,6 +55,7 @@
   ../../test_pool/pe/pe020.c
   ../../test_pool/pe/pe021.c
   ../../test_pool/pe/pe022.c
+  ../../test_pool/pe/pe066.c
   ../../test_pool/gic/g001.c
   ../../test_pool/gic/g002.c
   ../../test_pool/gic/g003.c

--- a/apps/uefi/Mem.inf
+++ b/apps/uefi/Mem.inf
@@ -53,6 +53,7 @@
   ../../test_pool/pe/pe020.c
   ../../test_pool/pe/pe021.c
   ../../test_pool/pe/pe022.c
+  ../../test_pool/pe/pe066.c
   ../../test_pool/gic/g001.c
   ../../test_pool/gic/g002.c
   ../../test_pool/gic/g003.c

--- a/apps/uefi/Sbsa.inf
+++ b/apps/uefi/Sbsa.inf
@@ -57,6 +57,7 @@
   ../../test_pool/pe/pe020.c
   ../../test_pool/pe/pe021.c
   ../../test_pool/pe/pe022.c
+  ../../test_pool/pe/pe066.c
   ../../test_pool/gic/g001.c
   ../../test_pool/gic/g002.c
   ../../test_pool/gic/g003.c

--- a/apps/uefi/Unified.inf
+++ b/apps/uefi/Unified.inf
@@ -56,6 +56,7 @@
   ../../test_pool/pe/pe020.c
   ../../test_pool/pe/pe021.c
   ../../test_pool/pe/pe022.c
+  ../../test_pool/pe/pe066.c
   ../../test_pool/gic/g001.c
   ../../test_pool/gic/g002.c
   ../../test_pool/gic/g003.c

--- a/apps/uefi/pc_bsa.inf
+++ b/apps/uefi/pc_bsa.inf
@@ -57,6 +57,7 @@
   ../../test_pool/pe/pe020.c
   ../../test_pool/pe/pe021.c
   ../../test_pool/pe/pe022.c
+  ../../test_pool/pe/pe066.c
   ../../test_pool/gic/g001.c
   ../../test_pool/gic/g002.c
   ../../test_pool/gic/g003.c

--- a/test_pool/pe/pe066.c
+++ b/test_pool/pe/pe066.c
@@ -1,0 +1,142 @@
+/** @file
+ * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/acs_val.h"
+#include "val/include/acs_pe.h"
+
+#define TEST_NUM  (ACS_PE_TEST_NUM_BASE + 66)
+#define TEST_RULE "XRPZG"
+#define TEST_DESC "Check num of Breakpoints and type      "
+
+static
+void
+payload()
+{
+    uint64_t dfr0 = 0, dfr1 = 0;
+    uint64_t dfr0_brps = 0, dfr1_brps = 0;
+    uint32_t dfr0_ctx = 0, dfr1_ctx = 0;
+    uint32_t ctx_start = 0, ctx_end = 0;
+    int32_t breakpointcount;
+    uint32_t context_aware_breakpoints = 0;
+    uint32_t pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+    dfr0 = val_pe_reg_read(ID_AA64DFR0_EL1);
+    dfr1 = val_pe_reg_read(ID_AA64DFR1_EL1);
+
+    /* bits 15:12 for Number of breakpoints - 1 */
+    dfr0_brps = VAL_EXTRACT_BITS(dfr0, 12, 15);
+    dfr1_brps = VAL_EXTRACT_BITS(dfr1, 12, 15);
+
+    /* If DFR0 reports maximum (0xF) and DFR1 is non-zero,
+     *   Total breakpoints = (DFR1 + 1)
+     *   Example: DFR0=0xF, DFR1=0x2 -> 16 + 3 = 19
+     * Else
+     *   Total breakpoints = DFR0 + 1
+     */
+    breakpointcount = (dfr0_brps == 0xF && dfr1_brps != 0) ?
+                  (dfr1_brps + 1) : (dfr0_brps + 1);
+
+    if (breakpointcount < 6)
+    {
+        val_print_primary_pe(ACS_PRINT_ERR,
+                             "\n       Number of PE breakpoints reported: %d, expected >= 6",
+                             breakpointcount, pe_index);
+        val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 1));
+        return;
+    }
+
+    /*bits [31:28] Number of breakpoints that are context-aware, minus 1*/
+    dfr0_ctx = VAL_EXTRACT_BITS(dfr0, 28, 31);
+    dfr1_ctx = VAL_EXTRACT_BITS(dfr1, 28, 31);
+
+    /* If CTX_CMP field in DFR0 is not 0xF,
+     *   Context-aware breakpoints = CTX_CMP + 1
+     * Else (when DFR0 reports 0xF),
+     *   If DFR1.CTX_CMP == 0 -> 16 context-aware breakpoints
+     *   Else -> (DFR1.CTX_CMP + 1)
+     */
+    if (dfr0_ctx != 0xF)
+        context_aware_breakpoints = dfr0_ctx + 1;
+    else
+        context_aware_breakpoints = (dfr1_ctx == 0) ? 16 : (dfr1_ctx + 1);
+
+    val_print_primary_pe(ACS_PRINT_DEBUG, "\n       Total Breakpoints          : %u",
+                         breakpointcount, pe_index);
+    val_print_primary_pe(ACS_PRINT_DEBUG, "\n       Context-Aware Breakpoints  : %u",
+                         context_aware_breakpoints, pe_index);
+
+    if (context_aware_breakpoints < 2)
+    {
+        val_print_primary_pe(ACS_PRINT_ERR,
+                             "\n       Context-aware breakpoints reported: %u, expected >= 2",
+                             context_aware_breakpoints, pe_index);
+        val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 2));
+        return;
+    }
+
+    if (breakpointcount <= 16) {
+        /* Highest-numbered breakpoints are context-aware */
+        ctx_start = breakpointcount - context_aware_breakpoints;
+        ctx_end = breakpointcount - 1;
+    } else if (context_aware_breakpoints <= 16) {
+        /* Top 16 slots used when >16 BRPs */
+        ctx_start = 16 - context_aware_breakpoints;
+        ctx_end = 15;
+    } else {
+        /* More than 16 context-aware BPs -> start from BP[0] */
+        ctx_start = 0;
+        ctx_end = context_aware_breakpoints - 1;
+    }
+
+    val_print_primary_pe(ACS_PRINT_DEBUG, "\n       Context-Aware BP range st     : BP[%u]",
+                ctx_start, pe_index);
+    val_print_primary_pe(ACS_PRINT_DEBUG, "\n       Context-Aware BP range end     : BP[%u]",
+                ctx_end, pe_index);
+
+    /* Breakpoints 4 and 5 must be context-aware */
+    if (ctx_start <= 4 && ctx_end >= 5)
+        val_set_status(pe_index, RESULT_PASS(TEST_NUM, 1));
+    else
+    {
+        val_print_primary_pe(ACS_PRINT_ERR,
+                "\n       Breakpoints 4 and 5 are not context-aware as required", 0, pe_index);
+        val_set_status(pe_index, RESULT_FAIL(TEST_NUM, 3));
+    }
+}
+
+/**
+  @brief   Check for the number of breakpoints available
+**/
+uint32_t
+pe066_entry(uint32_t num_pe)
+{
+    uint32_t status = ACS_STATUS_FAIL;
+
+    val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
+
+    status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+    if (status != ACS_STATUS_SKIP)
+        /* execute payload on present PE and then execute on other PE */
+        val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+    /* get the result from all PE and check for failure */
+    status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+
+    val_report_status(0, ACS_END(TEST_NUM), NULL);
+
+    return status;
+}

--- a/tools/cmake/infra/bsa_test.txt
+++ b/tools/cmake/infra/bsa_test.txt
@@ -18,6 +18,7 @@ pe019.c
 pe020.c
 pe021.c
 pe022.c
+pe066.c
 g001.c
 g002.c
 g003.c

--- a/val/include/acs_pe.h
+++ b/val/include/acs_pe.h
@@ -372,6 +372,7 @@ uint32_t pe061_entry(uint32_t num_pe);
 uint32_t pe062_entry(uint32_t num_pe);
 uint32_t pe063_entry(uint32_t num_pe);
 uint32_t pe064_entry(uint32_t num_pe);
+uint32_t pe066_entry(uint32_t num_pe);
 
 #endif
 

--- a/val/include/rule_based_execution_enum.h
+++ b/val/include/rule_based_execution_enum.h
@@ -533,6 +533,7 @@ typedef enum {
     PE063_ENTRY,
     PE037_ENTRY,
     PE015_ENTRY,
+    PE066_ENTRY,
     PE043_ENTRY,
     PE044_ENTRY,
     PE045_ENTRY,

--- a/val/src/bsa_execute_test.c
+++ b/val/src/bsa_execute_test.c
@@ -139,6 +139,7 @@ val_bsa_pe_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       if (g_bsa_level > 1 || g_bsa_only_level == 2) {
           view_print_info(OPERATING_SYSTEM);
           status |= pe015_entry(num_pe);
+          status |= pe066_entry(num_pe);
       }
   }
 

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -242,6 +242,14 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_PE_TEST_NUM_BASE  +  15,
         },
+        [XRPZG] = {
+            .test_entry_id    = PE066_ENTRY,
+            .module_id        = PE,
+            .rule_desc        = "Check num of Breakpoints and type",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = BASE_RULE,
+            .test_num         = ACS_PE_TEST_NUM_BASE  +  66,
+        },
         [B_SEC_01] = {
             .test_entry_id    = PE043_ENTRY,
             .module_id        = PE,
@@ -2807,6 +2815,7 @@ test_entry_fn_t test_entry_func_table[TEST_ENTRY_SENTINEL] = {
     [PE062_ENTRY] = pe062_entry,
     [PE063_ENTRY] = pe063_entry,
     [PE064_ENTRY] = pe064_entry,
+    [PE066_ENTRY] = pe066_entry,
 /* The following test entries are excluded from compilation for the BSA DT UEFI App, as they are
    not required for the BSA DT build. These tests invoke VAL APIs, which in turn call PAL APIs,
    and PAL_DT lacks a few necessary implementations.*/


### PR DESCRIPTION
- Add a new future rule for breakpoints numbering that overrides the existing B_PE_11.

Change-Id: I8541761e360f8e4d08315576073b5be7f9a825ce