### PR TITLE
fix(baremetal): fix spelling mistake in PCIe struct

### DIFF
--- a/pal/baremetal/base/src/pal_pcie_enumeration.c
+++ b/pal/baremetal/base/src/pal_pcie_enumeration.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -584,7 +584,7 @@ void pal_pcie_enumerate(void)
     print(ACS_PRINT_INFO, "\nStarting Enumeration\n", 0);
     while (pcie_index < g_pcie_info_table->num_entries)
     {
-       hb_count = platform_root_pcie_cfg.block[pcie_index].hb_enteries;
+       hb_count = platform_root_pcie_cfg.block[pcie_index].hb_entries;
        count = 0;
        while (count < hb_count)
        {

--- a/pal/baremetal/target/RDN2/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_struct.h
@@ -148,7 +148,7 @@ typedef struct {
 } PLATFORM_OVERRIDE_IOVIRT_INFO_TABLE;
 
 typedef struct {
-  uint32_t   hb_enteries;                              ///< No. of HB's in the ECAM
+  uint32_t   hb_entries;                              ///< No. of HB's in the ECAM
   uint32_t   segment_num[PLATFORM_MAX_HB_COUNT];       ///< Segment number of the ECAM
   uint32_t   start_bus_num[PLATFORM_MAX_HB_COUNT];     ///< Start Bus number for this ecam space
   uint32_t   end_bus_num[PLATFORM_MAX_HB_COUNT];       ///< Last Bus number

--- a/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
@@ -307,7 +307,7 @@ PCIE_INFO_TABLE platform_pcie_cfg = {
 };
 
 PCIE_ROOT_INFO_TABLE platform_root_pcie_cfg = {
-    .block[0].hb_enteries         = PLATFORM_OVERRIDE_PCIE_ECAM0_HB_COUNT,
+    .block[0].hb_entries         = PLATFORM_OVERRIDE_PCIE_ECAM0_HB_COUNT,
     .block[0].segment_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM0_SEG_NUM,
     .block[0].start_bus_num[0]    = PLATFORM_OVERRIDE_PCIE_ECAM0_START_BUS_NUM,
     .block[0].end_bus_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM0_END_BUS_NUM,

--- a/pal/baremetal/target/RDV3/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDV3/include/platform_override_struct.h
@@ -148,7 +148,7 @@ typedef struct {
 } PLATFORM_OVERRIDE_IOVIRT_INFO_TABLE;
 
 typedef struct {
-  uint32_t   hb_enteries;                              ///< No. of HB's in the ECAM
+  uint32_t   hb_entries;                              ///< No. of HB's in the ECAM
   uint32_t   segment_num[PLATFORM_MAX_HB_COUNT];       ///< Segment number of the ECAM
   uint32_t   start_bus_num[PLATFORM_MAX_HB_COUNT];     ///< Start Bus number for this ecam space
   uint32_t   end_bus_num[PLATFORM_MAX_HB_COUNT];       ///< Last Bus number

--- a/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
@@ -304,7 +304,7 @@ PCIE_INFO_TABLE platform_pcie_cfg = {
 };
 
 PCIE_ROOT_INFO_TABLE platform_root_pcie_cfg = {
-    .block[0].hb_enteries         = PLATFORM_OVERRIDE_PCIE_ECAM0_HB_COUNT,
+    .block[0].hb_entries         = PLATFORM_OVERRIDE_PCIE_ECAM0_HB_COUNT,
     .block[0].segment_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM0_SEG_NUM,
     .block[0].start_bus_num[0]    = PLATFORM_OVERRIDE_PCIE_ECAM0_START_BUS_NUM,
     .block[0].end_bus_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM0_END_BUS_NUM,
@@ -315,7 +315,7 @@ PCIE_ROOT_INFO_TABLE platform_root_pcie_cfg = {
     .block[0].rp_bar32_value[0]   = PLATFORM_OVERRIDE_PCIE_ECAM0_RP_BAR32,
 
     /* Example: Populate multi RC info
-    .block[1].hb_enteries         = PLATFORM_OVERRIDE_PCIE_ECAM1_HB_COUNT,
+    .block[1].hb_entries         = PLATFORM_OVERRIDE_PCIE_ECAM1_HB_COUNT,
     .block[1].segment_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM1_SEG_NUM,
     .block[1].start_bus_num[0]    = PLATFORM_OVERRIDE_PCIE_ECAM1_START_BUS_NUM,
     .block[1].end_bus_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM1_END_BUS_NUM,

--- a/pal/baremetal/target/RDV3CFG1/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDV3CFG1/include/platform_override_struct.h
@@ -148,7 +148,7 @@ typedef struct {
 } PLATFORM_OVERRIDE_IOVIRT_INFO_TABLE;
 
 typedef struct {
-  uint32_t   hb_enteries;                              ///< No. of HB's in the ECAM
+  uint32_t   hb_entries;                              ///< No. of HB's in the ECAM
   uint32_t   segment_num[PLATFORM_MAX_HB_COUNT];       ///< Segment number of the ECAM
   uint32_t   start_bus_num[PLATFORM_MAX_HB_COUNT];     ///< Start Bus number for this ecam space
   uint32_t   end_bus_num[PLATFORM_MAX_HB_COUNT];       ///< Last Bus number

--- a/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
@@ -241,7 +241,7 @@ PCIE_INFO_TABLE platform_pcie_cfg = {
 };
 
 PCIE_ROOT_INFO_TABLE platform_root_pcie_cfg = {
-    .block[0].hb_enteries         = PLATFORM_OVERRIDE_PCIE_ECAM0_HB_COUNT,
+    .block[0].hb_entries         = PLATFORM_OVERRIDE_PCIE_ECAM0_HB_COUNT,
     .block[0].segment_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM0_SEG_NUM,
     .block[0].start_bus_num[0]    = PLATFORM_OVERRIDE_PCIE_ECAM0_START_BUS_NUM,
     .block[0].end_bus_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM0_END_BUS_NUM,
@@ -252,7 +252,7 @@ PCIE_ROOT_INFO_TABLE platform_root_pcie_cfg = {
     .block[0].rp_bar32_value[0]   = PLATFORM_OVERRIDE_PCIE_ECAM0_RP_BAR32,
 
     /* Placeholder: Multiple ECAM entries
-    .block[1].hb_enteries         = PLATFORM_OVERRIDE_PCIE_ECAM1_HB_COUNT,
+    .block[1].hb_entries         = PLATFORM_OVERRIDE_PCIE_ECAM1_HB_COUNT,
     .block[1].segment_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM1_SEG_NUM,
     .block[1].start_bus_num[0]    = PLATFORM_OVERRIDE_PCIE_ECAM1_START_BUS_NUM,
     .block[1].end_bus_num[0]      = PLATFORM_OVERRIDE_PCIE_ECAM1_END_BUS_NUM,


### PR DESCRIPTION
  - Rename hb_enteries to hb_entries in PAL bare‑metal PCIe overrides and uses.

Fixes #250 

Change-Id: I930d97b8f37239971cf871a0f2a5920f9c82831f