### PR TITLE
reformat rule based logging

### DIFF
--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,12 +79,12 @@ val_log_context(char8_t *file, char8_t *func, uint32_t line)
       marker++;
   }
 
-  val_print(ACS_PRINT_TEST, "\n    ", 0);
-  val_print(ACS_PRINT_TEST, trimmed_file, 0);
-  val_print(ACS_PRINT_TEST, ":", 0);
-  val_print(ACS_PRINT_TEST, "%d", line);
-  val_print(ACS_PRINT_TEST, " ", 0);
-  val_print(ACS_PRINT_TEST, func, 0);
+  val_print(ACS_PRINT_DEBUG, "\n    ", 0);
+  val_print(ACS_PRINT_DEBUG, trimmed_file, 0);
+  val_print(ACS_PRINT_DEBUG, ":", 0);
+  val_print(ACS_PRINT_DEBUG, "%d", line);
+  val_print(ACS_PRINT_DEBUG, " ", 0);
+  val_print(ACS_PRINT_DEBUG, func, 0);
 }
 
 /**
@@ -774,9 +774,9 @@ val_check_for_error(uint32_t test_num, uint32_t num_pe, char8_t *ruleid)
       }
   }
   if (overall_status == TEST_FAIL) {
-      val_print(ACS_PRINT_ERR, "\n        Failed at checkpoint - %2d", checkpoint);
+      val_print(ACS_PRINT_ERR, "\n       Failed at checkpoint - %2d", checkpoint);
   } else if (overall_status == TEST_SKIP) {
-      val_print(ACS_PRINT_ERR, "\n        Skipped at checkpoint - %2d", checkpoint);
+      val_print(ACS_PRINT_ERR, "\n       Skipped at checkpoint - %2d", checkpoint);
   }
 
   return overall_status;

--- a/val/src/rule_based_execution_helpers.c
+++ b/val/src/rule_based_execution_helpers.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -136,6 +136,30 @@ void quick_sort_rule_list(RULE_ID_e *rule_list, uint32_t list_size)
 void
 print_rule_test_start(uint32_t rule_enum, uint32_t indent)
 {
+    static MODULE_NAME_e prev_module = MODULE_UNKNOWN;
+    MODULE_NAME_e curr_module = MODULE_UNKNOWN;
+
+    /* Check for module change */
+    if (rule_test_map[rule_enum].flag == INVALID_ENTRY) {
+        curr_module = MODULE_UNKNOWN;
+    } else {
+        curr_module = rule_test_map[rule_enum].module_id;
+    }
+
+    /* Print "Running <module> tests" if module change seen.
+       Don't print if MODULE_UNKNOWN was encounterd */
+    if (prev_module != curr_module && curr_module != MODULE_UNKNOWN) {
+        val_print(ACS_PRINT_TEST, "\n\n    ", 0);
+        if (indent)
+            val_print(ACS_PRINT_TEST, "    ", 0);
+        val_print(ACS_PRINT_TEST, "*** Running ", 0);
+        val_print(ACS_PRINT_TEST, module_name_string[curr_module], 0);
+        val_print(ACS_PRINT_TEST, " tests ***", 0);
+
+        /* Update prev_module for next call */
+        prev_module = curr_module;
+    }
+
     val_print(ACS_PRINT_TEST, "\n\n", 0);
     /* Print indent spaces */
     while (indent) {
@@ -143,21 +167,13 @@ print_rule_test_start(uint32_t rule_enum, uint32_t indent)
         indent--;
     }
 
-    val_print(ACS_PRINT_TEST, "START ", 0);
-
-    /* Print module name */
-    if (rule_test_map[rule_enum].flag == INVALID_ENTRY) {
-        val_print(ACS_PRINT_TEST, "-", 0);
-    } else {
-        val_print(ACS_PRINT_TEST, module_name_string[rule_test_map[rule_enum].module_id], 0);
-    }
-    val_print(ACS_PRINT_TEST, " ", 0);
+    /* Print rule id */
     val_print(ACS_PRINT_TEST, rule_id_string[rule_enum], 0);
 
     /* TODO
        Note: Test ID print would be deprecated in future, please use rule id as primary key to
        identify tests and comment on coverage */
-    val_print(ACS_PRINT_TEST, " ", 0);
+    val_print(ACS_PRINT_TEST, " : ", 0);
     if (rule_test_map[rule_enum].test_num == INVALID_ENTRY) {
         val_print(ACS_PRINT_TEST, "-", 0);
     }
@@ -186,6 +202,7 @@ print_rule_test_start(uint32_t rule_enum, uint32_t indent)
 void
 print_rule_test_status(uint32_t rule_enum, uint32_t indent, uint32_t status)
 {
+    (void)rule_enum;
     /* Only count top-level rules (indent == 0) */
     uint32_t top_level_rule = (indent == 0);
 
@@ -196,8 +213,7 @@ print_rule_test_status(uint32_t rule_enum, uint32_t indent, uint32_t status)
         indent--;
     }
 
-    val_print(ACS_PRINT_TEST, "END ", 0);
-    val_print(ACS_PRINT_TEST, rule_id_string[rule_enum], 0);
+    val_print(ACS_PRINT_TEST, "   Result: ", 0);
     val_print(ACS_PRINT_TEST, " ", 0);
 
     /* Update global counters for top-level rules only */

--- a/val/src/rule_based_orchestrator.c
+++ b/val/src/rule_based_orchestrator.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -464,6 +464,11 @@ run_tests(RULE_ID_e *rule_list, uint32_t list_size)
             /* convenience alias to the base rule list for this alias */
             base_rule_list = alias_rule_map[alias_rule_map_index].base_rule_list;
 
+            /* Print start header for alias rule */
+            val_print(ACS_PRINT_TEST, "\n\n  === Start tests for rules referenced by ", 0);
+            val_print(ACS_PRINT_TEST, rule_id_string[rule_list[i]], 0);
+            val_print(ACS_PRINT_TEST, " ===", 0);
+
             /* Run the base rules required by the alias; list is sentinel-terminated */
             for (j = 0; base_rule_list[j] != RULE_ID_SENTINEL; j++) {
                 /* Check if test for the base rule is present in current PAL */
@@ -514,10 +519,11 @@ run_tests(RULE_ID_e *rule_list, uint32_t list_size)
                 rule_test_status = TEST_PART_COV;
             }
 
-            /* Record and print overall alias rule status now and move to next rule */
-            rule_status_map[rule_list[i]] = rule_test_status;
-            print_rule_test_status(rule_list[i], 0, rule_test_status);
-            continue;
+            /* Print end header for alias rule */
+            val_print(ACS_PRINT_TEST, "\n\n  === End tests for rules referenced by ", 0);
+            val_print(ACS_PRINT_TEST, rule_id_string[rule_list[i]], 0);
+            val_print(ACS_PRINT_TEST, " ===\n", 0);
+
         } else if (rule_test_map[rule_list[i]].flag == BASE_RULE) {
             /* Base rule would have single test entry, could be wrapper too */
             rule_test_status =


### PR DESCRIPTION
- Switch log context prints from ACS_PRINT_TEST to ACS_PRINT_DEBUG.
- Change rule header formatting to rule_id : test_num : description.
- Update status line to “Result: <status>” and drop the rule id from status output.
- Add Running <module> tests print.
- Add start and end headers for alias rules.
- removed a redundant execution path.

Related to #221 

Change-Id: I72567f13f48bed779784cf2ed7bd47244c48d19d