### PR TITLE
Two colon after Running tests print is reserved for rule id:test num:test desc print

### DIFF
--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -109,7 +109,7 @@ uint32_t val_exerciser_create_info_table(void)
       }
   }
   g_exerciser_info_table.num_exerciser = num_exerciser_info;
-  val_print(ACS_PRINT_TEST, "\n     PCIE_INFO: Number of exerciser cards : %4d \n",
+  val_print(ACS_PRINT_TEST, "\n     PCIE_INFO: Number of exerciser cards  %4d \n",
                                                              g_exerciser_info_table.num_exerciser);
   return 0;
 }


### PR DESCRIPTION

 * the log parser logic to extract rule id, test num, test desc is based on format that print will follow rule id : test num : test desc print. The exerciser cards info print which comes in b/w test execution also uses two colons which throw the log parser logic off.

Change-Id: Id769abb5933243126d5650af3ce812e454e390e9