### PR TITLE
fixed a compiler error/warning of unterminated-string-initialization

### DIFF
--- a/val/include/rule_based_execution.h
+++ b/val/include/rule_based_execution.h
@@ -24,7 +24,7 @@
 #include "rule_based_execution_enum.h"
 
 #define RULE_STRING_SIZE 10
-#define RULE_DESC_SIZE   40
+#define RULE_DESC_SIZE   44
 #define INVALID_IDX 0xFFFFFFFF
 
 /* ----------------------------  Struct  Definations --------------------------------------------*/


### PR DESCRIPTION
the rule_desc field was allocated 40 bytes, but one rule needs 41 this cause issue of unterminated string initialization, fixed it by increasing the size to 44, so overall structure is capped at 64 bytes, this issue surfaced as warning in new compiler version - gcc 15.2