### PR TITLE
style(pcie): clarify comments about test scope

### DIFF
--- a/test_pool/pcie/p007.c
+++ b/test_pool/pcie/p007.c
@@ -1,5 +1,5 @@
 /** @file
-* Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+* Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 * SPDX-License-Identifier : Apache-2.0
 
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ payload(void)
       /* Check entry is RP or iEP_RP */
       if ((dp_type == RP) || (dp_type == iEP_RP))
       {
-          /* Test runs for atleast an endpoint */
+          /* Test runs for atleast one RP/iEP_RP */
           test_skip = 0;
           val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 

--- a/test_pool/pcie/p010.c
+++ b/test_pool/pcie/p010.c
@@ -1,5 +1,5 @@
 /** @file
-* Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+* Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 * SPDX-License-Identifier : Apache-2.0
 
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,7 +51,7 @@ payload(void)
       /* Check entry is RP or iEP_RP */
       if ((dp_type == RP) || (dp_type == iEP_RP))
       {
-          /* Test runs for atleast an endpoint */
+          /* Test runs for atleast one RP/iEP_RP */
           test_skip = 0;
           val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 

--- a/test_pool/pcie/p018.c
+++ b/test_pool/pcie/p018.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020,2021,2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020,2021,2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,7 +65,7 @@ payload(void)
           if (val_pcie_dev_p2p_support(bdf))
               continue;
 
-          /* Test runs for atleast an endpoint */
+          /* Test runs for atleast one Root Port */
           test_skip = 0;
           val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 

--- a/test_pool/pcie/p019.c
+++ b/test_pool/pcie/p019.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018,2021,2024-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018,2021,2024-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,7 +63,7 @@ payload(void)
       /* Check entry is RP */
       if (dp_type == RP)
       {
-          /* Test runs for atleast an endpoint */
+          /* Test runs for atleast one Root Port */
           test_skip = 0;
           val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
 


### PR DESCRIPTION
- Update misleading or ambiguous comments in tests p007, p010, p018, and p019 to accurately reflect the test applicability.
- Replace phrases like "at least an endpoint" with correct references to RP/iEP_RP devices as per the actual logic.
- No functional changes, improves code readability and intent clarity.
- Fixes #211


Change-Id: I32b7d302288f423b3f5132ccbc493a9162e0ab2d