### PR TITLE
feat: Add vendor test infrastructure framework

### DIFF
--- a/apps/uefi/vendor/README.md
+++ b/apps/uefi/vendor/README.md
@@ -1,0 +1,61 @@
+# Vendor INF Files
+
+Vendor-specific INF files that extend public sysarch-acs with vendor tests.
+
+## Architecture
+
+```
+apps/uefi/
+├── Bsa.inf                      # Public BSA
+├── Sbsa.inf                     # Public SBSA
+├── xbsa_acpi.inf                # Public xBSA ACPI
+└── vendor/
+    ├── verify_vendor_inf.sh     # Sync verification script
+    └── nvidia/
+        ├── BsaNvidia.inf        # BSA + NVIDIA tests
+        ├── SbsaNvidia.inf       # SBSA + NVIDIA tests
+        └── XbsaAcpiNvidia.inf   # xBSA ACPI + NVIDIA tests
+```
+
+## Build Commands
+
+```bash
+# Public builds (no vendor argument)
+source acsbuild.sh bsa
+source acsbuild.sh sbsa
+source acsbuild.sh xbsa_acpi
+
+# Vendor builds (add vendor name as second argument)
+source acsbuild.sh bsa nvidia
+source acsbuild.sh sbsa nvidia
+source acsbuild.sh xbsa_acpi nvidia
+```
+
+## Build-Time Sync Check
+
+Vendor builds automatically verify that vendor INFs include all upstream tests.
+If sync is broken, the build fails and shows missing tests.
+
+Manual verification:
+```bash
+./apps/uefi/vendor/verify_vendor_inf.sh nvidia
+```
+
+## Adding a New Vendor
+
+1. Create directory: `apps/uefi/vendor/<vendor>/`
+
+2. Create vendor INFs (copy from nvidia/ and modify):
+   - Change `BASE_NAME` and `FILE_GUID`
+   - Capitalize vendor name in INF filename (e.g., `BsaQualcomm.inf`)
+   - Update paths and vendor test sources
+
+3. The build script auto-detects vendor INFs by naming convention:
+   - `<AcsType><Vendor>.inf` (e.g., `BsaNvidia.inf`, `XbsaAcpiQualcomm.inf`)
+
+## Syncing with Upstream
+
+When upstream adds/removes tests:
+1. Run `./verify_vendor_inf.sh <vendor>` to find missing tests
+2. Update vendor INFs accordingly
+3. Re-verify before building

