### PR TITLE
log: fix print level check for display table output

### DIFF
--- a/pal/baremetal/base/src/pal_hmat.c
+++ b/pal/baremetal/base/src/pal_hmat.c
@@ -96,6 +96,6 @@ void pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
       }
   }
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_hmat_dump_info_table(HmatTable);
 }

--- a/pal/baremetal/base/src/pal_iovirt.c
+++ b/pal/baremetal/base/src/pal_iovirt.c
@@ -290,7 +290,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   block = &(IoVirtTable->blocks[0]);
   print(ACS_PRINT_DEBUG, " Number of IOVIRT blocks = %d\n", IoVirtTable->num_blocks);
 
-  if (g_print_level <= ACS_PRINT_DEBUG) {
+  if (g_print_level <= ACS_PRINT_INFO) {
       for (i = 0; i < IoVirtTable->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
       {
         dump_block(block);

--- a/pal/baremetal/base/src/pal_mpam.c
+++ b/pal/baremetal/base/src/pal_mpam.c
@@ -154,7 +154,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
       curr_entry = MPAM_NEXT_MSC(curr_entry);
   }
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_mpam_dump_table(MpamTable);
 }
 
@@ -209,6 +209,6 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr++;
   }
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_srat_dump_table(SratTable);
 }

--- a/pal/baremetal/base/src/pal_pcc.c
+++ b/pal/baremetal/base/src/pal_pcc.c
@@ -130,7 +130,7 @@ pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
     curr_entry++;
   }
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_pcc_dump_info_table(PccInfoTable);
 
   return;

--- a/pal/baremetal/base/src/pal_pmu.c
+++ b/pal/baremetal/base/src/pal_pmu.c
@@ -93,7 +93,7 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
       }
 
       /* Dump PMU info table */
-      if (g_print_level <= ACS_PRINT_DEBUG)
+      if (g_print_level <= ACS_PRINT_INFO)
           pal_pmu_dump_info_table(PmuTable);
   }
 }

--- a/pal/baremetal/base/src/pal_pptt.c
+++ b/pal/baremetal/base/src/pal_pptt.c
@@ -136,6 +136,6 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
 
   pal_cache_store_pe_res(CacheTable, PeTable);
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_cache_dump_info_table(CacheTable, PeTable);
 }

--- a/pal/baremetal/base/src/pal_ras.c
+++ b/pal/baremetal/base/src/pal_ras.c
@@ -236,7 +236,7 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
       curr_node++;
   }
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_ras_dump_info_table(RasInfoTable);
 }
 
@@ -333,6 +333,6 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
       RasFeatInfoTable->num_all_block++;
   }
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
       pal_ras2_dump_info_table(RasFeatInfoTable);
 }

--- a/val/driver/smmu_v3/smmu_v3.c
+++ b/val/driver/smmu_v3/smmu_v3.c
@@ -1024,7 +1024,7 @@ static int smmu_cdtab_write_ctx_desc(smmu_master_t *master,
 
     cdptr[0] = val;
 
-    if (g_print_level <= ACS_PRINT_DEBUG)
+    if (g_print_level <= ACS_PRINT_INFO)
         dump_cdtab(cdptr);
 
     return 1;
@@ -1212,7 +1212,7 @@ uint64_t val_smmu_map(smmu_master_attributes_t master_attr, pgt_descriptor_t pgt
     ste = smmu_strtab_get_ste_for_sid(smmu, master->sid);
     smmu_strtab_write_ste(master, ste);
 
-    if (g_print_level <= ACS_PRINT_DEBUG)
+    if (g_print_level <= ACS_PRINT_INFO)
         dump_strtab(ste);
 
     smmu_tlbi_cfgi(smmu);
@@ -1240,7 +1240,7 @@ uint32_t val_smmu_config_ste_dcp(smmu_master_attributes_t master_attr, uint32_t 
     else
         ste[1] = ste[1] & BITFIELD_SET(STRTAB_STE_1_DCP, value);
 
-    if (g_print_level <= ACS_PRINT_DEBUG)
+    if (g_print_level <= ACS_PRINT_INFO)
     {
         val_print(ACS_PRINT_INFO, "\n       Dump STE values", 0);
         dump_strtab(ste);

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -300,7 +300,7 @@ val_peripheral_create_info_table(uint64_t *peripheral_info_table)
   val_print(ACS_PRINT_TEST, " Peripheral: Num of UART controllers  :    %d\n",
     val_peripheral_get_info(NUM_UART, 0));
 
-  if (g_print_level <= ACS_PRINT_DEBUG)
+  if (g_print_level <= ACS_PRINT_INFO)
     val_peripheral_dump_info();
 
 }


### PR DESCRIPTION
  - The display table output functions logs at ACS_PRINT_INFO level, but was gated by an ACS_PRINT_DEBUG condition.

  - Change the check to ACS_PRINT_INFO for consistency and improved efficiency.

Change-Id: Id1f1f4bca7665b7a7fa447261f7f20db3cef6dea