### PR TITLE
fix(pre-si): fix invalid skip of BSS segment clearing

### DIFF
--- a/val/src/AArch64/BootEntry.S
+++ b/val/src/AArch64/BootEntry.S
@@ -165,13 +165,14 @@ primary_cpu_entry:
   add  x1,x1,:lo12:__BSS_END__
   sub x1, x1, x0
   //bl  val_inv_dcache_range
-#endif
+
 1:
    stp xzr, xzr, [x0]
    add x0, x0, #16
    sub x1, x1, #16
    cmp xzr, x1
    b.ne 1b
+#endif
 
    b  0f
 


### PR DESCRIPTION
    -Fix invalid skip of BSS segment clearing
     with TARGET_SIMULATION=ON


Change-Id: Ic2b08e90299454135d94e8090dc6e706f4075f1a