--- a/apps/uefi/vendor/verify_vendor_inf.sh
+++ b/apps/uefi/vendor/verify_vendor_inf.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+## @file
+#  Verify vendor INF files include all upstream tests
+#
+#  Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+#  SPDX-License-Identifier : Apache-2.0
+#
+#  Usage: ./verify_vendor_inf.sh [vendor_name]
+#         ./verify_vendor_inf.sh nvidia
+#         ./verify_vendor_inf.sh        # verifies all vendors
+##
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APPS_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Extract test sources from an INF file (excluding vendor tests and app sources)
+extract_test_sources() {
+    local inf_file="$1"
+    grep -E '^\s*(\.\./)*test_pool/' "$inf_file" | \
+        grep -v 'vendor/' | \
+        sed 's|.*test_pool/|test_pool/|' | \
+        sed 's|\.c.*|.c|' | \
+        sort -u
+}
+
+# Compare upstream and vendor INF
+verify_inf_pair() {
+    local upstream_inf="$1"
+    local vendor_inf="$2"
+    local upstream_name=$(basename "$upstream_inf" .inf)
+    local vendor_name=$(basename "$vendor_inf" .inf)
+
+    if [ ! -f "$upstream_inf" ]; then
+        echo "ERROR: Upstream INF not found: $upstream_inf"
+        return 1
+    fi
+
+    if [ ! -f "$vendor_inf" ]; then
+        echo "ERROR: Vendor INF not found: $vendor_inf"
+        return 1
+    fi
+
+    echo "Checking: $upstream_name -> $vendor_name"
+
+    # Extract sources
+    local upstream_sources=$(extract_test_sources "$upstream_inf")
+    local vendor_sources=$(extract_test_sources "$vendor_inf")
+
+    # Find missing sources
+    local missing=""
+    for src in $upstream_sources; do
+        if ! echo "$vendor_sources" | grep -q "^${src}$"; then
+            missing="$missing  - $src\n"
+        fi
+    done
+
+    if [ -n "$missing" ]; then
+        echo "  FAIL: Missing tests in $vendor_name:"
+        echo -e "$missing"
+        return 1
+    else
+        echo "  PASS: All upstream tests present"
+        return 0
+    fi
+}
+
+# Verify a vendor
+verify_vendor() {
+    local vendor="$1"
+    local vendor_dir="$SCRIPT_DIR/$vendor"
+    local errors=0
+    local found_infs=0
+
+    echo "========================================"
+    echo "Verifying vendor: $vendor"
+    echo "========================================"
+
+    # Check if vendor directory exists
+    if [ ! -d "$vendor_dir" ]; then
+        echo "WARNING: Vendor directory not found: $vendor_dir"
+        echo "  No vendor INFs to verify (this is OK if vendor tests not yet added)"
+        return 0
+    fi
+
+    # Check each INF file in vendor directory
+    # Look for pattern: <AcsType><Vendor>.inf (e.g., BsaNvidia.inf, XbsaAcpiNvidia.inf)
+    for vendor_inf in "$vendor_dir"/*.inf; do
+        [ -f "$vendor_inf" ] || continue
+        
+        local inf_basename=$(basename "$vendor_inf" .inf)
+        
+        # Skip if doesn't match vendor naming pattern
+        # Extract the ACS type by removing vendor name suffix (case insensitive)
+        local vendor_upper="${vendor^}"  # Capitalize first letter
+        local acs_type=$(echo "$inf_basename" | sed "s/${vendor_upper}$//i")
+        
+        # Skip if no ACS type extracted (means it's not a vendor INF)
+        [ -z "$acs_type" ] && continue
+        [ "$acs_type" == "$inf_basename" ] && continue
+        
+        ((found_infs++))
+
+        # Determine upstream INF name
+        local upstream_inf="$APPS_DIR/${acs_type}.inf"
+
+        if [ -f "$upstream_inf" ]; then
+            verify_inf_pair "$upstream_inf" "$vendor_inf" || ((errors++))
+        else
+            echo "WARNING: No upstream INF found for $vendor_inf (expected: $upstream_inf)"
+        fi
+    done
+
+    if [ $found_infs -eq 0 ]; then
+        echo "  No vendor INF files found (this is OK if vendor tests not yet added)"
+        return 0
+    fi
+
+    return $errors
+}
+
+# Main
+main() {
+    local total_errors=0
+    local vendors_checked=0
+
+    if [ -n "$1" ]; then
+        # Verify specific vendor
+        verify_vendor "$1"
+        total_errors=$?
+        vendors_checked=1
+    else
+        # Verify all vendors
+        for vendor_dir in "$SCRIPT_DIR"/*/; do
+            [ -d "$vendor_dir" ] || continue
+            vendor=$(basename "$vendor_dir")
+            [ "$vendor" = "." ] && continue
+            [ "$vendor" = "template" ] && continue  # Skip template directory
+            verify_vendor "$vendor"
+            [ $? -ne 0 ] && ((total_errors++))
+            ((vendors_checked++))
+        done
+    fi
+
+    echo ""
+    if [ $vendors_checked -eq 0 ]; then
+        echo "No vendor directories found. Vendor infrastructure ready for use."
+        exit 0
+    elif [ $total_errors -eq 0 ]; then
+        echo "All vendor INF files are in sync with upstream."
+        exit 0
+    else
+        echo "ERROR: $total_errors vendor(s) have sync issues."
+        echo "Please update vendor INF files to match upstream."
+        exit 1
+    fi
+}
+
+main "$@"

