### PR TITLE
chore - provide user an option use their own CMAKE_TOOLCHAIN_FILE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,10 +120,19 @@ foreach(clean_item ${CLEAN_LIST})
 endforeach()
 ###
 
+# Reuse the caller-provided toolchain for nested configure steps, so
+# convenience targets do not override user choices.
+set(_acs_toolchain_arg "")
+if(DEFINED CMAKE_TOOLCHAIN_FILE AND NOT "${CMAKE_TOOLCHAIN_FILE}" STREQUAL "")
+    set(_acs_toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+else()
+    set(_acs_toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${ROOT_DIR}/tools/cmake/toolchain/arm-none-elf-toolchain.cmake")
+endif()
+
 # Generate per-ACS custom targets and an aggregate target
 foreach(_acs IN LISTS ACS_LIST)
     add_custom_target(${_acs}
-        COMMAND ${CMAKE_COMMAND} -DACS=${_acs} -DTARGET=${TARGET} -DCMAKE_OSX_ARCHITECTURES= -DCMAKE_TOOLCHAIN_FILE=${ROOT_DIR}/tools/cmake/toolchain/arm-none-elf-toolchain.cmake -S ${CMAKE_SOURCE_DIR} -B ${CMAKE_BINARY_DIR}/${_acs}_build
+        COMMAND ${CMAKE_COMMAND} -DACS=${_acs} -DTARGET=${TARGET} -DCMAKE_OSX_ARCHITECTURES= ${_acs_toolchain_arg} -S ${CMAKE_SOURCE_DIR} -B ${CMAKE_BINARY_DIR}/${_acs}_build
         COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/${_acs}_build
     )
 endforeach()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,69 +2,67 @@
     "version": 3,
     "cmakeMinimumRequired": { "major": 3, "minor": 19, "patch": 0 },
     "configurePresets": [
-    {
-        "name": "baremetal",
-        "hidden": true,
-        "generator": "Unix Makefiles",
-        "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/tools/cmake/toolchain/arm-none-elf-toolchain.cmake",
-        "CMAKE_OSX_ARCHITECTURES": "",
-        "TARGET": "RDN2"
+        {
+            "name": "baremetal",
+            "hidden": true,
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/tools/cmake/toolchain/arm-none-elf-toolchain.cmake",
+                "CMAKE_OSX_ARCHITECTURES": "",
+                "TARGET": "RDN2"
+            }
+        },
+        {
+            "name": "bsa",
+            "displayName": "Configure: aarch64-none-elf (bsa)",
+            "binaryDir": "${sourceDir}/build/${presetName}_build",
+            "inherits": ["baremetal"],
+            "cacheVariables": {
+                "ACS": "bsa"
+            }
+        },
+        {
+            "name": "sbsa",
+            "displayName": "Configure: aarch64-none-elf (sbsa)",
+            "binaryDir": "${sourceDir}/build/${presetName}_build",
+            "inherits": ["baremetal"],
+            "cacheVariables": {
+                "ACS": "sbsa"
+            }
+        },
+        {
+            "name": "pc_bsa",
+            "displayName": "Configure: aarch64-none-elf (pc_bsa)",
+            "binaryDir": "${sourceDir}/build/${presetName}_build",
+            "inherits": ["baremetal"],
+            "cacheVariables": {
+                "ACS": "pc_bsa"
+            }
+        },
+        {
+            "name": "acs_all",
+            "displayName": "Configure: aarch64-none-elf (for make acs_all)",
+            "binaryDir": "${sourceDir}/build",
+            "inherits": ["baremetal"],
+            "cacheVariables": {}
         }
-    },
-    {
-        "name": "bsa",
-        "displayName": "Configure: aarch64-none-elf (bsa)",
-        "binaryDir": "${sourceDir}/build/${presetName}_build",
-        "inherits": ["baremetal"], 
-        "cacheVariables": {     
-        "ACS" : "bsa"
-        }
-    },
-    {
-        "name": "sbsa",
-        "displayName": "Configure: aarch64-none-elf (sbsa)",
-        "binaryDir": "${sourceDir}/build/${presetName}_build",
-        "inherits": ["baremetal"], 
-        "cacheVariables": {     
-        "ACS" : "sbsa"
-        }
-    },
-    {
-        "name": "pc_bsa",
-        "displayName": "Configure: aarch64-none-elf (pc_bsa)",
-        "binaryDir": "${sourceDir}/build/${presetName}_build",
-        "inherits": ["baremetal"], 
-        "cacheVariables": {     
-        "ACS" : "pc_bsa"
-        }
-    },
-    {
-        "name": "acs_all",
-        "displayName": "Configure: aarch64-none-elf (for make acs_all)",
-        "binaryDir": "${sourceDir}/build",
-        "inherits": ["baremetal"],
-        "cacheVariables": {     
-        }        
-    }    
-
     ],
     "buildPresets": [
-    {
-        "name": "bsa",
-        "configurePreset": "bsa",
-        "jobs": 8
-    },
-    {
-        "name": "sbsa",
-        "configurePreset": "sbsa",
-        "jobs": 8
-    },
-    {
-        "name": "pc_bsa",
-        "configurePreset": "pc_bsa",
-        "jobs": 8
-    }
+        {
+            "name": "bsa",
+            "configurePreset": "bsa",
+            "jobs": 8
+        },
+        {
+            "name": "sbsa",
+            "configurePreset": "sbsa",
+            "jobs": 8
+        },
+        {
+            "name": "pc_bsa",
+            "configurePreset": "pc_bsa",
+            "jobs": 8
+        }
     ]
 }
 

--- a/tools/cmake/toolchain/arm-none-elf-toolchain.cmake
+++ b/tools/cmake/toolchain/arm-none-elf-toolchain.cmake
@@ -30,7 +30,11 @@ if(NOT DEFINED CROSS_COMPILE)
 endif()
 
 if(NOT DEFINED CROSS_COMPILE OR "${CROSS_COMPILE}" STREQUAL "")
-    message(FATAL_ERROR "CROSS_COMPILE not defined in environment. Please set CROSS_COMPILE to your toolchain prefix.")
+    message(FATAL_ERROR
+        "[ACS] : CROSS_COMPILE not defined in environment.\n"
+        "        Please set/export CROSS_COMPILE=<toolchain-prefix->\n"
+        "        Example: export CROSS_COMPILE=/opt/arm/arm-gnu-toolchain-xx.x.rel1-xxx-aarch64-none-elf/bin/aarch64-none-elf-\n"
+        )
 endif()
 
 set(CMAKE_C_COMPILER "${CROSS_COMPILE}gcc" CACHE FILEPATH "C compiler" FORCE)


### PR DESCRIPTION
- removed hardcoding of CMAKE_TOOLCHAIN_FILE to interal one
- cleaned up the presets to correctly indent and remove stray spaces
- provided better instructions to set CROSS_COMPILE when not set.