### PR TITLE
Apply el1physkip flag only when acs running at EL1

### DIFF
--- a/apps/uefi/acs_helpers.c
+++ b/apps/uefi/acs_helpers.c
@@ -949,7 +949,10 @@ command_init (void)
     }
 
     if (ShellCommandLineGetFlag (ParamPackage, L"-el1physkip")) {
-        g_el1physkip = TRUE;
+        /* Flag is applicable when ACS is running at EL1 */
+        if (val_pe_reg_read(CurrentEL) == AARCH64_EL1) {
+            g_el1physkip = TRUE;
+        }
     }
 
     return 0;


### PR DESCRIPTION
 * el1physkip flag is applicable only at EL1 level

Change-Id: Ic6ac9408dfc366a4afa6371253587f0540ed712c