--- a/test_pool/vendor/README.md
+++ b/test_pool/vendor/README.md
@@ -1,0 +1,163 @@
+# Vendor Test Pool
+
+This directory contains vendor-specific tests that extend the standard BSA/SBSA test suites.
+
+## Directory Structure
+
+```
+vendor/
+├── README.md           # This file
+├── nvidia/             # NVIDIA-specific tests
+│   ├── README.md       # NVIDIA vendor test documentation
+│   └── timer/          # Timer-related vendor tests
+│       ├── vt001.c     # Vendor timer test 001
+│       └── ...
+├── <vendor>/           # Other vendor directories
+│   └── ...
+└── template/           # Template for new vendor tests
+    └── vtest_template.c
+```
+
+## Adding Vendor Tests
+
+### 1. Create Vendor Directory
+
+Create a new directory under `vendor/` with your vendor name (lowercase):
+
+```bash
+mkdir -p test_pool/vendor/<vendor_name>/timer
+```
+
+### 2. Test Numbering Convention
+
+Vendor tests use a separate numbering space to avoid conflicts with standard tests:
+
+```c
+/* Standard test numbering (reserved 0-9999) */
+#define ACS_TIMER_TEST_NUM_BASE      400
+
+/* Vendor test numbering (10000+) */
+#define ACS_VENDOR_TEST_NUM_BASE     10000
+
+/* Per-vendor offsets (1000 tests per vendor) */
+#define ACS_VENDOR_NVIDIA_BASE       (ACS_VENDOR_TEST_NUM_BASE + 0)
+#define ACS_VENDOR_QUALCOMM_BASE     (ACS_VENDOR_TEST_NUM_BASE + 1000)
+#define ACS_VENDOR_MEDIATEK_BASE     (ACS_VENDOR_TEST_NUM_BASE + 2000)
+/* Add more vendors as needed */
+
+/* Module offsets within vendor space (100 tests per module) */
+#define VENDOR_TIMER_OFFSET          0
+#define VENDOR_PCIE_OFFSET           100
+#define VENDOR_PE_OFFSET             200
+/* ... */
+```
+
+### 3. Test File Naming
+
+Vendor tests should be named with a `v` prefix:
+- `vt001.c` - Vendor timer test 001
+- `vp001.c` - Vendor PCIe test 001
+- `vpe001.c` - Vendor PE test 001
+
+### 4. Test Rule ID Convention
+
+Use vendor-prefixed rule IDs:
+```c
+#define TEST_RULE  "NVIDIA_TIME_01"  /* Vendor-specific rule */
+```
+
+### 5. Creating a Test
+
+Copy the template and modify:
+
+```c
+#include "val/include/acs_val.h"
+#include "val/include/acs_timer.h"
+#include "val/include/acs_pe.h"
+
+/* Test identification */
+#define TEST_NUM   (ACS_VENDOR_NVIDIA_BASE + VENDOR_TIMER_OFFSET + 1)
+#define TEST_DESC  "NVIDIA: Custom timer validation"
+#define TEST_RULE  "NVIDIA_TIME_01"
+
+static void payload(uint32_t num_pe)
+{
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    
+    /* Your test logic here */
+    
+    val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+}
+
+uint32_t
+vt001_entry(uint32_t num_pe)
+{
+    uint32_t status = ACS_STATUS_FAIL;
+
+    status = val_initialize_test(TEST_NUM, TEST_DESC, val_pe_get_num());
+    if (status != ACS_STATUS_SKIP)
+        payload(num_pe);
+
+    status = val_check_for_error(TEST_NUM, 1, TEST_RULE);
+    val_report_status(0, ACS_END(TEST_NUM), TEST_RULE);
+    
+    return status;
+}
+```
+
+### 6. Registering Vendor Tests
+
+Add your test entry point to the appropriate execute file or create a vendor-specific executor.
+
+## Running Vendor Tests
+
+### Run All Vendor Tests
+```bash
+xbsa_acpi.efi -m VENDOR -v 1
+```
+
+### Run Specific Vendor Tests
+```bash
+xbsa_acpi.efi -r NVIDIA_TIME_01 -v 1
+```
+
+### Run Standard + Vendor Tests
+```bash
+xbsa_acpi.efi -m BSA,VENDOR -v 1
+```
+
+## Build Architecture
+
+```
+apps/uefi/
+├── xbsa_acpi.inf                  # Public INF (unchanged from upstream)
+└── vendor/nvidia/
+    └── XbsaAcpiNvidia.inf         # Public tests + NVIDIA vendor tests
+```
+
+Vendor INF files copy the public test list and add vendor tests at the end.
+When upstream is updated, sync the test list in vendor INF files.
+
+### DSC Integration
+
+```ini
+[Components]
+  # Public build
+  ShellPkg/Application/sysarch-acs/apps/uefi/xbsa_acpi.inf
+
+  # OR NVIDIA internal build
+  ShellPkg/Application/sysarch-acs/apps/uefi/vendor/nvidia/XbsaAcpiNvidia.inf
+```
+
+## Guidelines
+
+1. **Isolation**: Vendor tests should not modify or depend on standard test behavior
+2. **Documentation**: Each vendor directory must have a README.md
+3. **Compatibility**: Use only public VAL/PAL APIs
+4. **Naming**: Follow the naming conventions strictly
+5. **Testing**: Ensure vendor tests pass on the target platform before submission
+
+## Contact
+
+For questions about adding vendor tests, contact the sysarch-acs maintainers.
+

