### PR TITLE
ras: generate peripheral info table when running RAS tests

### DIFF
--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -183,6 +183,7 @@ freeSbsaAvsMem()
       val_iovirt_free_info_table();
 
   if (acs_is_module_enabled(PE)     ||
+      acs_is_module_enabled(RAS)    ||
       acs_is_module_enabled(PCIE)   ||
       acs_is_module_enabled(MEM_MAP) ||
       acs_is_module_enabled(MPAM))
@@ -299,8 +300,9 @@ ShellAppMainsbsa()
         createIoVirtInfoTable();
 
     if (acs_is_module_enabled(PE)          ||
+        acs_is_module_enabled(RAS)         ||
         acs_is_module_enabled(PCIE)        ||
-        acs_is_module_enabled(MEM_MAP)      ||
+        acs_is_module_enabled(MEM_MAP)     ||
         acs_is_module_enabled(MPAM))
         createPeripheralInfoTable();
 


### PR DESCRIPTION
Peripheral info table is required for RAS test 008 and is now created as part of the RAS test flow.
Added during the module selection