### PR TITLE
(fix) Handle pointer access correctly when bsa exit due to error

### DIFF
--- a/apps/uefi/bsa_main.c
+++ b/apps/uefi/bsa_main.c
@@ -211,9 +211,10 @@ print_test_status:
     val_print_acs_test_status_summary();
     val_print(ACS_PRINT_ERR, "\n      *** BSA tests complete. Reset the system. ***\n\n", 0);
 
-    freeAcsMem();
 
 exit_acs:
+
+    freeAcsMem();
 
     if (g_dtb_log_file_handle) {
         ShellCloseFile(&g_dtb_log_file_handle);
@@ -223,6 +224,9 @@ exit_acs:
         ShellCloseFile(&g_acs_log_file_handle);
     }
 
-    val_pe_context_restore(AA64WriteSp(g_stack_pointer));
+    if (g_stack_pointer) {
+        val_pe_context_restore(AA64WriteSp(g_stack_pointer));
+    }
+
     return ACS_STATUS_PASS;
 }

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -94,9 +94,8 @@ val_gic_free_info_table(void)
         g_gic_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_gic_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+                  "\n g_gic_info_table pointer is already NULL", 0);
     }
 }
 

--- a/val/src/acs_iovirt.c
+++ b/val/src/acs_iovirt.c
@@ -322,9 +322,8 @@ val_iovirt_free_info_table(void)
         g_iovirt_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_iovirt_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+                  "\n g_iovirt_info_table pointer is already NULL", 0);
     }
 }
 

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -737,9 +737,8 @@ val_pcie_free_info_table(void)
         g_pcie_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_pcie_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+                  "\n g_pcie_info_table pointer is already NULL", 0);
     }
 }
 

--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -117,9 +117,8 @@ val_pe_free_info_table(void)
         g_pe_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_pe_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+                  "\n g_pe_info_table pointer is already NULL", 0);
     }
 }
 
@@ -540,7 +539,14 @@ val_get_num_smbios_slots()
 void
 val_smbios_free_info_table()
 {
-  pal_mem_free_aligned((void *)g_smbios_info_table);
+  if (g_smbios_info_table != NULL) {
+      pal_mem_free_aligned((void *)g_smbios_info_table);
+      g_smbios_info_table = NULL;
+  }
+  else {
+    val_print(ACS_PRINT_DEBUG,
+       "\n g_smbios_info_table pointer is already NULL", 0);
+    }
 }
 #endif
 

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -319,9 +319,8 @@ val_peripheral_free_info_table(void)
         g_peripheral_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_peripheral_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+              "\n g_peripheral_info_table pointer is already NULL", 0);
     }
 }
 

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -301,9 +301,8 @@ val_timer_free_info_table(void)
         g_timer_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_timer_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+                  "\n g_timer_info_table pointer is already NULL", 0);
     }
 }
 

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -98,9 +98,8 @@ val_wd_free_info_table(void)
         g_wd_info_table = NULL;
     }
     else {
-      val_print(ACS_PRINT_ERR,
-                  "\n WARNING: g_wd_info_table pointer is already NULL",
-        0);
+      val_print(ACS_PRINT_DEBUG,
+                  "\n g_wd_info_table pointer is already NULL", 0);
     }
 }
 


### PR DESCRIPTION
 - When running BSA DT on ACPI system, the BSA will exit before info table creation due to acs expecting device tree, exception is observed due to g_stack_pointer not NULL checked before accessing

 - Also for other cases where BSA exit in after info table creation or in between table creation, the freeacsmem was not called

 - pointer free prints should be debug

Change-Id: Ia8c887b1fda43d01889b11211f265c2b07b93dd3