--- a/test_pool/vendor/template/vtest_template.c
+++ b/test_pool/vendor/template/vtest_template.c
@@ -1,0 +1,166 @@
+/** @file
+ * Copyright (c) 2025, <Vendor> or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @brief Vendor test template
+ *
+ * INSTRUCTIONS:
+ * 1. Copy this file to your vendor directory (e.g., vendor/nvidia/timer/vt001.c)
+ * 2. Update the copyright header with your vendor name
+ * 3. Update TEST_NUM, TEST_DESC, and TEST_RULE
+ * 4. Implement your test logic in payload()
+ * 5. Rename the entry function (e.g., vt001_entry)
+ * 6. Add README documentation for your test
+ **/
+
+#include "val/include/acs_val.h"
+#include "val/include/acs_pe.h"
+#include "val/include/acs_common.h"
+
+/*
+ * Test Identification
+ *
+ * TEST_NUM:  Unique test number using vendor base offset
+ *            Format: ACS_VENDOR_<VENDOR>_BASE + MODULE_OFFSET + test_number
+ *
+ * TEST_DESC: Brief description (shown in test output)
+ *            Prefix with vendor name for clarity
+ *
+ * TEST_RULE: Rule identifier for traceability
+ *            Format: <VENDOR>_<MODULE>_<number>
+ */
+#define TEST_NUM   (ACS_VENDOR_TEST_NUM_BASE + 1)  /* Update with your vendor base */
+#define TEST_DESC  "VENDOR: Template test description"
+#define TEST_RULE  "VENDOR_TEST_01"
+
+/**
+ * @brief Per-PE test payload (optional)
+ *
+ * If your test needs to run on each PE, implement this function
+ * and call it via val_execute_on_pe() or val_run_test_payload().
+ **/
+static void
+per_pe_payload(void)
+{
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+    /* Per-PE test logic here */
+
+    val_set_status(index, RESULT_PASS(TEST_NUM, 1));
+}
+
+/**
+ * @brief Main test payload
+ * @param num_pe Number of PEs in the system
+ *
+ * This is the main entry point for your test logic.
+ * The function runs on the primary PE.
+ **/
+static void
+payload(uint32_t num_pe)
+{
+    uint32_t my_index = val_pe_get_index_mpid(val_pe_get_mpid());
+    uint32_t status = 0;
+
+    /*
+     * PREREQUISITE CHECKS (optional)
+     *
+     * Skip the test if prerequisites are not met:
+     *
+     * if (some_condition_not_met) {
+     *     val_print(ACS_PRINT_DEBUG, "\n       Skipping: reason\n", 0);
+     *     val_set_status(my_index, RESULT_SKIP(TEST_NUM, 1));
+     *     return;
+     * }
+     */
+
+    val_print(ACS_PRINT_INFO, "\n       Running vendor test with %d PEs", num_pe);
+
+    /*
+     * MAIN TEST LOGIC
+     *
+     * Implement your test here. Use VAL/PAL APIs for:
+     * - Hardware access
+     * - Multi-PE execution
+     * - Timer operations
+     * - Memory operations
+     * - etc.
+     *
+     * Example: Execute something on all PEs
+     *
+     * for (i = 0; i < num_pe; i++) {
+     *     if (i != my_index) {
+     *         val_execute_on_pe(i, per_pe_payload, 0);
+     *     }
+     * }
+     * per_pe_payload();  // Also run on primary
+     */
+
+    /*
+     * RESULT REPORTING
+     *
+     * Use appropriate result macros:
+     * - RESULT_PASS(TEST_NUM, status) - Test passed
+     * - RESULT_FAIL(TEST_NUM, status) - Test failed
+     * - RESULT_SKIP(TEST_NUM, status) - Test skipped
+     * - RESULT_WARN(TEST_NUM, status) - Test passed with warnings
+     *
+     * The 'status' field can be used for sub-test identification (1-255).
+     */
+
+    if (status == 0) {
+        val_print(ACS_PRINT_INFO, "\n       Test PASSED", 0);
+        val_set_status(my_index, RESULT_PASS(TEST_NUM, 1));
+    } else {
+        val_print(ACS_PRINT_ERR, "\n       Test FAILED: status=%d", status);
+        val_set_status(my_index, RESULT_FAIL(TEST_NUM, status));
+    }
+}
+
+/**
+ * @brief Test entry point
+ * @param num_pe Number of PEs to test
+ * @return Test status (ACS_STATUS_PASS, ACS_STATUS_FAIL, ACS_STATUS_SKIP)
+ *
+ * NAMING CONVENTION:
+ * - Timer tests: vt<NNN>_entry (e.g., vt001_entry)
+ * - PCIe tests:  vp<NNN>_entry (e.g., vp001_entry)
+ * - PE tests:    vpe<NNN>_entry (e.g., vpe001_entry)
+ * - GIC tests:   vg<NNN>_entry (e.g., vg001_entry)
+ **/
+uint32_t
+vtest_template_entry(uint32_t num_pe)
+{
+    uint32_t status = ACS_STATUS_FAIL;
+
+    /* Log context for debugging */
+    val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
+
+    /* Initialize test (prints test header) */
+    status = val_initialize_test(TEST_NUM, TEST_DESC, val_pe_get_num());
+
+    /* Run payload if not skipped */
+    if (status != ACS_STATUS_SKIP)
+        payload(num_pe);
+
+    /* Check results and generate final status */
+    status = val_check_for_error(TEST_NUM, 1, TEST_RULE);
+
+    /* Print final result */
+    val_report_status(0, ACS_END(TEST_NUM), TEST_RULE);
+
+    return status;
+}
+

