### PR TITLE
fix(ras): Iterate all error records and handle unsupported AEST v2

### DIFF
--- a/pal/uefi_acpi/src/pal_ras.c
+++ b/pal/uefi_acpi/src/pal_ras.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -258,6 +258,12 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
   aest = (EFI_ACPI_ARM_ERROR_SOURCE_TABLE *)pal_get_aest_ptr();
   if (aest == NULL) {
       acs_print(ACS_PRINT_DEBUG, L" AEST table not found\n");
+      return;
+  }
+
+  if (aest->Header.Revision == 2) {
+      acs_print(ACS_PRINT_WARN, L" NOT_SUPPORTED: AEST Revision %d detected.\n",
+                                  aest->Header.Revision);
       return;
   }
 

--- a/test_pool/ras/ras001.c
+++ b/test_pool/ras/ras001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,8 @@ payload()
   uint64_t num_node;
   uint64_t value;
   uint32_t node_index;
+  uint32_t err_rec_idx;
+  uint64_t num_err_recs;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   /* Get Number of nodes with RAS Functionality */
@@ -73,21 +75,31 @@ payload()
         continue;
     }
 
-    /* Read FR register of the first error record */
-    value = val_ras_reg_read(node_index, RAS_ERR_FR, 0);
-    if (value == INVALID_RAS_REG_VAL) {
-        val_print(ACS_PRINT_ERR,
-                    "\n       Couldn't read ERR<0>FR register for RAS node index: 0x%lx",
-                    node_index);
-        fail_cnt++;
-        continue;
+    /* Get Error Record number for Current Node */
+    status = val_ras_get_info(RAS_INFO_NUM_ERR_REC, node_index, &num_err_recs);
+    if (status || num_err_recs == 0) {
+         val_print(ACS_PRINT_ERR, "\n       RAS Node %d has no error records implemented ",
+                                   node_index);
+         continue;
     }
 
-    /* Check only if ERR_FR.CE != 0 - Check ERR_FR.CEC[14:12] != 0 for CEC to be implemented */
-    if ((value & ERR_FR_CE_MASK) && !(value & ERR_FR_CEC_MASK)) {
-      val_print(ACS_PRINT_ERR, "\n       CEC not implemented for node_index %d", node_index);
-      fail_cnt++;
-      continue;
+    /* Enumerate all implemented Error Records */
+    for (err_rec_idx = 0; err_rec_idx < num_err_recs; err_rec_idx++) {
+      /* Read FR register of the current error record */
+      value = val_ras_reg_read(node_index, RAS_ERR_FR, err_rec_idx);
+      if (value == INVALID_RAS_REG_VAL) {
+          val_print(ACS_PRINT_ERR, "\n       Couldn't read ERR<%d>FR register", err_rec_idx);
+          val_print(ACS_PRINT_ERR, "\n       RAS node index: %d", node_index);
+          fail_cnt++;
+          continue;
+      }
+
+      /* Check only if ERR_FR.CE != 0 - Check ERR_FR.CEC[14:12] != 0 for CEC to be implemented */
+      if ((value & ERR_FR_CE_MASK) && !(value & ERR_FR_CEC_MASK)) {
+        val_print(ACS_PRINT_ERR, "\n       CEC not implemented for node_index %d", node_index);
+        fail_cnt++;
+        continue;
+      }
     }
   }
 


### PR DESCRIPTION
- Update RAS_01 and RAS_02 to iterate over all error records of each memory controller or cache RAS node instead of checking only ERR<0>.
- Detect AEST revision 2 in pal_ras_create_info_table() and return early with a warning since it is not currently supported.


Change-Id: I202483a7db577326cbfb5f338813079113a65086
Signed-off-by: Shanmuga Priya L <[shanmuga.priyal@arm.com](mailto:shanmuga.priyal@arm.com)>