### PR TITLE
refactor(pfdi): Use aligned alloc for info table memory

### DIFF
--- a/apps/uefi/Pfdi.inf
+++ b/apps/uefi/Pfdi.inf
@@ -81,4 +81,4 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.1-a
-  GCC:*_*_*_CC_FLAGS   = -O0 -DTARGET_UEFI -DEXCLUDE_RBX
+  GCC:*_*_*_CC_FLAGS   = -O0 -DTARGET_UEFI -DEXCLUDE_RBX  -I${ACS_PATH}/val

--- a/apps/uefi/pfdi_main.c
+++ b/apps/uefi/pfdi_main.c
@@ -266,17 +266,7 @@ createPeInfoTable (
 
   UINT64   *PeInfoTable;
 
-/* allowing room for growth, at present each entry is 16 bytes,
- * so we can support upto 511 PEs with 8192 bytes */
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                               PE_INFO_TBL_SZ,
-                               (VOID **) &PeInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
+  PeInfoTable = val_aligned_alloc(SIZE_4K, PE_INFO_TBL_SZ);
 
   Status = val_pe_create_info_table(PeInfoTable);
 
@@ -291,15 +281,7 @@ createGicInfoTable (
   EFI_STATUS Status;
   UINT64     *GicInfoTable;
 
-  Status = gBS->AllocatePool (EfiBootServicesData,
-                               GIC_INFO_TBL_SZ,
-                               (VOID **) &GicInfoTable);
-
-  if (EFI_ERROR(Status))
-  {
-    Print(L"Allocate Pool failed %x\n", Status);
-    return Status;
-  }
+  GicInfoTable = val_aligned_alloc(SIZE_4K, GIC_INFO_TBL_SZ);
 
   Status = val_gic_create_info_table(GicInfoTable);
 


### PR DESCRIPTION
Fixes: ARM-software/arm-systemready#570

- Replaced gBS->AllocatePool with val_aligned_alloc for PE and GIC info tables in pfdi module
- Updated build flags to include val directory for required headers