### PR TITLE
fix: fix PCI_LI_02 rule test fail

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -523,6 +523,10 @@ typedef struct {
   uint8_t                                      PciSegment;
 } PLATFORM_OVERRIDE_UART_INFO_TABLE;
 
+typedef struct {
+  uint32_t                                     GlobalSystemInterrupt;
+} PLATFORM_OVERRIDE_SATA_INFO_TABLE;
+
 /**
   @brief MSI(X) controllers info structure
 **/

--- a/pal/baremetal/base/src/pal_peripherals.c
+++ b/pal/baremetal/base/src/pal_peripherals.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #include "platform_override_struct.h"
 
 extern PLATFORM_OVERRIDE_UART_INFO_TABLE platform_uart_cfg;
+extern PLATFORM_OVERRIDE_SATA_INFO_TABLE platform_sata_cfg;
 extern PLATFORM_OVERRIDE_MEMORY_INFO_TABLE  platform_mem_cfg;
 extern PCIE_INFO_TABLE platform_pcie_cfg;
 
@@ -104,6 +105,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
        DeviceBdf = pal_pcie_get_bdf(SATA_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_SATA;
+          per_info->irq   = platform_sata_cfg.GlobalSystemInterrupt;
           for (bar_index = 0; bar_index < TYPE0_MAX_BARS; bar_index++)
           {
               per_info->base0 = pal_pcie_get_base(DeviceBdf, bar_index);

--- a/pal/baremetal/target/RDN2/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_fvp.h
@@ -604,6 +604,8 @@
 #define UART_PCI_FLAGS                   0x0
 #define UART_PCI_SEGMENT                 0x0
 
+#define SATA_GLOBAL_SYSTEM_INTERRUPT     0x100       /* SATA GSIV                                */
+
 /* IOVIRT platform config parameters */
 #define IOVIRT_ADDRESS                0xF98DEB18
 #define IORT_NODE_COUNT               13

--- a/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
@@ -534,6 +534,10 @@ PLATFORM_OVERRIDE_UART_INFO_TABLE platform_uart_cfg = {
     .PciSegment            = UART_PCI_SEGMENT
 };
 
+PLATFORM_OVERRIDE_SATA_INFO_TABLE platform_sata_cfg = {
+    .GlobalSystemInterrupt = SATA_GLOBAL_SYSTEM_INTERRUPT
+};
+
 DMA_INFO_TABLE platform_dma_cfg = {
     .num_dma_ctrls = PLATFORM_OVERRIDE_DMA_CNT
 
@@ -872,6 +876,11 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[19].dma_64bit     = PLATFORM_PCIE_DEV19_DMA_64BIT,
     .device[19].behind_smmu   = PLATFORM_PCIE_DEV19_BEHIND_SMMU,
     .device[19].atc_present   = PLATFORM_PCIE_DEV19_ATC_SUPPORT,
+     /* IRQ list of interrupt pin INTx# */
+    .device[19].irq_map.legacy_irq_map[0].irq_count = 1,
+    .device[19].irq_map.legacy_irq_map[0].irq_list[0] = 100,
+    .device[19].irq_map.legacy_irq_map[1].irq_count = 1,
+    .device[19].irq_map.legacy_irq_map[1].irq_list[0] = 200,
 
     .device[20].class_code    = PLATFORM_PCIE_DEV20_CLASSCODE,
     .device[20].vendor_id     = PLATFORM_PCIE_DEV20_VENDOR_ID,

--- a/pal/baremetal/target/RDV3/README.md
+++ b/pal/baremetal/target/RDV3/README.md
@@ -41,21 +41,5 @@ Follow the build steps mentioned in [README](../../README.md) with the TARGET pa
 
 - ./run_model.sh
 
-## Known Limitations
-Some PCIe and Exerciser tests, primarily related to interrupt/MSI generation, are expected to fail on the RDV3 platform. This is due to overlapping BAR register mappings observed during PCIe enumeration in the Baremetal environment. While a fix is under development, the following tests may fail:
 
-
-| Test ID | Description                                | Suite    | Status |
-|---------|--------------------------------------------|----------|--------|
-| 830     | Check Cmd Reg memory space enable          | BSA      | Fail   |
-| 1506    | Generate PCIe legacy interrupt             | BSA      | Fail   |
-| 1507    | Check PCIe I/O Coherency                   | BSA      | Fail   |
-| 1533    | MSI(-X) triggers interrupt with unique ID  | BSA      | Fail   |
-| 1535    | MSI-cap device can target any ITS block    | BSA      | Fail   |
-| 1508    | Tx pending bit clear correctness RCiEP     | SBSA     | Fail   |
-| 1523    | Check AER functionality for RPs            | SBSA     | Fail   |
-| 1524    | Check DPC functionality for RPs            | SBSA     | Fail   |
-
------------------
-
-*Copyright (c) 2025, Arm Limited and Contributors. All rights reserved.*
+*Copyright (c) 2025-2026, Arm Limited and Contributors. All rights reserved.*

--- a/pal/baremetal/target/RDV3/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3/include/platform_override_fvp.h
@@ -632,6 +632,8 @@
 #define UART_PCI_FLAGS                   0x0
 #define UART_PCI_SEGMENT                 0x0
 
+#define SATA_GLOBAL_SYSTEM_INTERRUPT     0x100       /* SATA GSIV                                 */
+
 /* IOVIRT platform config parameters */
 #define IOVIRT_ADDRESS                0xF98DEB18  /* Non-zero if IORT is present                 */
 #define IORT_NODE_COUNT               9           /* Total nodes in IORT                         */

--- a/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
@@ -458,6 +458,10 @@ PLATFORM_OVERRIDE_UART_INFO_TABLE platform_uart_cfg = {
     .PciSegment            = UART_PCI_SEGMENT
 };
 
+PLATFORM_OVERRIDE_SATA_INFO_TABLE platform_sata_cfg = {
+    .GlobalSystemInterrupt = SATA_GLOBAL_SYSTEM_INTERRUPT
+};
+
 DMA_INFO_TABLE platform_dma_cfg = {
     .num_dma_ctrls = PLATFORM_OVERRIDE_DMA_CNT
 
@@ -582,9 +586,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[5].dma_64bit     = PLATFORM_PCIE_DEV5_DMA_64BIT,
     .device[5].behind_smmu   = PLATFORM_PCIE_DEV5_BEHIND_SMMU,
     .device[5].atc_present   = PLATFORM_PCIE_DEV5_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
-    .device[5].irq_map.legacy_irq_map[2].irq_count = 1,
-    .device[5].irq_map.legacy_irq_map[2].irq_list[0] = 200,
+    /* IRQ list of interrupt pin INTD# */
+    .device[5].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[5].irq_map.legacy_irq_map[3].irq_list[0] = 244,
 
     .device[6].class_code    = PLATFORM_PCIE_DEV6_CLASSCODE,
     .device[6].vendor_id     = PLATFORM_PCIE_DEV6_VENDOR_ID,
@@ -599,9 +603,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[6].dma_64bit     = PLATFORM_PCIE_DEV6_DMA_64BIT,
     .device[6].behind_smmu   = PLATFORM_PCIE_DEV6_BEHIND_SMMU,
     .device[6].atc_present   = PLATFORM_PCIE_DEV6_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
-    .device[6].irq_map.legacy_irq_map[2].irq_count = 1,
-    .device[6].irq_map.legacy_irq_map[2].irq_list[0] = 200,
+    /* IRQ list of interrupt pin INTD# */
+    .device[6].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[6].irq_map.legacy_irq_map[3].irq_list[0] = 244,
 
     .device[7].class_code    = PLATFORM_PCIE_DEV7_CLASSCODE,
     .device[7].vendor_id     = PLATFORM_PCIE_DEV7_VENDOR_ID,
@@ -616,7 +620,7 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[7].dma_64bit     = PLATFORM_PCIE_DEV7_DMA_64BIT,
     .device[7].behind_smmu   = PLATFORM_PCIE_DEV7_BEHIND_SMMU,
     .device[7].atc_present   = PLATFORM_PCIE_DEV7_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTD# */
     .device[7].irq_map.legacy_irq_map[3].irq_count = 1,
     .device[7].irq_map.legacy_irq_map[3].irq_list[0] = 200,
 
@@ -678,7 +682,7 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[11].dma_64bit     = PLATFORM_PCIE_DEV11_DMA_64BIT,
     .device[11].behind_smmu   = PLATFORM_PCIE_DEV11_BEHIND_SMMU,
     .device[11].atc_present   = PLATFORM_PCIE_DEV11_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTA# */
     .device[11].irq_map.legacy_irq_map[0].irq_count = 1,
     .device[11].irq_map.legacy_irq_map[0].irq_list[0] = 200,
 
@@ -695,6 +699,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[12].dma_64bit     = PLATFORM_PCIE_DEV12_DMA_64BIT,
     .device[12].behind_smmu   = PLATFORM_PCIE_DEV12_BEHIND_SMMU,
     .device[12].atc_present   = PLATFORM_PCIE_DEV12_ATC_SUPPORT,
+    /* IRQ list of interrupt pin INTD# */
+    .device[12].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[12].irq_map.legacy_irq_map[3].irq_list[0] = 246,
 
     .device[13].class_code    = PLATFORM_PCIE_DEV13_CLASSCODE,
     .device[13].vendor_id     = PLATFORM_PCIE_DEV13_VENDOR_ID,
@@ -709,6 +716,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[13].dma_64bit     = PLATFORM_PCIE_DEV13_DMA_64BIT,
     .device[13].behind_smmu   = PLATFORM_PCIE_DEV13_BEHIND_SMMU,
     .device[13].atc_present   = PLATFORM_PCIE_DEV13_ATC_SUPPORT,
+    /* IRQ list of interrupt pin INTD# */
+    .device[13].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[13].irq_map.legacy_irq_map[3].irq_list[0] = 246,
 
     .device[14].class_code    = PLATFORM_PCIE_DEV14_CLASSCODE,
     .device[14].vendor_id     = PLATFORM_PCIE_DEV14_VENDOR_ID,
@@ -779,9 +789,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[18].dma_64bit     = PLATFORM_PCIE_DEV18_DMA_64BIT,
     .device[18].behind_smmu   = PLATFORM_PCIE_DEV18_BEHIND_SMMU,
     .device[18].atc_present   = PLATFORM_PCIE_DEV18_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTD# */
     .device[18].irq_map.legacy_irq_map[3].irq_count = 1,
-    .device[18].irq_map.legacy_irq_map[3].irq_list[0] = 200,
+    .device[18].irq_map.legacy_irq_map[3].irq_list[0] = 243,
 
     .device[19].class_code    = PLATFORM_PCIE_DEV19_CLASSCODE,
     .device[19].vendor_id     = PLATFORM_PCIE_DEV19_VENDOR_ID,
@@ -796,6 +806,11 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[19].dma_64bit     = PLATFORM_PCIE_DEV19_DMA_64BIT,
     .device[19].behind_smmu   = PLATFORM_PCIE_DEV19_BEHIND_SMMU,
     .device[19].atc_present   = PLATFORM_PCIE_DEV19_ATC_SUPPORT,
+     /* IRQ list of interrupt pin INTx# */
+    .device[19].irq_map.legacy_irq_map[0].irq_count = 1,
+    .device[19].irq_map.legacy_irq_map[0].irq_list[0] = 100,
+    .device[19].irq_map.legacy_irq_map[1].irq_count = 1,
+    .device[19].irq_map.legacy_irq_map[1].irq_list[0] = 200,
 
     .device[20].class_code    = PLATFORM_PCIE_DEV20_CLASSCODE,
     .device[20].vendor_id     = PLATFORM_PCIE_DEV20_VENDOR_ID,
@@ -810,9 +825,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[20].dma_64bit     = PLATFORM_PCIE_DEV20_DMA_64BIT,
     .device[20].behind_smmu   = PLATFORM_PCIE_DEV20_BEHIND_SMMU,
     .device[20].atc_present   = PLATFORM_PCIE_DEV20_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTD# */
     .device[20].irq_map.legacy_irq_map[3].irq_count = 1,
-    .device[20].irq_map.legacy_irq_map[3].irq_list[0] = 200,
+    .device[20].irq_map.legacy_irq_map[3].irq_list[0] = 243,
 };
 
 /** SBSA Module definitions */

--- a/pal/baremetal/target/RDV3CFG1/README.md
+++ b/pal/baremetal/target/RDV3CFG1/README.md
@@ -42,17 +42,6 @@ Follow the build steps mentioned in [README](../../README.md) with the TARGET pa
 - ./run_model.sh
 
 ## Known Limitations
-Some PCIe and Exerciser tests, primarily related to interrupt/MSI generation, are expected to fail on the RDV3-Cfg1 platform. This is due to overlapping BAR register mappings observed during PCIe enumeration in the Baremetal environment. While a fix is under development, the following tests may fail:
-
-| Test ID | Description                                | Suite    | Status |
-|---------|--------------------------------------------|----------|--------|
-| 1506    | Generate PCIe legacy interrupt             | BSA      | Fail   |
-| 1507    | Check PCIe I/O Coherency                   | BSA      | Fail   |
-| 1533    | MSI(-X) triggers interrupt with unique ID  | BSA      | Fail   |
-| 1535    | MSI-cap device can target any ITS block    | BSA      | Fail   |
-| 1508    | Tx pending bit clear correctness RCiEP     | SBSA     | Fail   |
-| 1523    | Check AER functionality for RPs            | SBSA     | Fail   |
-| 1524    | Check DPC functionality for RPs            | SBSA     | Fail   |
 
 **Note:** To run PCIe MSE tests on RDV3-Cfg1 FVP, add `-C pcie_group_0.pcie0.ur_rao_wi=1` to `run_model.sh` so UR handling is enabled and the tests do not trigger an EL3 exception. If PCIe MSE tests still fail, set `g_pcie_skip_dp_nic_ms=1` in `apps/baremetal/acs_globals.c` locally.
 

--- a/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
@@ -581,6 +581,8 @@
 #define UART_PCI_FLAGS                   0x0
 #define UART_PCI_SEGMENT                 0x0
 
+#define SATA_GLOBAL_SYSTEM_INTERRUPT     0x100       /* SATA GSIV                                */
+
 /* IOVIRT platform config parameters */
 #define IOVIRT_ADDRESS                0xF98DEB18  /* Non-zero if IORT is present                 */
 #define IORT_NODE_COUNT               3           /* Total nodes in IORT                         */

--- a/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
@@ -374,6 +374,10 @@ PLATFORM_OVERRIDE_UART_INFO_TABLE platform_uart_cfg = {
     .PciSegment            = UART_PCI_SEGMENT
 };
 
+PLATFORM_OVERRIDE_SATA_INFO_TABLE platform_sata_cfg = {
+    .GlobalSystemInterrupt = SATA_GLOBAL_SYSTEM_INTERRUPT
+};
+
 DMA_INFO_TABLE platform_dma_cfg = {
     .num_dma_ctrls = PLATFORM_OVERRIDE_DMA_CNT
 
@@ -498,9 +502,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[5].dma_64bit     = PLATFORM_PCIE_DEV5_DMA_64BIT,
     .device[5].behind_smmu   = PLATFORM_PCIE_DEV5_BEHIND_SMMU,
     .device[5].atc_present   = PLATFORM_PCIE_DEV5_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
-    .device[5].irq_map.legacy_irq_map[2].irq_count = 1,
-    .device[5].irq_map.legacy_irq_map[2].irq_list[0] = 200,
+    /* IRQ list of interrupt pin INTD# */
+    .device[5].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[5].irq_map.legacy_irq_map[3].irq_list[0] = 244,
 
     .device[6].class_code    = PLATFORM_PCIE_DEV6_CLASSCODE,
     .device[6].vendor_id     = PLATFORM_PCIE_DEV6_VENDOR_ID,
@@ -515,9 +519,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[6].dma_64bit     = PLATFORM_PCIE_DEV6_DMA_64BIT,
     .device[6].behind_smmu   = PLATFORM_PCIE_DEV6_BEHIND_SMMU,
     .device[6].atc_present   = PLATFORM_PCIE_DEV6_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
-    .device[6].irq_map.legacy_irq_map[2].irq_count = 1,
-    .device[6].irq_map.legacy_irq_map[2].irq_list[0] = 200,
+    /* IRQ list of interrupt pin INTD# */
+    .device[6].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[6].irq_map.legacy_irq_map[3].irq_list[0] = 244,
 
     .device[7].class_code    = PLATFORM_PCIE_DEV7_CLASSCODE,
     .device[7].vendor_id     = PLATFORM_PCIE_DEV7_VENDOR_ID,
@@ -532,7 +536,7 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[7].dma_64bit     = PLATFORM_PCIE_DEV7_DMA_64BIT,
     .device[7].behind_smmu   = PLATFORM_PCIE_DEV7_BEHIND_SMMU,
     .device[7].atc_present   = PLATFORM_PCIE_DEV7_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTD# */
     .device[7].irq_map.legacy_irq_map[3].irq_count = 1,
     .device[7].irq_map.legacy_irq_map[3].irq_list[0] = 200,
 
@@ -594,7 +598,7 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[11].dma_64bit     = PLATFORM_PCIE_DEV11_DMA_64BIT,
     .device[11].behind_smmu   = PLATFORM_PCIE_DEV11_BEHIND_SMMU,
     .device[11].atc_present   = PLATFORM_PCIE_DEV11_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTA# */
     .device[11].irq_map.legacy_irq_map[0].irq_count = 1,
     .device[11].irq_map.legacy_irq_map[0].irq_list[0] = 200,
 
@@ -611,6 +615,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[12].dma_64bit     = PLATFORM_PCIE_DEV12_DMA_64BIT,
     .device[12].behind_smmu   = PLATFORM_PCIE_DEV12_BEHIND_SMMU,
     .device[12].atc_present   = PLATFORM_PCIE_DEV12_ATC_SUPPORT,
+    /* IRQ list of interrupt pin INTD# */
+    .device[12].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[12].irq_map.legacy_irq_map[3].irq_list[0] = 246,
 
     .device[13].class_code    = PLATFORM_PCIE_DEV13_CLASSCODE,
     .device[13].vendor_id     = PLATFORM_PCIE_DEV13_VENDOR_ID,
@@ -625,6 +632,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[13].dma_64bit     = PLATFORM_PCIE_DEV13_DMA_64BIT,
     .device[13].behind_smmu   = PLATFORM_PCIE_DEV13_BEHIND_SMMU,
     .device[13].atc_present   = PLATFORM_PCIE_DEV13_ATC_SUPPORT,
+    /* IRQ list of interrupt pin INTD# */
+    .device[13].irq_map.legacy_irq_map[3].irq_count = 1,
+    .device[13].irq_map.legacy_irq_map[3].irq_list[0] = 246,
 
     .device[14].class_code    = PLATFORM_PCIE_DEV14_CLASSCODE,
     .device[14].vendor_id     = PLATFORM_PCIE_DEV14_VENDOR_ID,
@@ -695,9 +705,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[18].dma_64bit     = PLATFORM_PCIE_DEV18_DMA_64BIT,
     .device[18].behind_smmu   = PLATFORM_PCIE_DEV18_BEHIND_SMMU,
     .device[18].atc_present   = PLATFORM_PCIE_DEV18_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTD# */
     .device[18].irq_map.legacy_irq_map[3].irq_count = 1,
-    .device[18].irq_map.legacy_irq_map[3].irq_list[0] = 200,
+    .device[18].irq_map.legacy_irq_map[3].irq_list[0] = 243,
 
     .device[19].class_code    = PLATFORM_PCIE_DEV19_CLASSCODE,
     .device[19].vendor_id     = PLATFORM_PCIE_DEV19_VENDOR_ID,
@@ -712,6 +722,11 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[19].dma_64bit     = PLATFORM_PCIE_DEV19_DMA_64BIT,
     .device[19].behind_smmu   = PLATFORM_PCIE_DEV19_BEHIND_SMMU,
     .device[19].atc_present   = PLATFORM_PCIE_DEV19_ATC_SUPPORT,
+     /* IRQ list of interrupt pin INTx# */
+    .device[19].irq_map.legacy_irq_map[0].irq_count = 1,
+    .device[19].irq_map.legacy_irq_map[0].irq_list[0] = 100,
+    .device[19].irq_map.legacy_irq_map[1].irq_count = 1,
+    .device[19].irq_map.legacy_irq_map[1].irq_list[0] = 200,
 
     .device[20].class_code    = PLATFORM_PCIE_DEV20_CLASSCODE,
     .device[20].vendor_id     = PLATFORM_PCIE_DEV20_VENDOR_ID,
@@ -726,9 +741,9 @@ PCIE_READ_TABLE platform_pcie_device_hierarchy = {
     .device[20].dma_64bit     = PLATFORM_PCIE_DEV20_DMA_64BIT,
     .device[20].behind_smmu   = PLATFORM_PCIE_DEV20_BEHIND_SMMU,
     .device[20].atc_present   = PLATFORM_PCIE_DEV20_ATC_SUPPORT,
-    /* IRQ list of interrupt pin INTC# */
+    /* IRQ list of interrupt pin INTD# */
     .device[20].irq_map.legacy_irq_map[3].irq_count = 1,
-    .device[20].irq_map.legacy_irq_map[3].irq_list[0] = 200,
+    .device[20].irq_map.legacy_irq_map[3].irq_list[0] = 243,
 };
 
 /** SBSA Module definitions */

--- a/test_pool/pcie/p096.c
+++ b/test_pool/pcie/p096.c
@@ -68,6 +68,13 @@ payload (void)
     count--;
     if (val_peripheral_get_info (ANY_GSIV, count)) {
       dev_bdf = val_peripheral_get_info (ANY_BDF, count);
+
+      if (dev_bdf == 0) {
+        val_print(ACS_PRINT_INFO,
+                  "\n       Skipping legacy IRQ check for peripheral without BDF", 0);
+        continue;
+      }
+
       status = val_pci_get_legacy_irq_map (dev_bdf, irq_map);
 
       switch (status) {


### PR DESCRIPTION
  - p096: skip for peripheral without BDF (bdf=0) to avoid invalid legacy IRQ map lookup.
  - e006: add INTx->SPI mappings so legacy interrupts route/trigger.


Change-Id: I7f27f9d312f2f8d50a1965bc89d748724975598b