### PR TITLE
docs(checklist): Update PCIe information across BSA/SBSA/vBSA test case checklist

### DIFF
--- a/docs/bsa/arm_bsa_testcase_checklist.md
+++ b/docs/bsa/arm_bsa_testcase_checklist.md
@@ -1371,7 +1371,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td rowspan="2">PCI_MSI_2</td>
@@ -1380,7 +1380,7 @@ The checklist provides information about:
       <td>No</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>1533</td>
@@ -1567,7 +1567,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td rowspan="3">PCI_PP_04</td>
@@ -1576,7 +1576,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>1501</td>
@@ -1601,7 +1601,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PAS_1</td>
@@ -1610,7 +1610,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PASID support required</td>
     </tr>
     <tr>
       <td>PCI_PTM_1</td>
@@ -1930,7 +1930,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>RI_ORD_1</td>
@@ -1966,7 +1966,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>Exerciser VIP required</td>
+      <td>Exerciser VIP required; ATC cache required</td>
     </tr>
     <tr>
       <td>RI_SMU_2</td>
@@ -2407,7 +2407,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_MSI_2</td>
@@ -2416,7 +2416,7 @@ The checklist provides information about:
       <td>No</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_LI_01</td>
@@ -2587,7 +2587,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_04</td>
@@ -2596,7 +2596,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_05</td>
@@ -2605,7 +2605,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_06</td>
@@ -2623,7 +2623,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PASID support required</td>
     </tr>
     <tr>
       <td>PCI_PTM_1</td>
@@ -2713,7 +2713,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>RE_ACS_2</td>
@@ -2722,7 +2722,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>RE_ACS_3</td>
@@ -2823,7 +2823,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>RI_ORD_1</td>
@@ -2859,7 +2859,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>Exerciser VIP required</td>
+      <td>Exerciser VIP required; ATC cache required</td>
     </tr>
     <tr>
       <td>RI_SMU_2</td>
@@ -3300,7 +3300,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_MSI_2</td>
@@ -3309,7 +3309,7 @@ The checklist provides information about:
       <td>No</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_LI_01</td>
@@ -3480,7 +3480,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_04</td>
@@ -3489,7 +3489,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_05</td>
@@ -3498,7 +3498,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_06</td>
@@ -3516,7 +3516,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PASID support required</td>
     </tr>
     <tr>
       <td>PCI_PTM_1</td>
@@ -3606,7 +3606,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>IE_ACS_2</td>
@@ -3615,7 +3615,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>IE_REG_1</td>
@@ -3707,7 +3707,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>FR</td>

--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -668,7 +668,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP, iEP</td>
+      <td>RCiEP, iEP; MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>RI_ORD_1</td>
@@ -704,7 +704,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>Exerciser VIP required</td>
+      <td>Exerciser VIP required; ATC cache required</td>
     </tr>
     <tr>
       <td>RI_SMU_2</td>
@@ -1145,7 +1145,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_MSI_2</td>
@@ -1154,7 +1154,7 @@ The checklist provides information about:
       <td>No</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_LI_01</td>
@@ -1325,7 +1325,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_04</td>
@@ -1334,7 +1334,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_05</td>
@@ -1343,7 +1343,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_06</td>
@@ -1361,7 +1361,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PASID support required</td>
     </tr>
     <tr>
       <td>PCI_PTM_1</td>
@@ -1379,7 +1379,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP</td>
+      <td>RCiEP; PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>RE_PCI_2</td>
@@ -1451,7 +1451,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP</td>
+      <td>RCiEP; PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>RE_ACS_2</td>
@@ -1460,7 +1460,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP</td>
+      <td>RCiEP; PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>RE_ACS_3</td>
@@ -1561,7 +1561,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP, iEP</td>
+      <td>RCiEP, iEP; MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>RI_ORD_1</td>
@@ -1597,7 +1597,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>Exerciser VIP required</td>
+      <td>Exerciser VIP required; ATC cache required</td>
     </tr>
     <tr>
       <td>RI_SMU_2</td>
@@ -2038,7 +2038,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_MSI_2</td>
@@ -2047,7 +2047,7 @@ The checklist provides information about:
       <td>No</td>
       <td>Yes</td>
       <td>Yes</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_LI_01</td>
@@ -2218,7 +2218,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PAS_1</td>
@@ -2227,7 +2227,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_05</td>
@@ -2236,7 +2236,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_06</td>
@@ -2254,7 +2254,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PASID support required</td>
     </tr>
     <tr>
       <td>PCI_PTM_1</td>
@@ -2344,7 +2344,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>iEP_EP</td>
+      <td>iEP_EP; PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>IE_ACS_2</td>
@@ -2353,7 +2353,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>iEP RP</td>
+      <td>iEP RP; PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>IE_REG_1</td>
@@ -3407,7 +3407,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td rowspan="2">GPU_04</td>
@@ -3613,4 +3613,3 @@ The checklist provides information about:
 - Updated Checklist as per SBSA 8.0 Specification.
 - Added version 8.0 rules.
 - Added details for rules which are not covered.
-

--- a/docs/vbsa/arm_vbsa_testcase_checklist.md
+++ b/docs/vbsa/arm_vbsa_testcase_checklist.md
@@ -903,7 +903,7 @@ The checklist provides information about:
       <td>Check MSI support for PCIe dev</td>
       <td>✅</td>
       <td>❌</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td>PCI_MSI_2</td>
@@ -911,7 +911,7 @@ The checklist provides information about:
       <td>Check MSI=X vectors uniqueness</td>
       <td>❌</td>
       <td>✅</td>
-      <td></td>
+      <td>MSI/MSI-X support required</td>
     </tr>
     <tr>
       <td></td>
@@ -1079,7 +1079,7 @@ The checklist provides information about:
       <td>RP must suprt ACS if P2P Txn are allow</td>
       <td>✅</td>
       <td>❌</td>
-      <td></td>
+      <td>PCIe Hierarchy P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_04</td>
@@ -1087,7 +1087,7 @@ The checklist provides information about:
       <td>Check RP Adv Error Report</td>
       <td>✅</td>
       <td>❌</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td></td>
@@ -1111,7 +1111,7 @@ The checklist provides information about:
       <td>Check Direct Transl P2P Support</td>
       <td>✅</td>
       <td>❌</td>
-      <td></td>
+      <td>PCIe Hierarchy and Device P2P support required</td>
     </tr>
     <tr>
       <td>PCI_PP_06</td>
@@ -1127,7 +1127,7 @@ The checklist provides information about:
       <td>PASID support atleast 16 bits</td>
       <td>✅</td>
       <td>❌</td>
-      <td></td>
+      <td>PASID support required</td>
     </tr>
     <tr>
       <td>PCI_PTM_1</td>


### PR DESCRIPTION
- Add P2P support required notes for PCIe tests
- Add MSI/MSI-X, ATC cache and PASID support required notes

Fixes #212 
Change-Id: I7557d7b3d1f84c312403948e75a31adf0e4f6cdf