### PR TITLE
(improv)  Report rules under thier respective modules

### DIFF
--- a/test_pool/pcie/p038.c
+++ b/test_pool/pcie/p038.c
@@ -67,9 +67,9 @@ next_bdf:
           val_pcie_read_cfg(bdf, TYPE01_VIDR, &reg_value);
           device_id = (reg_value >> TYPE01_DIDR_SHIFT) & TYPE01_DIDR_MASK;
           vendor_id = (reg_value >> TYPE01_VIDR_SHIFT) & TYPE01_VIDR_MASK;
-          val_print(ACS_PRINT_DEBUG, "\n       BDF: 0x%x ", bdf);
-          val_print(ACS_PRINT_DEBUG, "Dev ID: 0x%x ", device_id);
-          val_print(ACS_PRINT_DEBUG, "Vendor ID: 0x%x", vendor_id);
+          val_print(ACS_PRINT_DEBUG, "\n       BDF 0x%x ", bdf);
+          val_print(ACS_PRINT_DEBUG, "Dev ID 0x%x ", device_id);
+          val_print(ACS_PRINT_DEBUG, "Vendor ID 0x%x", vendor_id);
 
           rp_ecam_base = val_pcie_get_ecam_base(bdf);
           rp_segment = PCIE_EXTRACT_BDF_SEG(bdf);

--- a/test_pool/pe/pe001.c
+++ b/test_pool/pe/pe001.c
@@ -251,22 +251,22 @@ payload(uint32_t num_pe)
          val_pe_reg_write(CSSELR_EL1, i << 1);
          cache_list[i] = return_reg_value(reg_list[0].reg_name, reg_list[0].dependency);
          val_data_cache_ops_by_va((addr_t)(cache_list + i), CLEAN_AND_INVALIDATE);
-         val_print(ACS_PRINT_INFO, "\n       Primary PE Index: %d", my_index);
-         val_print(ACS_PRINT_INFO, ", cache index: %d", i);
-         val_print(ACS_PRINT_INFO, ", size read: 0x%016llx", cache_list[i]);
+         val_print(ACS_PRINT_INFO, "\n       Primary PE Index %d", my_index);
+         val_print(ACS_PRINT_INFO, ", cache index %d", i);
+         val_print(ACS_PRINT_INFO, ", size read 0x%016llx", cache_list[i]);
       }
       i++;
   }
 
   for (i = 1; i < NUM_OF_REGISTERS; i++) {
       rd_data_array[i] = return_reg_value(reg_list[i].reg_name, reg_list[i].dependency);
-      val_print(ACS_PRINT_INFO, "\n       Primary PE Index: %d, ", my_index);
+      val_print(ACS_PRINT_INFO, "\n       Primary PE Index %d, ", my_index);
       val_print(ACS_PRINT_INFO, reg_list[i].reg_desc, 0);
 
       if (reg_list[i].dependency == AA32)
-          val_print(ACS_PRINT_INFO, " : 0x%08llx ", rd_data_array[i]);
+          val_print(ACS_PRINT_INFO, "  0x%08llx ", rd_data_array[i]);
       else
-          val_print(ACS_PRINT_INFO, " : 0x%016llx ", rd_data_array[i]);
+          val_print(ACS_PRINT_INFO, "  0x%016llx ", rd_data_array[i]);
 
       val_data_cache_ops_by_va((addr_t)(rd_data_array + i), CLEAN_AND_INVALIDATE);
   }
@@ -295,8 +295,8 @@ payload(uint32_t num_pe)
       }
   }
 
