### PR TITLE
(github CI) Include Shell.efi in CI artifacts

### DIFF
--- a/.github/workflows/sysarch_ci.yml
+++ b/.github/workflows/sysarch_ci.yml
@@ -206,11 +206,13 @@ jobs:
           source edksetup.sh
           make -C BaseTools/Source/C
           source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh ${{ matrix.target.arg }}
+          build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/Shell/Shell.inf
 
       - name: Move output to toolchain folder
         run: |
           mkdir -p "artifacts/${{ matrix.toolchain }}"
           cp "edk2/Build/Shell/DEBUG_GCC/AARCH64/${{ matrix.target.outfile }}" "artifacts/${{ matrix.toolchain }}/${{ matrix.target.artifact }}"
+          cp "edk2/Build/Shell/DEBUG_GCC/AARCH64/ShellPkg/Application/Shell/Shell/OUTPUT/Shell.efi" "artifacts/${{ matrix.toolchain }}/"
 
       - name: Upload ${{ matrix.target.artifact }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- If a user wants to make a bootable disk with ACS uefi binary, Shell.efi is needed to be placed in image boot partition 
- Added steps in build jobs to compile and package Shell.efi for each acs