### PR TITLE
feat(pcie): add helper APIs to enable/disable DPC

### DIFF
--- a/test_pool/exerciser/e024.c
+++ b/test_pool/exerciser/e024.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -258,10 +258,12 @@ err_check:
           val_print(ACS_PRINT_INFO, "       EP BDF : 0x%x\n", e_bdf);
 
           irq_pending = 1;
+          /* Enable DPC */
+          val_pcie_enable_dpc(erp_bdf, msg_type[i]);
+
+          /* Enable DPC Interrupt bit */
           val_pcie_read_cfg(erp_bdf, rp_dpc_cap_base + DPC_CTRL_OFFSET, &reg_value);
-          reg_value &= DPC_DISABLE_MASK;
           reg_value |= DPC_INTR_ENABLE;
-          reg_value = reg_value | (msg_type[i] << DPC_CTRL_TRG_EN_SHIFT);
           val_pcie_write_cfg(erp_bdf, rp_dpc_cap_base + DPC_CTRL_OFFSET, reg_value);
 
           val_pcie_read_cfg(erp_bdf, rp_dpc_cap_base + DPC_CTRL_OFFSET, &reg_value);
@@ -381,13 +383,13 @@ err_check:
           }
 
 disable_dpc:
-          /*Disable the DPC*/
+          /*Disable the DPC status register*/
 
           val_pcie_read_cfg(erp_bdf, rp_dpc_cap_base + DPC_STATUS_OFFSET, &reg_value);
           val_pcie_write_cfg(erp_bdf, rp_dpc_cap_base + DPC_STATUS_OFFSET, reg_value | 0x1);
 
-          val_pcie_read_cfg(erp_bdf, rp_dpc_cap_base + DPC_CTRL_OFFSET, &reg_value);
-          val_pcie_write_cfg(erp_bdf, rp_dpc_cap_base + DPC_CTRL_OFFSET, reg_value & 0xFFFCFFFF);
+          /*Disable the DPC control register*/
+          val_pcie_disable_dpc(erp_bdf);
 
           /* Restore the EP config space after Secondary Bus Reset */
           restore_config_space(erp_bdf);

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -270,6 +270,8 @@ void     val_pcie_enable_msa(uint32_t bdf);
 void     val_pcie_clear_urd(uint32_t bdf);
 void     val_pcie_enable_eru(uint32_t bdf);
 void     val_pcie_disable_eru(uint32_t bdf);
+void     val_pcie_enable_dpc(uint32_t bdf, uint32_t err_type);
+void     val_pcie_disable_dpc(uint32_t bdf);
 void     val_pcie_get_mmio_bar(uint32_t bdf, void *base);
 void     val_pcie_read_acsctrl(uint32_t arr[][1]);
 void     val_pcie_write_acsctrl(uint32_t arr[][1]);


### PR DESCRIPTION
- Introduce `val_pcie_enable_dpc()` and `val_pcie_disable_dpc()` helper functions to manage DPC trigger enable bits in the DPC capability structure.
- Use these APIs to disable DPC for all Root Ports and Downstream Ports during PCIe device table creation to avoid unintended error signaling.
- Update Exerciser test e024 to call the new API for disabling DPC instead of manually clearing control register bits.
- Update relevant headers and extend copyright year to 2026.
- Fixes https://github.com/ARM-software/sysarch-acs/pull/192

Change-Id: I8450efdc15d582bdbbddc90a8c885991613039e5