### PR TITLE
fix(smmu): Correct Secure EL2 skip log message

### DIFF
--- a/test_pool/smmu/i005.c
+++ b/test_pool/smmu/i005.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2021-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2021-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +110,7 @@ payload_check_sel2_and_smmu_stg2_support()
 
     /* Skip the test if Secure EL2 is implemented */
     if (pe_s_el2 == 0x1) {
-        val_print(ACS_PRINT_DEBUG, "\n       Secure EL2 not supported, skipping the test.", 0);
+        val_print(ACS_PRINT_DEBUG, "\n       Secure EL2 is supported, skipping the test.", 0);
         val_set_status(index, RESULT_SKIP(TEST_NUM1, 1));
         return;
     }


### PR DESCRIPTION
- Update debug log to reflect that Secure EL2 is supported when skipping the test

Fixes https://github.com/ARM-software/arm-systemready/issues/669
Signed-off-by: Shanmuga Priya L <[shanmuga.priyal@arm.com](mailto:shanmuga.priyal@arm.com)>
Change-Id: Ie347a7209974b10a3ec85da2edf909fffed412ca