### PR TITLE
fix(baremetal): make MAX_IRQ_CNT platform-overridable

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2020-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
+#include "platform_override_fvp.h"
 
 typedef uintptr_t addr_t;
 typedef char     char8_t;
@@ -395,7 +396,7 @@ typedef struct {
 **/
 
 #define LEGACY_PCI_IRQ_CNT 4  // Legacy PCI IRQ A, B, C. and D
-#define MAX_IRQ_CNT 0xFFFF    // This value is arbitrary and may have to be adjusted
+#define MAX_IRQ_CNT PLATFORM_BM_OVERRIDE_MAX_IRQ_CNT
 
 typedef struct {
   uint32_t  irq_list[MAX_IRQ_CNT];

--- a/pal/baremetal/target/RDV3/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3/include/platform_override_fvp.h
@@ -291,6 +291,8 @@
 #define PLATFORM_BM_OVERRIDE_PCIE_MAX_BUS      0x9    /* Max bus walked by bare-metal tests      */
 #define PLATFORM_BM_OVERRIDE_PCIE_MAX_DEV      32     /* Max device per bus checked              */
 #define PLATFORM_BM_OVERRIDE_PCIE_MAX_FUNC     8      /* Max function per device checked         */
+
+// This value is arbitrary and may have to be adjusted
 #define PLATFORM_BM_OVERRIDE_MAX_IRQ_CNT       0xFFFF /* Max IRQs any device may raise           */
 
 #define PLATFORM_OVERRIDE_TIMEOUT              0      /* Override default wakeup timeout         */

--- a/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
@@ -240,6 +240,8 @@
 #define PLATFORM_BM_OVERRIDE_PCIE_MAX_BUS      0x9    /* Max bus walked by bare-metal tests      */
 #define PLATFORM_BM_OVERRIDE_PCIE_MAX_DEV      32     /* Max device per bus checked              */
 #define PLATFORM_BM_OVERRIDE_PCIE_MAX_FUNC     8      /* Max function per device checked         */
+
+// This value is arbitrary and may have to be adjusted
 #define PLATFORM_BM_OVERRIDE_MAX_IRQ_CNT       0xFFFF /* Max IRQs any device may raise           */
 
 #define PLATFORM_OVERRIDE_TIMEOUT              0      /* Override default wakeup timeout         */


### PR DESCRIPTION
  - MAX_IRQ_CNT depends on the platform and should be modified by partners according to the platform.  
  - Therefore, added in the platform override file.


Change-Id: I2bf2d4f909b2cad2816bed5943028ad777060bde