### PR TITLE
(upgrade): acs edk2 build version move to edk2-stable202511

### DIFF
--- a/.github/workflows/sysarch_ci.yml
+++ b/.github/workflows/sysarch_ci.yml
@@ -12,7 +12,7 @@ on:
         description: "edk2 ref/branch/tag to checkout"
         required: false
         type: string
-        default: "edk2-stable202508"
+        default: "edk2-stable202511"
       run-uefi:
         description: "Run UEFI builds"
         required: false

--- a/.github/workflows/sysarch_commit.yml
+++ b/.github/workflows/sysarch_commit.yml
@@ -11,7 +11,7 @@ jobs:
   run:
     uses: ./.github/workflows/sysarch_ci.yml
     with:
-      edk2-ref: edk2-stable202508
+      edk2-ref: edk2-stable202511
       toolchain: arm-toolchain,gcc
       run-uefi: true
       run-baremetal: true

--- a/.github/workflows/sysarch_daily.yml
+++ b/.github/workflows/sysarch_daily.yml
@@ -9,7 +9,7 @@ jobs:
   run:
     uses: ./.github/workflows/sysarch_ci.yml
     with:
-      edk2-ref: edk2-stable202508
+      edk2-ref: edk2-stable202511
       toolchain: arm-toolchain
       run-uefi: true
       run-baremetal: true

--- a/docs/common/uefi_build.md
+++ b/docs/common/uefi_build.md
@@ -11,7 +11,7 @@ This guide captures the shared steps required to build any of the ACS UEFI appli
 ## Workspace setup
 ```bash
 mkdir -p workspace && cd workspace
-git clone -b edk2-stable202508 https://github.com/tianocore/edk2.git
+git clone -b edk2-stable202511 https://github.com/tianocore/edk2.git
 cd edk2
 git submodule update --init --recursive
 git clone https://github.com/tianocore/edk2-libc.git

--- a/docs/pfdi/README.md
+++ b/docs/pfdi/README.md
@@ -61,7 +61,7 @@ ACS build requires that the following requirements are met, Please skip this if 
 #### Setup the workspace and clone required repositories
 ```
 mkdir workspace && cd workspace
-git clone -b edk2-stable202508 https://github.com/tianocore/edk2
+git clone -b edk2-stable202511 https://github.com/tianocore/edk2
 cd edk2
 git submodule update --init --recursive
 git clone https://github.com/tianocore/edk2-libc
@@ -178,4 +178,4 @@ PFDI ACS is distributed under Apache v2.0 License.
 
 --------------
 
-*Copyright (c) 2024-2025, Arm Limited and Contributors. All rights reserved.*
+*Copyright (c) 2024-2026, Arm Limited and Contributors. All rights reserved.*

--- a/docs/sbsa/arm_sbsa_nist_user_guide.md
+++ b/docs/sbsa/arm_sbsa_nist_user_guide.md
@@ -28,7 +28,7 @@ Current release require the below tool:
     Before you start the ACS build, ensure that the following requirements are met.
 
 - Any mainstream Linux-based OS distribution running on a x86 or AArch64 machine.
-- git clone the [EDK2 tree](https://github.com/tianocore/edk2). Recommended edk2 commit is edk2-stable202505
+- git clone the [EDK2 tree](https://github.com/tianocore/edk2). Recommended edk2 commit is edk2-stable202511
 - git clone the [EDK2 port of libc](https://github.com/tianocore/edk2-libc) to local <edk2_path>.
 - Install GCC-ARM 14.3 [toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
 - Install the build prerequisite packages to build EDK2.<br />
@@ -138,4 +138,4 @@ For more details on NIST STS, see: <https://doi.org/10.6028/NIST.SP.800-22r1a>
 
 --------------
 
-*Copyright (c) 2020, 2023-2025, Arm Limited and Contributors. All rights reserved.*
+*Copyright (c) 2020, 2023-2026, Arm Limited and Contributors. All rights reserved.*

--- a/tools/scripts/build_drtm_uefi.sh
+++ b/tools/scripts/build_drtm_uefi.sh
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+#  Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ fi
 echo "Building DRTM ACS for UEFI"
 if [ ! -d edk2 ]
 then
-    git clone --recursive --branch edk2-stable202402 https://github.com/tianocore/edk2.git
+    git clone --recursive --branch edk2-stable202511 https://github.com/tianocore/edk2.git
     git clone https://github.com/tianocore/edk2-libc edk2/edk2-libc
 fi
 cd ${WORK_DIR}/edk2

--- a/tools/scripts/build_pfdi_uefi.sh
+++ b/tools/scripts/build_pfdi_uefi.sh
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+#  Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 #  SPDX-License-Identifier : Apache-2.0
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ fi
 echo "Building Pfdi ACS for UEFI"
 if [ ! -d edk2 ]
 then
-    git clone --depth 1 --single-branch --branch edk2-stable202411 https://github.com/tianocore/edk2.git
+    git clone --depth 1 --single-branch --branch edk2-stable202511 https://github.com/tianocore/edk2.git
     pushd edk2
     git checkout 836942fbadb629050b866a8052e6af755bcdf623
     git submodule update --init --recursive


### PR DESCRIPTION
 * readme build steps updated to use 202511 version
 * ci workflow build version updated
 * no changes to patch required

Change-Id: I9f0244f953b4756e4dbe5d211e05149d197b018d