### PR TITLE
fix(memory_map): m001: add DSB after unpopulated store

### DIFF
--- a/test_pool/memory_map/m001.c
+++ b/test_pool/memory_map/m001.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2020, 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2020, 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,6 +87,9 @@ payload()
           branch_to_test = &&exception_taken;
 
           *((volatile uint64_t*)addr) = 0x100;
+
+          /* Issue a DSB instruction */
+          val_mem_issue_dsb();
 exception_taken:
           /* if the access did not go to our exception handler, fail and exit */
           if (IS_TEST_FAIL(val_get_status(index))) {


### PR DESCRIPTION
  Add a DSB SY after the write to an unpopulated address so any abort/SError is
  observed before the test checks status, avoiding intermittent false failures.


Change-Id: I1b335338e936d89913a8e72658e79c7d20f64e78