### PR TITLE
(fix) S_L3GI_02 is not UEFI test, p071_entry is not for BSA L1

### DIFF
--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -1964,7 +1964,7 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .test_entry_id    = P046_ENTRY,
             .module_id        = PCIE,
             .rule_desc        = "Check all MSI(X) vectors are LPIs",
-            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI | PLATFORM_LINUX,
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_LINUX,
             .flag             = BASE_RULE,
             .test_num         = ACS_PCIE_TEST_NUM_BASE + 46,
         },
@@ -2479,7 +2479,7 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .test_entry_id    = P046_ENTRY,
             .module_id        = PCIE,
             .rule_desc        = "Check all MSI(X) vectors are LPIs",
-            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI | PLATFORM_LINUX,
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_LINUX,
             .flag             = BASE_RULE,
             .test_num         = ACS_PCIE_TEST_NUM_BASE + 46,
         },
@@ -3080,7 +3080,6 @@ test_entry_fn_t test_entry_func_table[TEST_ENTRY_SENTINEL] = {
     [P038_ENTRY] = p038_entry,
     [P039_ENTRY] = p039_entry,
     [P042_ENTRY] = p042_entry,
-    [P046_ENTRY] = p046_entry,
     [P047_ENTRY] = p047_entry,
     [P048_ENTRY] = p048_entry, // used in wrapper.
     [P049_ENTRY] = p049_entry, // used in wrapper.

--- a/val/src/test_wrappers.c
+++ b/val/src/test_wrappers.c
@@ -344,8 +344,15 @@ pci_in_13_entry(uint32_t num_pe)
 uint32_t
 pci_in_17_entry(uint32_t num_pe)
 {
-    TEST_ENTRY_ID_e p_list[] = { P036_ENTRY, P071_ENTRY, TEST_ENTRY_SENTINEL };
+
     TEST_ENTRY_ID_e e_list[] = { E015_ENTRY, TEST_ENTRY_SENTINEL };
+
+    if (g_base_rule == B_PER_08) {
+        TEST_ENTRY_ID_e p_list[] = {P036_ENTRY, TEST_ENTRY_SENTINEL};
+        return run_pcie_static_and_exerciser(p_list, e_list, num_pe);
+    }
+
+    TEST_ENTRY_ID_e p_list[] = { P036_ENTRY, P071_ENTRY, TEST_ENTRY_SENTINEL };
 
     return run_pcie_static_and_exerciser(p_list, e_list, num_pe);
 }


### PR DESCRIPTION
 * S_L3GI_02 rule test is only for BM and Linux, enabling on UEFI gives incorrect SKIP as the msi flags are not populated on UEFI and the default value 0 indicates msi is disabled

 * PCI_IN_17 rule when as part of B_PER_08 should not run integrated dev test

Change-Id: I796f045401b3bb9c8cd04f38d9ab5666407c10f3