### PR TITLE
fix(uefi): handle pal_pcie_dev_p2p_support not-implemented

### DIFF
--- a/pal/uefi_acpi/src/pal_pcie.c
+++ b/pal/uefi_acpi/src/pal_pcie.c
@@ -385,7 +385,8 @@ pal_pcie_dev_p2p_support (
    * transactions is platform implementation specific
    */
 
-  return 1;
+  pal_warn_not_implemented(__func__);
+  return PAL_STATUS_NOT_IMPLEMENTED;
 }
 
 

--- a/pal/uefi_dt/src/pal_pcie.c
+++ b/pal/uefi_dt/src/pal_pcie.c
@@ -385,7 +385,8 @@ pal_pcie_dev_p2p_support (
    * transactions is platform implementation specific
    */
 
-  return 1;
+  pal_warn_not_implemented(__func__);
+  return PAL_STATUS_NOT_IMPLEMENTED;
 }
 
 /**

--- a/test_pool/pcie/p017.c
+++ b/test_pool/pcie/p017.c
@@ -42,6 +42,7 @@ payload(void)
   uint32_t rc_ats_attr;
   uint32_t rc_ats_supp;
   uint32_t data;
+  uint32_t status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -92,7 +93,12 @@ payload(void)
       if (dp_type == RP)
       {
           /* Check If RP supports P2P with other RP's. */
-          if (val_pcie_dev_p2p_support(bdf))
+          status = val_pcie_dev_p2p_support(bdf);
+          if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+              val_set_status(pe_index, RESULT_WARN(TEST_NUM, 1));
+              return;
+          }
+          if (status)
               continue;
 
           /* If test runs for atleast one RP */

--- a/test_pool/pcie/p018.c
+++ b/test_pool/pcie/p018.c
@@ -36,6 +36,7 @@ payload(void)
   uint32_t cap_base = 0;
   uint32_t test_fails;
   uint32_t test_skip = 1;
+  uint32_t status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
@@ -59,7 +60,12 @@ payload(void)
       if (dp_type == RP)
       {
           /* Check If RP supports P2P with other RP's. */
-          if (val_pcie_dev_p2p_support(bdf))
+          status = val_pcie_dev_p2p_support(bdf);
+          if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+              val_set_status(pe_index, RESULT_WARN(TEST_NUM, 1));
+              return;
+          }
+          if (status)
               continue;
 
           /* Test runs for atleast one Root Port */

--- a/test_pool/pcie/p081.c
+++ b/test_pool/pcie/p081.c
@@ -39,6 +39,7 @@ payload(void)
   uint32_t test_skip = 1;
   uint32_t acs_data;
   uint32_t data;
+  uint32_t status;
   uint32_t iep_rp_bdf;
   uint32_t curr_bdf_failed = 0;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -65,7 +66,12 @@ payload(void)
       {
           val_print(ACS_PRINT_DEBUG, "\n       BDF - 0x%x", bdf);
           /* Check If iEP_EP supports P2P with others. */
-          if (val_pcie_dev_p2p_support(bdf))
+          status = val_pcie_dev_p2p_support(bdf);
+          if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+              val_set_status(pe_index, RESULT_WARN(TEST_NUM, 01));
+              return;
+          }
+          if (status)
               continue;
 
           /* If test runs for atleast an endpoint */

--- a/test_pool/pcie/p082.c
+++ b/test_pool/pcie/p082.c
@@ -71,6 +71,7 @@ payload(void *arg)
   uint32_t aer_cap_fail = 0;
   uint32_t acs_data;
   uint32_t data;
+  uint32_t status;
   uint8_t p2p_support_flag = 0;
   pcie_device_bdf_table *bdf_tbl_ptr;
   test_data_t *test_data = (test_data_t *)arg;
@@ -103,7 +104,12 @@ payload(void *arg)
               continue;
 
           /* Check If Endpoint supports P2P with other Functions. */
-          if (val_pcie_dev_p2p_support(bdf))
+          status = val_pcie_dev_p2p_support(bdf);
+          if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+              val_set_status(pe_index, RESULT_WARN(test_data->test_num, 01));
+              return;
+          }
+          if (status)
               continue;
 
           /* If test runs for atleast an endpoint */


### PR DESCRIPTION
  - Warn and exit when val_pcie_dev_p2p_support reports NOT_IMPLEMENTED
  - Return PAL_STATUS_NOT_IMPLEMENTED from pal_pcie_dev_p2p_support()


Change-Id: I52a45048c829668ab7d23a4edd4343cbe0f6996f