--- a/tools/scripts/acsbuild.sh
+++ b/tools/scripts/acsbuild.sh
@@ -38,11 +38,87 @@ echo "sysarch-acs path is: $(realpath "$acs_path")"
 
 export ACS_PATH=$(realpath "$acs_path")
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh <acs_type>"
-    echo "where acs_type is xbsa_acpi, bsa, bsa_dt, sbsa, nist, mpam, drtm, mem_test, pfdi"
+ACS_TYPE="$1"
+VENDOR="$2"
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "Usage: source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh <acs_type> [vendor]"
+    echo ""
+    echo "Public builds (no vendor):"
+    echo "  acsbuild.sh xbsa_acpi"
+    echo "  acsbuild.sh bsa"
+    echo "  acsbuild.sh sbsa"
+    echo "  acsbuild.sh bsa_dt"
+    echo "  acsbuild.sh nist"
+    echo "  acsbuild.sh mpam"
+    echo "  acsbuild.sh drtm"
+    echo "  acsbuild.sh mem_test"
+    echo "  acsbuild.sh pfdi"
+    echo ""
+    echo "Vendor builds:"
+    echo "  acsbuild.sh xbsa_acpi nvidia"
+    echo "  acsbuild.sh bsa nvidia"
+    echo "  acsbuild.sh sbsa nvidia"
     return 1;
 fi
