### PR TITLE
Fix: Corrected the return types of certain system register helper functions

### DIFF
--- a/val/driver/gic/acs_exception.c
+++ b/val/driver/gic/acs_exception.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021, 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,8 +93,8 @@ uint32_t common_exception_handler(uint32_t exception_type)
    */
   g_esr_handler[exception_type](exception_type, NULL);
 
-  val_print(ACS_PRINT_INFO, "\n       GIC_INIT: Common Handler, FAR = %x", bsa_gic_get_far());
-  val_print(ACS_PRINT_INFO, "\n       GIC_INIT: Common Handler, ESR = %x", bsa_gic_get_esr());
+  val_print(ACS_PRINT_INFO, "\n       GIC_INIT: Common Handler, FAR = %llx", bsa_gic_get_far());
+  val_print(ACS_PRINT_INFO, "\n       GIC_INIT: Common Handler, ESR = %llx", bsa_gic_get_esr());
 
   /* If ELR is updated inside the handler then skip the elr update in assembly handler
    * Return 1 else return 0

--- a/val/driver/gic/acs_exception.h
+++ b/val/driver/gic/acs_exception.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021,2024-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021,2024-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +23,11 @@
 #define ICC_EOIR1_EL1   S3_0_C12_C12_1
 
 void bsa_gic_set_el2_vector_table(void);
-uint32_t bsa_gic_update_elr(uint64_t elr_value);
-uint32_t bsa_gic_get_elr(void);
-uint32_t bsa_gic_get_far(void);
-uint32_t bsa_gic_get_esr(void);
-uint32_t bsa_gic_ack_intr(void);
+void bsa_gic_update_elr(uint64_t elr_value);
+uint64_t bsa_gic_get_elr(void);
+uint64_t bsa_gic_get_far(void);
+uint64_t bsa_gic_get_esr(void);
+uint64_t bsa_gic_ack_intr(void);
 void bsa_gic_end_intr(uint32_t interrupt_id);
 void bsa_gic_vector_table_init(void);
 uint32_t common_exception_handler(uint32_t exception_type);

--- a/val/driver/gic/gic.c
+++ b/val/driver/gic/gic.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2021,2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2021,2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,7 +84,7 @@ val_gic_acknowledgeInterrupt(void)
 
   gic_version = val_gic_get_info(GIC_INFO_VERSION);
   if ((gic_version == 3) || (gic_version == 4))
-      return v3_AcknowledgeInterrupt();
+      return (uint32_t) v3_AcknowledgeInterrupt();
   else
       return v2_AcknowledgeInterrupt();
 }

--- a/val/driver/gic/v3/gic_v3.c
+++ b/val/driver/gic/v3/gic_v3.c
@@ -171,7 +171,7 @@ uint64_t v3_get_pe_gicr_base(void)
   @param  none
   @return interrupt id
 **/
-uint32_t
+uint64_t
 v3_AcknowledgeInterrupt(void)
 {
   return bsa_gic_ack_intr();

--- a/val/driver/gic/v3/gic_v3.h
+++ b/val/driver/gic/v3/gic_v3.h
@@ -41,7 +41,7 @@
 void v3_Init(void);
 void v3_EnableInterruptSource(uint32_t);
 void v3_DisableInterruptSource(uint32_t);
-uint32_t v3_AcknowledgeInterrupt(void);
+uint64_t v3_AcknowledgeInterrupt(void);
 void v3_EndofInterrupt(uint32_t int_id);
 uint32_t v3_read_gicdTyper(void);
 uint64_t v3_get_pe_gicr_base(void);


### PR DESCRIPTION

   modified following function prototypes
   uint64_t bsa_gic_get_far(void)
   uint64_t bsa_gic_get_esr(void)
   void bsa_gic_update_elr(uint64_t elr_value)
   uint64_t bsa_gic_get_elr(void)
   uint64_t bsa_gic_ack_intr(void)

Fixes #240 

Change-Id: Ic8b0fcc869fb878f495633c31a06b0f94ddfb45d