### PR TITLE
docs: add Unified ACS documentation and update main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Table of Contents
 
 * [Introduction](#introduction)
-* [Repository Structure](#repository-structure)
+* [Repository Structure](#-repository-structure)
 * [Architecture Compliance Suites](#architecture-compliance-suites)
   * [BSA ACS](#bsa-architecture-compliance-suite)
   * [SBSA ACS](#sbsa-architecture-compliance-suite)
@@ -13,10 +13,11 @@
   * [DRTM ACS](#drtm-architecture-compliance-suite)
   * [MemTest ACS](#memtest-architecture-compliance-suite)
   * [PFDI ACS](#pfdi-architecture-compliance-suite)
-* [Security Implications](#security-implications)
-* [Limitations](#limitations)
-* [Feedback and Support](#feedback-and-support)
-* [License](#license)
+* [Unified ACS](#unified-architecture-compliance-suite)
+* [Security Implications](#-security-implications)
+* [Limitations](#-limitations)
+* [Feedback and Support](#-feedback-and-support)
+* [License](#-license)
 
 ---
 
@@ -50,6 +51,7 @@ sysarch-acs/
 │   ├── uefi/
 │   |   └── <acs_name>_main.c
 ├── docs/
+│   ├── unified/
 │   ├── bsa/
 │   ├── sbsa/
 │   ├── drtm/
@@ -182,6 +184,14 @@ Validates platform compliance with Arm PFDI specification.
 
 ####  Reference for Build, Execution, and More
 Refer to the [PFDI ACS README](docs/pfdi/README.md) for detailed build steps, execution procedures, additional information, and known limitations.
+
+---
+
+## Unified Architecture Compliance Suite
+Provides a unified entry point for running BSA, SBSA, PC-BSA validation from a single UEFI application.
+
+####  Reference for Build, Execution, and More
+Refer to the [Unified ACS README](docs/unified/README.md) for build steps, execution procedures, additional information, and known limitations.
 
 ---
 

--- a/docs/unified/README.md
+++ b/docs/unified/README.md
@@ -1,0 +1,173 @@
+## Table of Contents
+
+- [Unified Architecture Compliance Suite](#unified-architecture-compliance-suite)
+- [Release Details](#release-details)
+- [Unified build steps](#unified-build-steps)
+  - [UEFI Shell application](#uefi-shell-application)
+    - [Prerequisites](#prerequisites)
+    - [Setup the workspace and clone required repositories](#setup-the-workspace-and-clone-required-repositories)
+    - [Build edk2 prerequisites](#build-edk2-prerequisites)
+    - [Start the Unified ACS build](#start-the-unified-acs-build)
+    - [Build output](#build-output)
+  - [Linux application](#linux-application)
+- [Unified run steps](#unified-run-steps)
+  - [For UEFI application](#for-uefi-application)
+  - [For Linux application](#for-linux-application)
+- [Related Documentation](#related-documentation)
+- [Support](#support)
+
+## Unified Architecture Compliance Suite
+
+The **Unified Architecture Compliance Suite (ACS)** packages the BSA, SBSA and PC-BSA test suites into a single, self-checking UEFI binary.  
+It is intended for platform teams that want to validate a design once and cover the combined requirements of the Base System Architecture (BSA), Server Base System Architecture (SBSA) and PCBase System Architecture (PC-BSA) specifications.
+
+Most tests run from the **UEFI Shell** by invoking the Unified ACS UEFI application.  
+Selected PCIe and peripheral tests require the Exerciser VIP to achieve complete coverage.  
+The test suite can also be executed in bare-metal environments; initialization of those environments remains platform-specific.
+
+## Release Details
+
+- **Coverage:** Aggregates validation for [BSA 1.1](https://developer.arm.com/documentation/den0094/d/?lang=en) and [SBSA 7.2](https://developer.arm.com/documentation/den0029/i/?lang=en).  
+- **Execution levels:** Suitable for both Pre-Silicon and Silicon validation.  
+- **Complementary requirements:** Running with the Exerciser VIP is recommended for complete PCIe compliance coverage.  
+- **Linux dependencies:** The Unified ACS relies on the BSA and SBSA Linux applications for tests that require an OS environment. Refer to the dedicated BSA and SBSA documentation for details.
+
+## Unified build steps
+
+Follow the steps below to build the combined UEFI shell application (`UnifiedAcs.efi`) inside an edk2 workspace.
+
+### UEFI Shell application
+
+#### Prerequisites
+- A mainstream Linux distribution on x86 or AArch64.
+- Bash shell for building.
+- edk2 build dependencies (compiler toolchains, required packages).  
+  *Note: Package specifics vary by distribution and are out of scope for this guide.*
+
+#### Setup the workspace and clone required repositories
+```
+mkdir workspace && cd workspace
+git clone -b edk2-stable202508 https://github.com/tianocore/edk2
+cd edk2
+git submodule update --init --recursive
+git clone https://github.com/tianocore/edk2-libc
+git clone https://github.com/ARM-software/sysarch-acs.git ShellPkg/Application/sysarch-acs
+cd -
+```
+- On x86 hosts download and extract the Arm GNU AArch64 toolchain:
+```
+wget https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
+tar -xf arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
+export GCC_AARCH64_PREFIX=$PWD/arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+```
+- On native AArch64 hosts export the system toolchain prefix:
+```
+export GCC_AARCH64_PREFIX=/usr/bin/
+```
+
+#### Build edk2 prerequisites
+```
+cd edk2
+export PACKAGES_PATH=$PWD/edk2-libc
+source edksetup.sh
+make -C BaseTools/Source/C
+```
+
+#### Start the Unified ACS build
+```
+rm -rf Build/
+source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh unified
+```
+
+#### Build output
+The Unified ACS EFI binary is generated at:
+`workspace/edk2/Build/Shell/DEBUG_GCC/AARCH64/UnifiedAcs.efi`
+
+> **Note:** Unified ACS currently supports ACPI-based builds. Platform-specific device tree enablement is not available for the unified target. Ensure Exerciser PAL APIs are implemented when the Exerciser VIP is present.
+
+### Linux application
+Unified ACS relies on the existing BSA and SBSA Linux applications when OS-based tests are required. Build these components using the instructions in `docs/bsa/README.md` and `docs/sbsa/README.md`, then deploy them alongside the Unified ACS UEFI binary.
+
+## Unified run steps
+
+### For UEFI application
+
+#### Silicon system
+On platforms with USB access:
+1. Copy `UnifiedAcs.efi` to a FAT-formatted USB device.
+
+- **For U-Boot firmware systems, additional steps**
+  1. Copy `Shell.efi` to the USB device (available under `prebuilt_images/IR`).
+  2. Boot to the **U-Boot** shell.
+  3. Discover the USB device:
+     ```
+     usb start
+     ```
+  4. Load `Shell.efi` into memory and start the UEFI shell:
+     ```
+     fatload usb <dev_num> ${kernel_addr_r} Shell.efi
+     fatload usb 0 ${kernel_addr_r} Shell.efi
+     ```
+2. In the UEFI shell refresh the filesystem mappings:
+   ```sh
+   map -r
+   ```
+3. Switch to the USB filesystem (for example, `fs0:`).
+4. Run `UnifiedAcs.efi` with the required parameters.
+5. Capture the UART console output for log retention.
+
+- For application parameters, see the [Unified ACS User Guide](user_guide.rst).
+
+#### Emulation environment with secondary storage
+1. Create an image containing `UnifiedAcs.efi` and `Shell.efi` (for U-Boot systems):
+   ```
+   mkfs.vfat -C -n HD0 hda.img 2097152
+   sudo mount -o rw,loop=/dev/loop0,uid=$(whoami),gid=$(whoami) hda.img /mnt/unified
+   sudo cp "<path to application>/UnifiedAcs.efi" /mnt/unified/
+   sudo umount /mnt/unified
+   ```
+   *(Select an available loop device if `/dev/loop0` is busy.)*
+2. Load the image into the emulated secondary storage using the platform-specific mechanism.
+3. Boot to the UEFI shell.
+4. Identify the filesystem with `map -r`.
+5. Switch to the filesystem (`fs<x>:`).
+6. Execute `UnifiedAcs.efi` with the appropriate parameters.
+7. Preserve the UART console output for debug or certification review.
+
+- For application parameters, see the [Unified ACS User Guide](user_guide.rst).
+
+### For Linux application
+
+Unified ACS reuses the BSA and SBSA Linux applications to exercise OS-reliant tests:
+1. Transfer the built binaries (`bsa_acs.ko`, `bsa_app`, `sbsa_acs.ko`, `sbsa_app`) to the target system (for example, on a USB drive).
+2. Boot into Linux and locate the removable storage device.
+3. Load each kernel module before running the corresponding user-space application:
+   ```sh
+   sudo insmod bsa_acs.ko
+   sudo insmod sbsa_acs.ko
+   ```
+4. Execute the user-space applications to run the Linux portions of the suite:
+   ```sh
+   ./bsa_app
+   ./sbsa_app
+   ```
+5. Remove the kernel modules once testing is complete:
+   ```sh
+   sudo rmmod sbsa_acs
+   sudo rmmod bsa_acs
+   ```
+
+- For application parameters, see the [Unified ACS User Guide](user_guide.rst).
+
+## Related Documentation
+
+- [BSA ACS README](../bsa/README.md) — UEFI, Linux, and bare-metal build/run guidance.  
+- [SBSA ACS README](../sbsa/README.md) — UEFI, Linux, and bare-metal build/run guidance.  
+- [PC-BSA ACS README](../pc_bsa/README.md) — UEFI, Linux, and bare-metal build/run guidance.  
+- [PCIe Exerciser documentation](../pcie/Exerciser.md) — Reference implementation and PAL requirements.  
+
+## Support
+
+- Email: [support-systemready-acs@arm.com](mailto:support-systemready-acs@arm.com)  
+- GitHub Issues: [sysarch-acs issue tracker](../../issues)  
+- Contributions: [GitHub Pull Requests](../../pulls)

--- a/docs/unified/user_guide.rst
+++ b/docs/unified/user_guide.rst
@@ -1,0 +1,58 @@
+Unified Command Line Options
+============================
+
+Usage::
+
+  Unified.efi [options]
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Option
+     - Description
+   * - ``-a`` ``{bsa|sbsa|pcbsa}``
+     - Architecture selection. ``bsa`` uses the full BSA rule checklist, ``sbsa`` uses the full SBSA rule checklist, and ``pcbsa`` uses the full PC BSA rule checklist.
+   * - ``-cache``
+     - Indicate that the test system supports PCIe address translation cache.
+   * - ``-dtb``
+     - Dump the Device Tree Blob (DTB) file.
+   * - ``-el1physkip``
+     - Skip EL1 register checks. VE systems run ACS at EL1 and some systems crash when accessing EL1 registers; use for debugging only.
+   * - ``-f`` *<path>*
+     - Specify the log file that records the test results.
+   * - ``-fr``
+     - Run rules up to the Future Requirements (FR) level, validated against the ``-a`` selection (for example, ``-a sbsa -fr``).
+   * - ``-h``, ``-help``
+     - Print the usage message.
+   * - ``-l`` *<level>*
+     - Run compliance tests up to the provided level, validated against the ``-a`` selection (for example, ``-a sbsa -l 7``). Example: ``-l 4``.
+   * - ``-m`` *<modules>*
+     - Run only the specified modules (comma-separated names). Accepted values: ``PE``, ``GIC``, ``PERIPHERAL``, ``MEM_MAP``, ``PMU``, ``RAS``, ``SMMU``, ``TIMER``, ``WATCHDOG``, ``NIST``, ``PCIE``, ``MPAM``, ``ETE``, ``TPM``, ``POWER_WAKEUP``. Example: ``-m PE,GIC,PCIE``.
+   * - ``-mmio``
+     - Enable ``pal_mmio_read``/``pal_mmio_write`` prints; use with ``-v 1``.
+   * - ``-no_crypto_ext``
+     - Declare that the cryptography extension is not supported due to export restrictions.
+   * - ``-only`` *<level>*
+     - Run tests only for rules at the provided level, validated against the ``-a`` selection (for example, ``-a sbsa -only 4``).
+   * - ``-os``, ``-hyp``, ``-ps``
+     - Software view filters that work with ``-a bsa`` only; flags can be combined. ``-os`` runs BSA operating system software view tests, ``-hyp`` runs BSA hypervisor software view tests, and ``-ps`` runs BSA platform security software view tests.
+   * - ``-p2p``
+     - Indicate that the PCIe hierarchy supports peer-to-peer.
+   * - ``-r`` *<rules>*
+     - Run tests for the provided comma-separated rule IDs or a rules file (for example, ``-r B_PE_01,B_PE_02,B_GIC_01`` or ``-r rules.txt``). Files may mix commas and newlines; lines starting with ``#`` are treated as comments.
+   * - ``-slc`` *<type>*
+     - Provide the system last-level cache type: ``1`` for PPTT PE-side cache, ``2`` for HMAT memory-side cache.
+   * - ``-skip`` *<rules>*
+     - Skip the specified rule IDs (comma-separated, similar to ``-r``). Example: ``-skip B_PE_01,B_GIC_02``.
+   * - ``-skip-dp-nic-ms``
+     - Skip PCIe tests for DisplayPort, Network, and Mass Storage devices.
+   * - ``-skipmodule`` *<modules>*
+     - Skip the specified modules (comma-separated names). Example: ``-skipmodule PE,GIC,PCIE``.
+   * - ``-timeout`` *<value>*
+     - Set the timeout multiplier for wakeup tests (minimum 1, maximum 5; defaults to 1).
+   * - ``-v`` *<level>*
+     - Set the verbosity of the prints (``1`` prints all messages, ``5`` prints only errors).


### PR DESCRIPTION
- Added new `docs/unified/README.md` detailing Unified ACS purpose, build, and usage.
- Updated top-level README to reference Unified ACS and include relevant table of contents entries.
- Introduced unified validation description for BSA, SBSA, and PC-BSA compliance.

Fixes: #139 

Signed-off-by: Rajat Goyal <rajat.goyal@arm.com>
Change-Id: I1df662eb72d96e9efaf65e060c143a66a7e6a452