-  val_print(ACS_PRINT_TEST, "\n       Primary PE Index    : %d", my_index);
-  val_print(ACS_PRINT_TEST, "\n       Primary PE MIDR_EL1 : 0x%08llx", rd_data_array[1]);
+  val_print(ACS_PRINT_TEST, "\n       Primary PE Index     %d", my_index);
+  val_print(ACS_PRINT_TEST, "\n       Primary PE MIDR_EL1  0x%08llx", rd_data_array[1]);
 
   for (i = 0; i < num_pe; i++) {
       uint32_t unique = 1;
@@ -311,7 +311,7 @@ payload(uint32_t num_pe)
           }
           if (unique == 1 && rd_data_array[1] != pe_buffer->reg_data[1]) {
               if (t == 0) {
-                  val_print(ACS_PRINT_TEST, "\n       Other Cores         : 0x%08llx      ",
+                  val_print(ACS_PRINT_TEST, "\n       Other Cores          0x%08llx      ",
                                                                         pe_buffer->reg_data[1]);
                   t = 1;
               } else {
@@ -323,7 +323,7 @@ payload(uint32_t num_pe)
   }
 
   if (t == 0) {
-      val_print(ACS_PRINT_TEST, "\n       Other Cores         : Identical       ", 0);
+      val_print(ACS_PRINT_TEST, "\n       Other Cores          Identical       ", 0);
   }
 
   pe_buffer = NULL;
@@ -336,20 +336,20 @@ payload(uint32_t num_pe)
              if (!(pe_buffer->cache_status[cache_index]) &&
                                                     (pe_buffer->pe_cache[cache_index] != 0))
              {
-                 val_print(ACS_PRINT_INFO, "\n        PE Index: %d", i);
-                 val_print(ACS_PRINT_INFO, ", cache index: %d", cache_index);
-                 val_print(ACS_PRINT_INFO, ", size read: 0x%016llx",
+                 val_print(ACS_PRINT_INFO, "\n        PE Index %d", i);
+                 val_print(ACS_PRINT_INFO, ", cache index %d", cache_index);
+                 val_print(ACS_PRINT_INFO, ", size read 0x%016llx",
                                                              pe_buffer->pe_cache[cache_index]);
              }
              else if (pe_buffer->pe_cache[cache_index] != 0)
              {
-                   val_print(ACS_PRINT_ERR, "\n        PE Index: %d", i);
-                   val_print(ACS_PRINT_ERR, ", cache index: %d", cache_index);
-                   val_print(ACS_PRINT_ERR, ", size read: 0x%016llx     FAIL\n",
+                   val_print(ACS_PRINT_ERR, "\n        PE Index %d", i);
+                   val_print(ACS_PRINT_ERR, ", cache index %d", cache_index);
+                   val_print(ACS_PRINT_ERR, ", size read 0x%016llx     FAIL\n",
                                                              pe_buffer->pe_cache[cache_index]);
-                   val_print(ACS_PRINT_ERR, "          Masked Primary PE Value : 0x%016llx \n",
+                   val_print(ACS_PRINT_ERR, "          Masked Primary PE Value  0x%016llx \n",
                                               cache_list[cache_index] & (~reg_list[0].reg_mask));
-                   val_print(ACS_PRINT_ERR, "          Masked Current PE Value : 0x%016llx ",
+                   val_print(ACS_PRINT_ERR, "          Masked Current PE Value  0x%016llx ",
                                       pe_buffer->pe_cache[cache_index] & (~reg_list[0].reg_mask));
                    cache_fail = cache_fail + 1;
              }
@@ -357,28 +357,28 @@ payload(uint32_t num_pe)
 
           for (int reg_index = 1; reg_index < NUM_OF_REGISTERS; reg_index++) {
              if (!(pe_buffer->reg_status[reg_index])) {
-                 val_print(ACS_PRINT_INFO, "\n        PE Index: %d, ", i);
+                 val_print(ACS_PRINT_INFO, "\n        PE Index %d, ", i);
                  val_print(ACS_PRINT_INFO, reg_list[reg_index].reg_desc, 0);
                  if (reg_list[reg_index].dependency == AA32)
-                     val_print(ACS_PRINT_INFO, "  : 0x%08llx", pe_buffer->reg_data[reg_index]);
+                     val_print(ACS_PRINT_INFO, "   0x%08llx", pe_buffer->reg_data[reg_index]);
                  else
-                     val_print(ACS_PRINT_INFO, "  : 0x%016llx", pe_buffer->reg_data[reg_index]);
+                     val_print(ACS_PRINT_INFO, "   0x%016llx", pe_buffer->reg_data[reg_index]);
              } else  {
-                 val_print(ACS_PRINT_ERR, "\n        PE Index: %d, ", i);
+                 val_print(ACS_PRINT_ERR, "\n        PE Index %d, ", i);
                  val_print(ACS_PRINT_ERR, reg_list[reg_index].reg_desc, 0);
                  if (reg_list[reg_index].dependency == AA32) {
-                     val_print(ACS_PRINT_ERR, "   : 0x%08llx    FAIL\n",
+                     val_print(ACS_PRINT_ERR, "    0x%08llx    FAIL\n",
                                                         pe_buffer->reg_data[reg_index]);
-                     val_print(ACS_PRINT_ERR, "          Masked Primary PE Value : 0x%08llx \n",
+                     val_print(ACS_PRINT_ERR, "          Masked Primary PE Value  0x%08llx \n",
                                        rd_data_array[reg_index] & (~reg_list[reg_index].reg_mask));
-                     val_print(ACS_PRINT_ERR, "          Masked Current PE Value : 0x%08llx ",
+                     val_print(ACS_PRINT_ERR, "          Masked Current PE Value  0x%08llx ",
                                  pe_buffer->reg_data[reg_index] & (~reg_list[reg_index].reg_mask));
                  } else {
-                     val_print(ACS_PRINT_ERR, "   : 0x%016llx    FAIL\n",
+                     val_print(ACS_PRINT_ERR, "    0x%016llx    FAIL\n",
                                                         pe_buffer->reg_data[reg_index]);
-                     val_print(ACS_PRINT_ERR, "          Masked Primary PE Value : 0x%016llx \n",
+                     val_print(ACS_PRINT_ERR, "          Masked Primary PE Value  0x%016llx \n",
                                        rd_data_array[reg_index] & (~reg_list[reg_index].reg_mask));
-                     val_print(ACS_PRINT_ERR, "          Masked Current PE Value : 0x%016llx ",
+                     val_print(ACS_PRINT_ERR, "          Masked Current PE Value  0x%016llx ",
                                  pe_buffer->reg_data[reg_index] & (~reg_list[reg_index].reg_mask));
                    }
                  reg_fail = reg_fail + 1;
@@ -391,7 +391,7 @@ payload(uint32_t num_pe)
   }
 
   if (total_fail) {
-      val_print(ACS_PRINT_ERR, "\n\n    Total Register and cache fail for all PE: %d \n",
+      val_print(ACS_PRINT_ERR, "\n\n    Total Register and cache fail for all PE %d \n",
                                                                              total_fail);
       val_set_status(my_index, RESULT_FAIL(TEST_NUM, 4));
   }

--- a/val/include/acs_common.h
+++ b/val/include/acs_common.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,7 @@
 #define ACS_ETE_TEST_NUM_BASE        1400
 #define ACS_EXERCISER_TEST_NUM_BASE  1500
 #define ACS_TPM2_TEST_NUM_BASE       1600
+#define ACS_GPU_TEST_NUM_BASE        1700
 
 /* Module specific print APIs */
 

--- a/val/include/rule_based_execution_enum.h
+++ b/val/include/rule_based_execution_enum.h
@@ -90,11 +90,6 @@ typedef enum {
     S_L7PE_07,
     S_L7PE_08,
     S_L7PE_09,
-    S_L7TME_1,
-    S_L7TME_2,
-    S_L7TME_3,
-    S_L7TME_4,
-    S_L7TME_5,
     S_L8PE_01,
     S_L8PE_02,
     S_L8PE_03,
@@ -104,7 +99,6 @@ typedef enum {
     S_L8PE_07,
     S_L8PE_08,
     WNPXD,
-    S_L8RME_1,
     S_L8SHD_1,
 
     /* PE PCBSA rules */
@@ -129,6 +123,7 @@ typedef enum {
     ITS_DEV_7,
     ITS_DEV_8,
     S_L3GI_01,
+    S_L3GI_02,
     B_PPI_00,
     S_L3PP_01,
     S_L5GI_01,
@@ -152,7 +147,6 @@ typedef enum {
     S_L3PR_01,
     B_PER_06,
     B_PER_07,
-    B_PER_08,
     B_PER_09,
     B_PER_10,
     B_PER_11,
@@ -212,10 +206,10 @@ typedef enum {
     RAS_10,
     RAS_11,
     RAS_12,
-    S_L7RAS_1,
-    S_L7RAS_2,
     S_RAS_01,
     S_RAS_03,
+    S_L7RAS_1,
+    S_L7RAS_2,
     SYS_RAS,
     SYS_RAS_1,
     SYS_RAS_2,
@@ -249,12 +243,10 @@ typedef enum {
     B_SMMU_23,
     B_SMMU_24,
     B_SMMU_25,
-    GPU_04,
     SMMU_01,
     SMMU_02,
-    S_L3SM_01,
-
     S_L4SM_01,
+    S_L3SM_01,
     S_L4SM_02,
     S_L4SM_03,
     S_L5SM_01,
@@ -287,8 +279,8 @@ typedef enum {
     B_TIME_08,
     B_TIME_09,
     B_TIME_10,
-    S_L5TI_01,
     S_L8TI_01,
+    S_L5TI_01,
 
     /* WATCHDOG rules */
     B_WD_00,
@@ -326,9 +318,9 @@ typedef enum {
     ETE_10,
 
     /* Power wakeup */
+    B_WAK_03,
     B_WAK_01,
     B_WAK_02,
-    B_WAK_03,
     B_WAK_04,
     B_WAK_05,
     B_WAK_06,
@@ -352,14 +344,10 @@ typedef enum {
     P_L1TP_04,
 
     /*PCIe*/
+    B_PER_08,
     B_PER_12,  // revisit peripheral rule in pcie module
     B_PCIe_10,
     B_PCIe_11,
-    S_PCIe_10,
-    XDGKZ,
-    GPU_01,
-    GPU_02,
-    GPU_03,
     B_REP_1,
     B_IEP_1,
     BJLPB,
@@ -493,8 +481,8 @@ typedef enum {
     RI_PWR_1,
     JKZMT,
     HVZJY,
-    S_L4PCI_1,
     S_L4PCI_2,
+    S_L4PCI_1,
     S_L6PCI_1,
     S_PCIe_01,
     S_PCIe_02,
@@ -505,11 +493,24 @@ typedef enum {
     S_PCIe_09,
     S_PCIe_07,
     S_PCIe_08,
+    S_PCIe_10,
     S_L8CXL_1,
-    S_L3GI_02, /* GIC rule is in part of PCIe module */
+    S_L8RME_1,
 
     P_L1PCI_1,
     P_L1PCI_2,
+    S_L7TME_1,
+    S_L7TME_2,
+    S_L7TME_3,
+    S_L7TME_4,
+    S_L7TME_5,
+
+    /* GPU rules */
+    XDGKZ,
+    GPU_03,
+    GPU_01,
+    GPU_02,
+    GPU_04,
 
     /* VBSA rules */
     V_L1PE_01,
@@ -990,6 +991,8 @@ typedef enum {
     TPM,
     POWER_WAKEUP,
     PFDI,
+    RME,
+    GPU,
     MODULE_ID_SENTINEL /* need to be in last */
 } MODULE_NAME_e;
 

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -1334,7 +1334,7 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
           id = bf_entry->ecap_id;
           break;
       default:
-          val_print(ACS_PRINT_ERR, "\n       Invalid reg_type : 0x%x  ", bf_entry->reg_type);
+          val_print(ACS_PRINT_ERR, "\n       Invalid reg_type  0x%x  ", bf_entry->reg_type);
           return 1;
   }
 
@@ -1358,9 +1358,9 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
   /* Check if bit-field value is proper */
   if (bf_value != bf_entry->cfg_value)
   {
-      val_print(ACS_PRINT_ERR, "\n       BDF 0x%x : ", bdf);
+      val_print(ACS_PRINT_ERR, "\n       BDF 0x%x  ", bdf);
       val_print(ACS_PRINT_ERR, bf_entry->err_str1, 0);
-      val_print(ACS_PRINT_ERR, ": 0x%x", bf_value);
+      val_print(ACS_PRINT_ERR, " 0x%x", bf_value);
       val_print(ACS_PRINT_ERR, " instead of 0x%x", bf_entry->cfg_value);
       if (!val_strncmp(bf_entry->err_str1, "WARNING", WARN_STR_LEN))
           return 0;
@@ -1409,15 +1409,15 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
           val_pcie_write_cfg(bdf, cap_base + reg_offset, temp_reg_value);
           break;
       default:
-          val_print(ACS_PRINT_ERR, "\n       Invalid Attribute : 0x%x  ", bf_entry->attr);
+          val_print(ACS_PRINT_ERR, "\n       Invalid Attribute  0x%x  ", bf_entry->attr);
           return 1;
   }
 
   if (reg_overwrite_value != reg_value)
   {
-      val_print(ACS_PRINT_ERR, "\n       BDF 0x%x : ", bdf);
+      val_print(ACS_PRINT_ERR, "\n       BDF 0x%x  ", bdf);
       val_print(ACS_PRINT_ERR, bf_entry->err_str2, 0);
-      val_print(ACS_PRINT_ERR, ": 0x%x",
+      val_print(ACS_PRINT_ERR, " 0x%x",
                           reg_overwrite_value >> REG_SHIFT(alignment_byte_cnt, bf_entry->start));
       val_print(ACS_PRINT_ERR, " instead of 0x%x",
                           reg_value >> REG_SHIFT(alignment_byte_cnt, bf_entry->start));
@@ -1427,7 +1427,7 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
   }
 
   /* Return pass status */
-  val_print(ACS_PRINT_INFO, "\n       BDF 0x%x : PASS", bdf);
+  val_print(ACS_PRINT_INFO, "\n       BDF 0x%x  PASS", bdf);
   return 0;
 }
 

--- a/val/src/rule_enum_string_map.c
+++ b/val/src/rule_enum_string_map.c
@@ -225,7 +225,6 @@ char *rule_id_string[RULE_ID_SENTINEL] = {
     [B_SMMU_23]   = "B_SMMU_23",
     [B_SMMU_24]   = "B_SMMU_24",
     [B_SMMU_25]   = "B_SMMU_25",
-    [GPU_04]      = "GPU_04",
     [SMMU_01]     = "SMMU_01",
     [SMMU_02]     = "SMMU_02",
     [S_L3SM_01]   = "S_L3SM_01",
@@ -311,10 +310,6 @@ char *rule_id_string[RULE_ID_SENTINEL] = {
     [B_PCIe_10]   = "B_PCIe_10",
     [B_PCIe_11]   = "B_PCIe_11",
     [S_PCIe_10]   = "S_PCIe_10",
-    [XDGKZ]       = "XDGKZ",
-    [GPU_01]      = "GPU_01",
-    [GPU_02]      = "GPU_02",
-    [GPU_03]      = "GPU_03",
     [IE_ACS_1]    = "IE_ACS_1",
     [IE_ACS_2]    = "IE_ACS_2",
     [IE_ORD_4]    = "IE_ORD_4",
@@ -461,6 +456,13 @@ char *rule_id_string[RULE_ID_SENTINEL] = {
     [S_L8CXL_1]   = "S_L8CXL_1",
     [S_L3GI_02]   = "S_L3GI_02",
 
+    /* GPU rules */
+    [XDGKZ]       = "XDGKZ",
+    [GPU_01]      = "GPU_01",
+    [GPU_02]      = "GPU_02",
+    [GPU_03]      = "GPU_03",
+    [GPU_04]      = "GPU_04",
+
     /* PC-BSA identifiers */
     [P_L1_01]     = "P_L1_01",
     [P_L1PE_01]   = "P_L1PE_01",
@@ -577,4 +579,6 @@ char *module_name_string[MODULE_ID_SENTINEL] = {
     [TPM]          = "TPM",
     [POWER_WAKEUP] = "POWER_WAKEUP",
     [PFDI]         = "PFDI",
+    [RME]          = "RME",
+    [GPU]          = "GPU",
 };

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -672,6 +672,14 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_GIC_TEST_NUM_BASE + 12,
         },
+        [S_L3GI_02] = {
+            .test_entry_id    = P046_ENTRY,
+            .module_id        = GIC,
+            .rule_desc        = "Check all MSI(X) vectors are LPIs",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_LINUX,
+            .flag             = BASE_RULE,
+            .test_num         = ACS_PCIE_TEST_NUM_BASE + 46,
+        },
         [B_PPI_00] = {
             .test_entry_id    = B_PPI_00_ENTRY,
             .module_id        = GIC,
@@ -1522,20 +1530,28 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_PCIE_TEST_NUM_BASE + 21,
         },
+        [XDGKZ] = {
+            .test_entry_id    = NULL_ENTRY,
+            .module_id        = GPU,
+            .rule_desc        = "Check GPU devices",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = ALIAS_RULE,
+        },
         [GPU_03] = {
             .test_entry_id    = P093_ENTRY,
-            .module_id        = PCIE,
+            .module_id        = GPU,
             .rule_desc        = "Switches must support ACS if P2P",
             .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
             .flag             = BASE_RULE,
-            .test_num         = ACS_PCIE_TEST_NUM_BASE + 93,
+            .test_num         = ACS_GPU_TEST_NUM_BASE + 01,
         },
         [GPU_04] = {
             .test_entry_id    = GPU_04_ENTRY,
-            .module_id        = PCIE,
+            .module_id        = GPU,
             .rule_desc        = "Check ATS support for RC and SMMU",
             .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
             .flag             = BASE_RULE,
+            .test_num         = ACS_GPU_TEST_NUM_BASE + 02,
         },
         [IE_ACS_1] = {
             .test_entry_id    = P082_ENTRY,
@@ -1974,14 +1990,6 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
             .flag             = BASE_RULE,
             .test_num         = ACS_PCIE_TEST_NUM_BASE + 35,
-        },
-        [S_L3GI_02] = {
-            .test_entry_id    = P046_ENTRY,
-            .module_id        = PCIE,
-            .rule_desc        = "Check all MSI(X) vectors are LPIs",
-            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_LINUX,
-            .flag             = BASE_RULE,
-            .test_num         = ACS_PCIE_TEST_NUM_BASE + 46,
         },
         [S_L4PCI_2] = {
             .test_entry_id    = P087_ENTRY,
@@ -4053,6 +4061,9 @@ RULE_ID_e s_l3pr_01_rule_list[]   = {B_PER_05, RULE_ID_SENTINEL};
 /* S_L3WD_01 */
 RULE_ID_e s_l3wd_01_rule_list[]   = {B_WD_01, B_WD_02, B_WD_03, B_WD_04, B_WD_05,
                                      RULE_ID_SENTINEL};
+/* SBSA l8 GPU rules*/
+RULE_ID_e xdgkz_rule_list[] = {GPU_03, GPU_01, GPU_02, GPU_04, RULE_ID_SENTINEL};
+
 /* S_L6PCI_1 */
 RULE_ID_e s_l6pci_1_rule_list[] = {
     /* S_L6PCI_1 refers B_REP_1 */
@@ -4257,6 +4268,7 @@ alias_rule_map_t alias_rule_map[] = {
     {S_L8SHD_1, s_l8shd_1_rule_list},
     {SYS_RAS,   sys_ras_rule_list},
     {LVQBC,     lvqbc_rule_list},
+    {XDGKZ,     xdgkz_rule_list},
 
     /* PCBSA alias rules */
     {P_L1_01,   bsa_l1_rule_list},


### PR DESCRIPTION
 - When the first rule of a module is not implemented, it is getting reported as part of previous module in logs.
 - Due to this even in systemready log parser the rule is getting reported as part of different modules
 - Corrected this by reordering the enum to have first executable rule of that module at start
 - Defined GPU module to report rules under the SBSA l8 gpu module

Other improv
 - When BSA/SBSA is run at highest verbosity, couple of PCIe prints uses multiple colons which breaks log parser
 - The colons are not bringing any extra readability, having a space is good enough

 - TODO in future
   - Modules which doesn't have even a single executable rule like TME are reported under PCIe right now
   - This will be handled in future as it needs update to RBX f/w

Change-Id: I90520763a8ac9fe5b5daf0475d81d5200a7fa9bd