### PR TITLE
fix(ras): gate ERR_FR feature checks on CE/DE bits

### DIFF
--- a/apps/uefi/Mem.inf
+++ b/apps/uefi/Mem.inf
@@ -139,6 +139,7 @@
   ../../test_pool/exerciser/e015.c
   ../../test_pool/exerciser/e016.c
   ../../test_pool/exerciser/e017.c
+  ../../test_pool/exerciser/e030.c
   ../../test_pool/exerciser/e033.c
   ../../test_pool/exerciser/e035.c
   ../../test_pool/exerciser/e039.c

--- a/test_pool/ras/ras001.c
+++ b/test_pool/ras/ras001.c
@@ -83,8 +83,8 @@ payload()
         continue;
     }
 
-    /* Check ERR_FR.CEC[14:12] != 0 for CEC to be implemented */
-    if (!(value & ERR_FR_CEC_MASK)) {
+    /* Check only if ERR_FR.CE != 0 - Check ERR_FR.CEC[14:12] != 0 for CEC to be implemented */
+    if ((value & ERR_FR_CE_MASK) && !(value & ERR_FR_CEC_MASK)) {
       val_print(ACS_PRINT_ERR, "\n       CEC not implemented for node_index %d", node_index);
       fail_cnt++;
       continue;

--- a/test_pool/ras/ras002.c
+++ b/test_pool/ras/ras002.c
@@ -83,15 +83,15 @@ payload()
         continue;
     }
 
-    /* Check DUI[17:16] != 0 of FR Register For DUI Control */
-    if (!(value & ERR_FR_DUI_MASK)) {
+    /* Check only if DE[52] != 0 then DUI[17:16] != 0 of FR Register For DUI Control */
+    if ((value & ERR_FR_DE_MASK) && !(value & ERR_FR_DUI_MASK)) {
       val_print(ACS_PRINT_ERR, "\n       DUI not implemented for node_index %d", node_index);
       fail_cnt++;
       continue;
     }
 
-    /* Check CFI[11:10] != 0 of FR Register For CFI Control */
-    if (!(value & ERR_FR_CFI_MASK)) {
+    /* Check only if ERR_FR.CE != 0 -> Check CFI[11:10] != 0 of FR Register For CFI Control */
+    if ((value & ERR_FR_CE_MASK) && !(value & ERR_FR_CFI_MASK)) {
       val_print(ACS_PRINT_ERR, "\n       CFI not implemented for node_index %d", node_index);
       fail_cnt++;
       continue;

--- a/val/include/acs_ras.h
+++ b/val/include/acs_ras.h
@@ -19,6 +19,8 @@
 #define __ACS_RAS_H
 
 
+#define ERR_FR_CE_MASK   (0x3ull << 53)
+#define ERR_FR_DE_MASK   (0x1ull << 52)
 #define ERR_FR_INJ_MASK  (0x3ull << 20)
 #define ERR_FR_DUI_MASK  (0x3ull << 16)
 #define ERR_FR_CEC_MASK  (0x7ull << 12)


### PR DESCRIPTION
 - Add ERR_FR_CE_MASK and ERR_FR_DE_MASK definitions for FR register decoding
 - Update ras001/ras002 to validate CEC, DUI, and CFI only when corresponding CE/DE bits are set
 - Include exerciser test e030.c in UEFI Mem.inf build configuration

Signed-off-by: Rajat Goyal <[rajat.goyal@arm.com](mailto:rajat.goyal@arm.com)>
Change-Id: If0432af8a7af38fadeae7a8f292ea396342f5f47