+
+# Helper function to build with vendor support
+build_with_vendor() {
+    local acs_type="$1"
+    local vendor="$2"
+    local patch_file="$3"
+    local public_inf="$4"
+
+    if [ -n "$vendor" ]; then
+        # Vendor build - verify sync first
+        echo "========================================"
+        echo "Building $acs_type with $vendor vendor tests"
+        echo "========================================"
+
+        local verify_script="ShellPkg/Application/sysarch-acs/apps/uefi/vendor/verify_vendor_inf.sh"
+        if [ ! -f "$verify_script" ]; then
+            echo "ERROR: Vendor verification script not found: $verify_script"
+            return 1
+        fi
+
+        bash "$verify_script" "$vendor"
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Vendor INF sync check failed. Please update vendor INFs."
+            return 1
+        fi
+
+        # Determine vendor INF path
+        local vendor_inf_name
+        case "$acs_type" in
+            xbsa_acpi) vendor_inf_name="XbsaAcpi${vendor^}.inf" ;;
+            bsa)       vendor_inf_name="Bsa${vendor^}.inf" ;;
+            sbsa)      vendor_inf_name="Sbsa${vendor^}.inf" ;;
+            *)
+                echo "ERROR: Vendor builds not supported for $acs_type"
+                return 1
+                ;;
+        esac
+
+        local vendor_inf="ShellPkg/Application/sysarch-acs/apps/uefi/vendor/$vendor/$vendor_inf_name"
+        if [ ! -f "$vendor_inf" ]; then
+            echo "ERROR: Vendor INF not found: $vendor_inf"
+            return 1
+        fi
+
+        git checkout ShellPkg/ShellPkg.dsc
+        git apply "ShellPkg/Application/sysarch-acs/patches/$patch_file"
+        build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m "$vendor_inf"
+    else
+        # Public build
+        echo "========================================"
+        echo "Building $acs_type (public)"
+        echo "========================================"
+
+        git checkout ShellPkg/ShellPkg.dsc
+        git apply "ShellPkg/Application/sysarch-acs/patches/$patch_file"
+        build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m "ShellPkg/Application/sysarch-acs/apps/uefi/$public_inf"
+    fi
+}
 
 NISTStatus=1;
 
@@ -95,20 +171,18 @@ function build_with_NIST()
 }
 
 
-if [ "$1" == "nist" ]; then
+if [ "$ACS_TYPE" == "nist" ]; then
     build_with_NIST
     NISTStatus=$?
     return 0;
 fi
 
-if [ "$1" == "bsa" ]; then
-    git checkout ShellPkg/ShellPkg.dsc
-    git apply ShellPkg/Application/sysarch-acs/patches/edk2_bsa_acpi.patch
-    build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/Bsa.inf
+if [ "$ACS_TYPE" == "bsa" ]; then
+    build_with_vendor "bsa" "$VENDOR" "edk2_bsa_acpi.patch" "Bsa.inf"
     return 0;
 fi
 
