### PR TITLE
fix(exerciser): correct BAR type detection and handle unimplemented PAL ioremap

### DIFF
--- a/pal/baremetal/target/RDN2/src/pal_bsa.c
+++ b/pal/baremetal/target/RDN2/src/pal_bsa.c
@@ -886,13 +886,13 @@ pal_pcie_mem_get_offset(uint32_t bdf, PCIE_MEM_TYPE_INFO_e mem_type)
 
 /* Peripheral PAL API's */
 
-uint64_t
-pal_memory_ioremap(void *ptr, uint32_t size, uint32_t attr)
+uint32_t
+pal_memory_ioremap(void *ptr, uint32_t size, uint32_t attr, void **baseptr)
 {
   (void) size;
   (void) attr;
-
-  return (uint64_t)ptr;
+  *baseptr = ptr;
+  return NOT_IMPLEMENTED;
 }
 
 void

--- a/pal/baremetal/target/RDN2/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDN2/src/pal_exerciser.c
@@ -691,26 +691,34 @@ uint32_t pal_exerciser_get_data(EXERCISER_DATA_TYPE Type, exerciser_data_t *Data
               Data->bar_space.type = MMIO_NON_PREFETCHABLE;
           return 0;
       case EXERCISER_DATA_MMIO_SPACE:
+          uint32_t BarRegLowerValue = 0;
+          uint32_t Seg, Bus, Dev, Func;
+          uint32_t Offset;
           Index = 0;
           Data->bar_space.base_addr = 0;
           while (Index < TYPE0_MAX_BARS)
           {
               EcamBAR = pal_exerciser_get_ecsr_base(Bdf, Index);
 
+              Seg  = PCIE_EXTRACT_BDF_SEG(Bdf);
+              Bus  = PCIE_EXTRACT_BDF_BUS(Bdf);
+              Dev  = PCIE_EXTRACT_BDF_DEV(Bdf);
+              Func = PCIE_EXTRACT_BDF_FUNC(Bdf);
+              Offset = BAR0_OFFSET + (4 * Index);
+              pal_cfg_read(Seg, Bus, Dev, Func, Offset, &BarRegLowerValue);
+
               /* Check if the BAR is Memory Mapped IO type */
-              if (((EcamBAR >> BAR_MIT_SHIFT) & BAR_MIT_MASK) == MMIO)
+              if (((BarRegLowerValue >> BAR_MIT_SHIFT) & BAR_MIT_MASK) == MMIO)
               {
                   Data->bar_space.base_addr = (void *)(EcamBAR);
-                  if (((EcamBAR >> PREFETCHABLE_BIT_SHIFT) & MASK_BIT) == 0x1)
+                  if (((BarRegLowerValue >> PREFETCHABLE_BIT_SHIFT) & MASK_BIT) == 0x1)
                       Data->bar_space.type = MMIO_PREFETCHABLE;
                   else
                       Data->bar_space.type = MMIO_NON_PREFETCHABLE;
-
-                  Data->bar_space.base_addr = (void *)EcamBAR;
                   return 0;
               }
 
-              if (((EcamBAR >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_64)
+              if (((BarRegLowerValue >> BAR_MDT_SHIFT) & BAR_MDT_MASK) == BITS_64)
               {
                   /* Adjust the index to skip next sequential BAR */
                   Index++;

--- a/pal/baremetal/target/RDV3/src/pal_bsa.c
+++ b/pal/baremetal/target/RDV3/src/pal_bsa.c
@@ -916,13 +916,13 @@ pal_pcie_mem_get_offset(uint32_t bdf, PCIE_MEM_TYPE_INFO_e mem_type)
 
 /* Peripheral PAL API's */
 
-uint64_t
-pal_memory_ioremap(void *ptr, uint32_t size, uint32_t attr)
+uint32_t
+pal_memory_ioremap(void *ptr, uint32_t size, uint32_t attr, void **baseptr)
 {
   (void) size;
   (void) attr;
-
-  return (uint64_t)ptr;
+  *baseptr = ptr;
+  return NOT_IMPLEMENTED;
 }
 
 void

--- a/pal/baremetal/target/RDV3CFG1/src/pal_bsa.c
+++ b/pal/baremetal/target/RDV3CFG1/src/pal_bsa.c
@@ -916,13 +916,13 @@ pal_pcie_mem_get_offset(uint32_t bdf, PCIE_MEM_TYPE_INFO_e mem_type)
 
 /* Peripheral PAL API's */
 
-uint64_t
-pal_memory_ioremap(void *ptr, uint32_t size, uint32_t attr)
+uint32_t
+pal_memory_ioremap(void *ptr, uint32_t size, uint32_t attr, void **baseptr)
 {
   (void) size;
   (void) attr;
-
-  return (uint64_t)ptr;
+  *baseptr = ptr;
+  return NOT_IMPLEMENTED;
 }
 
 void

--- a/pal/uefi_acpi/src/pal_peripherals.c
+++ b/pal/uefi_acpi/src/pal_peripherals.c
@@ -345,15 +345,16 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   @param ptr Pointer to physical memory region
   @param size Size
   @param attr Attributes
+  @param baseptr   OUT: Returned mapped address pointer
 
-  @return Pointer to mapped virtual address space
+  @return  Status of mapping operation
 **/
-UINT64
-pal_memory_ioremap(VOID *ptr, UINT32 size, UINT32 attr)
+UINT32
+pal_memory_ioremap(VOID *ptr, UINT32 size, UINT32 attr, VOID **baseptr)
 {
+  *baseptr = ptr;
 
-
-  return (UINT64)ptr;
+  return NOT_IMPLEMENTED;
 }
 
 /**

--- a/pal/uefi_dt/src/pal_peripherals.c
+++ b/pal/uefi_dt/src/pal_peripherals.c
@@ -802,15 +802,16 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   @param ptr Pointer to physical memory region
   @param size Size
   @param attr Attributes
+  @param baseptr   OUT: Returned mapped address pointer
 
-  @return Pointer to mapped virtual address space
+  @return  Status of mapping operation
 **/
-UINT64
-pal_memory_ioremap(VOID *ptr, UINT32 size, UINT32 attr)
+UINT32
+pal_memory_ioremap(VOID *ptr, UINT32 size, UINT32 attr, VOID **baseptr)
 {
+  *baseptr = ptr;
 
-
-  return (UINT64)ptr;
+  return NOT_IMPLEMENTED;
 }
 
 /**

--- a/test_pool/pcie/p094.c
+++ b/test_pool/pcie/p094.c
@@ -198,8 +198,6 @@ next_bdf:
               goto next_bar;
           }
 
-          test_skip = 0;
-
           /* Enable Memory Space Access to the BDF if not enabled */
           msa_en = val_pcie_is_msa_enabled(bdf);
           if (msa_en)
@@ -208,7 +206,16 @@ next_bdf:
           branch_to_test = &&exception_return_normal;
 
           /* Map the BARs to a NORMAL memory attribute. check unaligned access */
-          baseptr = (char *)val_memory_ioremap((void *)base, 1024, NORMAL_NC);
+          status = val_memory_ioremap((void *)base, 1024, NORMAL_NC, (void **)&baseptr);
+
+          /* Handle unimplemented PAL -> SKIP gracefully */
+          if (status == NOT_IMPLEMENTED) {
+            val_print(ACS_PRINT_ERR,
+                  "\n       pal_memory_ioremap not implemented, skipping test.", 0);
+            goto test_skip_unimplemented;
+          }
+
+          test_skip = 0;
 
           /* Check for unaligned access. Normal memory can be read-only.
            * Not performing data comparison check.
@@ -243,9 +250,11 @@ next_bar:
       }
   }
 
-  if (test_skip)
-      val_set_status(index, RESULT_SKIP(test_num, 0));
-  else if (test_fail)
+  if (test_skip) {
+test_skip_unimplemented:
+    val_set_status(index, RESULT_SKIP(test_num, 0));
+    return;
+  } else if (test_fail)
       val_set_status(index, RESULT_FAIL(test_num, test_fail));
   else
       val_set_status(index, RESULT_PASS(test_num, 0));

--- a/val/include/acs_memory.h
+++ b/val/include/acs_memory.h
@@ -23,7 +23,7 @@
 #define MEM_MAP_FAILURE  0x2
 #define MEM_SIZE_64KB    65536
 
-addr_t val_memory_ioremap(void *addr, uint32_t size, uint32_t attr);
+uint32_t val_memory_ioremap(void *addr, uint32_t size, uint32_t attr, void **baseptr);
 addr_t val_memory_get_addr(MEMORY_INFO_e mem_type, uint32_t instance, uint64_t *attr);
 
 

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -734,7 +734,7 @@ typedef struct {
 } MEMORY_INFO_TABLE;
 
 void  pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable);
-uint64_t pal_memory_ioremap(void *addr, uint32_t size, uint32_t attr);
+uint32_t pal_memory_ioremap(void *addr, uint32_t size, uint32_t attr, void **baseptr);
 void pal_memory_unmap(void *addr);
 uint64_t pal_memory_get_unpopulated_addr(uint64_t *addr, uint32_t instance);
 uint32_t pal_mem_set_wb_executable(void *addr, uint32_t size);

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -177,10 +177,10 @@ val_memory_get_info(addr_t addr, uint64_t *attr)
 
   @return  Mapped Address Starting Pointer
 **/
-addr_t
-val_memory_ioremap(void *addr, uint32_t size, uint32_t attr)
+uint32_t
+val_memory_ioremap(void *addr, uint32_t size, uint32_t attr, void **baseptr)
 {
-  return (pal_memory_ioremap(addr, size, attr));
+  return pal_memory_ioremap(addr, size, attr, baseptr);
 }
 
 /**


### PR DESCRIPTION
 - Fixed incorrect BAR type identification in pal_exerciser_get_data() where BARs always reported as non-prefetchable, causing test e039 to always return SKIP.
 - Updated pal_memory_ioremap() to return NOT_IMPLEMENTED when functionality is absent.
 - Modified tests (e003, e016, e021, e039, p045, p094) to skip tests gracefully when pal_memory_ioremap() is unimplemented, preventing false PASS/FAIL results.
 - Ensures e039 exits gracefully and behaves correctly with valid BAR types.


Change-Id: I98c8a73c69bc2417db443be08d0291f086687832