-if [ "$1" == "bsa_dt" ]; then
+if [ "$ACS_TYPE" == "bsa_dt" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git checkout MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
     git apply ShellPkg/Application/sysarch-acs/patches/edk2_bsa_dt.patch
@@ -116,36 +190,34 @@ if [ "$1" == "bsa_dt" ]; then
     return 0;
 fi
 
-if [ "$1" == "sbsa" ]; then
-    git checkout ShellPkg/ShellPkg.dsc
-    git apply ShellPkg/Application/sysarch-acs/patches/edk2_sbsa.patch
-    build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/Sbsa.inf
+if [ "$ACS_TYPE" == "sbsa" ]; then
+    build_with_vendor "sbsa" "$VENDOR" "edk2_sbsa.patch" "Sbsa.inf"
     return 0;
 fi
 
 
-if [ "$1" == "pc_bsa" ]; then
+if [ "$ACS_TYPE" == "pc_bsa" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git apply ShellPkg/Application/sysarch-acs/patches/edk2_pcbsa.patch
     build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/pc_bsa.inf
     return 0;
 fi
 
-if [ "$1" == "vbsa" ]; then
+if [ "$ACS_TYPE" == "vbsa" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git apply ShellPkg/Application/sysarch-acs/patches/edk2_vbsa.patch
     build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/vbsa.inf
     return 0;
 fi
 
-if [ "$1" == "drtm" ]; then
+if [ "$ACS_TYPE" == "drtm" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git apply ShellPkg/Application/sysarch-acs/patches/edk2_drtm.patch
     build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/Drtm.inf
     return 0;
 fi
 
-if [ "$1" == "pfdi" ]; then
+if [ "$ACS_TYPE" == "pfdi" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git checkout MdePkg/Library/UefiMemoryAllocationLib/MemoryAllocationLib.c
     git checkout MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.c
@@ -155,23 +227,24 @@ if [ "$1" == "pfdi" ]; then
 fi
 
 
-if [ "$1" == "mem_test" ]; then
+if [ "$ACS_TYPE" == "mem_test" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git apply ShellPkg/Application/sysarch-acs/mem_test/patches/mem_test_edk2.patch
     build -a AARCH64 -t GCCNOLTO -n 1 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/Mem.inf
     return 0;
 fi
 
-if [ "$1" == "mpam" ]; then
+if [ "$ACS_TYPE" == "mpam" ]; then
     git checkout ShellPkg/ShellPkg.dsc
     git apply ShellPkg/Application/sysarch-acs/patches/edk2_mpam.patch
     build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/Mpam.inf
     return 0;
 fi
 
-if [ "$1" == "xbsa_acpi" ]; then
-    git checkout ShellPkg/ShellPkg.dsc
-    git apply ShellPkg/Application/sysarch-acs/patches/edk2_xbsa_acpi.patch
-    build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/sysarch-acs/apps/uefi/xbsa_acpi.inf
+if [ "$ACS_TYPE" == "xbsa_acpi" ]; then
+    build_with_vendor "xbsa_acpi" "$VENDOR" "edk2_xbsa_acpi.patch" "xbsa_acpi.inf"
     return 0;
 fi
+
+echo "ERROR: Unknown acs_type: $ACS_TYPE"
+return 1;

--- a/val/include/acs_common.h
+++ b/val/include/acs_common.h
@@ -46,6 +46,34 @@
 #define ACS_EXERCISER_TEST_NUM_BASE  1500
 #define ACS_TPM2_TEST_NUM_BASE       1600
 
+/*
+ * Vendor Test Numbering
+ *
+ * Vendor-specific tests use a separate numbering space (10000+) to avoid
+ * conflicts with standard BSA/SBSA tests. Each vendor gets a 1000-test range.
+ *
+ * Directory structure: test_pool/vendor/<vendor_name>/<module>/
+ * See test_pool/vendor/README.md for details.
+ */
+#define ACS_VENDOR_TEST_NUM_BASE     10000
+
+/* Per-vendor base offsets (1000 tests per vendor) */
+#define ACS_VENDOR_NVIDIA_BASE       (ACS_VENDOR_TEST_NUM_BASE + 0)
+#define ACS_VENDOR_QUALCOMM_BASE     (ACS_VENDOR_TEST_NUM_BASE + 1000)
+#define ACS_VENDOR_MEDIATEK_BASE     (ACS_VENDOR_TEST_NUM_BASE + 2000)
+#define ACS_VENDOR_AMPERE_BASE       (ACS_VENDOR_TEST_NUM_BASE + 3000)
+#define ACS_VENDOR_MARVELL_BASE      (ACS_VENDOR_TEST_NUM_BASE + 4000)
+/* Add more vendors as needed, incrementing by 1000 */
+
+/* Module offsets within each vendor's range (100 tests per module) */
+#define ACS_VENDOR_TIMER_OFFSET      0
+#define ACS_VENDOR_PCIE_OFFSET       100
+#define ACS_VENDOR_PE_OFFSET         200
+#define ACS_VENDOR_GIC_OFFSET        300
+#define ACS_VENDOR_SMMU_OFFSET       400
+#define ACS_VENDOR_MEMORY_OFFSET     500
+/* Add more modules as needed, incrementing by 100 */
+
 /* Module specific print APIs */
 
 typedef enum {
@@ -65,7 +93,8 @@ typedef enum {
     NIST_MODULE,
     ETE_MODULE,
     EXERCISER_MODULE,
-    TPM2_MODULE
+    TPM2_MODULE,
+    VENDOR_MODULE       /* Vendor-specific tests */
 } MODULE_ID_e;
 
 #define STATE_BIT   28


### PR DESCRIPTION
 - Add vendor test numbering scheme in acs_common.h (10000+ range)
 - Add vendor test template and documentation in test_pool/vendor/
 - Add verify_vendor_inf.sh script to check vendor INFs are in sync
 - Update acsbuild.sh to support vendor builds with two-argument syntax
 - Vendor builds auto-verify upstream sync before building