### PR TITLE
feat(baremetal): Enable MMU and caches on secondary PEs

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -1122,6 +1122,16 @@ typedef struct {
   int32_t  status;             /* command response status code */
 } PCC_MPAM_MSC_WRITE_RESP_PARA;
 
+typedef struct {
+  uint64_t ttbr0;      ///< Translation Table Base Register 0
+  uint64_t ttbr1;      ///< Translation Table Base Register 1
+  uint64_t tcr;        ///< Translation Control Register
+  uint64_t mair;       ///< Memory Attribute Indirection Register
+  uint64_t sctlr;      ///< System Control Register
+  uint32_t current_el; ///< Current Exception Level (1 or 2)
+  uint32_t reserved;   ///< Reserved for alignment
+} PE_MMU_CONFIG;
+
 #define MPAM_FB_PROTOCOL_ID    0x1A
 #define MPAM_MSG_TYPE_CMD      0x0
 #define MPAM_MSC_READ_CMD_ID   0x4

--- a/pal/baremetal/base/src/AArch64/ModuleEntryPoint.S
+++ b/pal/baremetal/base/src/AArch64/ModuleEntryPoint.S
@@ -1,5 +1,5 @@
 #/** @file
-# Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,12 +24,105 @@
 GCC_ASM_IMPORT(ArmReadMpidr)
 GCC_ASM_IMPORT(PalGetSecondaryStackBase)
 GCC_ASM_IMPORT(PalGetMaxMpidr)
+GCC_ASM_IMPORT(PalGetMmuConfigAddr)
 GCC_ASM_EXPORT(ModuleEntryPoint)
 
 StartupAddr:         .8byte ASM_PFX(val_test_entry)
 ASM_PFX(StackSize):  .8byte 0x100
 
+// PE_MMU_CONFIG structure offsets
+.equ MMU_CFG_TTBR0,     0
+.equ MMU_CFG_TTBR1,     8
+.equ MMU_CFG_TCR,       16
+.equ MMU_CFG_MAIR,      24
+.equ MMU_CFG_SCTLR,     32
+.equ MMU_CFG_EL,        40
+
+// SCTLR bits
+.equ SCTLR_M_BIT,       (1 << 0)   // MMU enable
+.equ SCTLR_C_BIT,       (1 << 2)   // Data cache enable
+.equ SCTLR_I_BIT,       (1 << 12)  // Instruction cache enable
+
 ASM_PFX(ModuleEntryPoint):
+//
+  // Enable MMU and caches using primary PE's configuration
+  //
+_EnableMmu:
+  // Get the MMU configuration address from primary PE
+  // Note: This is a C function call, but we haven't set up stack yet
+  // so we use a special calling convention (just branch and link)
+  adr   x9, MmuConfigAddr
+  ldr   x9, [x9]
+  blr   x9
+
+  // x0 now contains the address of PE_MMU_CONFIG structure
+  mov   x11, x0  // Save config address in x11
+
+  // Load all config values from the structure
+  ldr   x12, [x11, #MMU_CFG_TTBR0]  // TTBR0
+  ldr   x13, [x11, #MMU_CFG_TTBR1]  // TTBR1
+  ldr   x14, [x11, #MMU_CFG_TCR]    // TCR
+  ldr   x15, [x11, #MMU_CFG_MAIR]   // MAIR
+  ldr   x16, [x11, #MMU_CFG_SCTLR]  // SCTLR
+  ldr   w17, [x11, #MMU_CFG_EL]     // Current EL (32-bit)
+
+  // Determine current exception level
+  mrs   x18, CurrentEL
+  lsr   x18, x18, 2
+  and   x18, x18, 0x3
+
+  // Check if we're at EL2
+  cmp   x18, #2
+  b.eq  _SetupMmuEl2
+
+_SetupMmuEl1:
+  // Invalidate TLB for EL1
+  tlbi  vmalle1
+  dsb   sy
+  isb
+
+  // Set MAIR, TCR, TTBR0/1 for EL1
+  msr   mair_el1, x15
+  isb
+  msr   tcr_el1, x14
+  isb
+  msr   ttbr0_el1, x12
+  isb
+  msr   ttbr1_el1, x13
+  isb
+
+  // Enable MMU and caches for EL1
+  // Use the same SCTLR value as primary PE (which has M, C, I bits set)
+  msr   sctlr_el1, x16
+  isb
+  b     _MmuEnabled
+
+_SetupMmuEl2:
+  // Invalidate TLB for EL2
+  tlbi  alle2
+  dsb   sy
+  isb
+
+  // Set MAIR, TCR, TTBR0/1 for EL2
+  msr   mair_el2, x15
+  isb
+  msr   tcr_el2, x14
+  isb
+  msr   ttbr0_el2, x12
+  isb
+  msr   ttbr1_el2, x13
+  isb
+
+  // Enable MMU and caches for EL2
+  // Use the same SCTLR value as primary PE (which has M, C, I bits set)
+  msr   sctlr_el2, x16
+  isb
+
+_MmuEnabled:
+  //
+  // MMU and caches are now enabled, proceed with original entry code
+  //
+
   // Get ID of this CPU in Multicore system
   bl    ASM_PFX(ArmReadMpidr)
   // Keep a copy of the MpId register value
@@ -82,3 +175,7 @@ _PrepareArguments:
 
 _NeverReturn:
   b _NeverReturn
+
+// Function pointer for PalGetMmuConfigAddr
+.align 3
+MmuConfigAddr:   .8byte ASM_PFX(PalGetMmuConfigAddr)

--- a/pal/baremetal/base/src/pal_pe.c
+++ b/pal/baremetal/base/src/pal_pe.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,26 @@ extern int32_t gPsciConduit;
 
 uint8_t   *gSecondaryPeStack;
 uint64_t  gMpidrMax;
+
+/**
+  Global MMU configuration structure for secondary PE initialization.
+  This is populated by the primary PE and used by secondary PEs to
+  enable MMU/caches with the same page table configuration.
+**/
+static PE_MMU_CONFIG gMmuConfig __attribute__((aligned(64)));
+
+/* External assembly functions for reading MMU registers */
+uint64_t AA64ReadCurrentEL(void);
+uint64_t AA64ReadTtbr0El1(void);
+uint64_t AA64ReadTtbr0El2(void);
+uint64_t AA64ReadTtbr1El1(void);
+uint64_t AA64ReadTtbr1El2(void);
+uint64_t AA64ReadTcr1(void);
+uint64_t AA64ReadTcr2(void);
+uint64_t AA64ReadMair1(void);
+uint64_t AA64ReadMair2(void);
+uint64_t AA64ReadSctlr1(void);
+uint64_t AA64ReadSctlr2(void);
 
 #define SIZE_STACK_SECONDARY_PE  0x100          //256 bytes per core
 #define UPDATE_AFF_MAX(src,dest,mask)  ((dest & mask) > (src & mask) ? (dest & mask) : (src & mask))
@@ -137,6 +157,65 @@ PalAllocateSecondaryStack(uint64_t mpidr)
 }
 
 /**
+  @brief   Captures the primary PE's MMU configuration for use by secondary PEs.
+           This function reads TTBR0, TCR, MAIR, and SCTLR from the current EL
+           and stores them in a global structure that secondary PEs can access.
+
+  @param   None
+  @return  None
+**/
+static
+void
+PalCaptureMmuConfig(void)
+{
+  uint64_t CurrentEl;
+
+  /* Read current exception level */
+  CurrentEl = (AA64ReadCurrentEL() >> 2) & 0x3;
+  gMmuConfig.current_el = (uint32_t)CurrentEl;
+
+  /* Read MMU configuration registers based on current EL */
+  if (CurrentEl == 2) {
+    gMmuConfig.ttbr0 = AA64ReadTtbr0El2();
+    gMmuConfig.ttbr1 = AA64ReadTtbr1El2();
+    gMmuConfig.tcr   = AA64ReadTcr2();
+    gMmuConfig.mair  = AA64ReadMair2();
+    gMmuConfig.sctlr = AA64ReadSctlr2();
+  } else {
+    /* Assume EL1 */
+    gMmuConfig.ttbr0 = AA64ReadTtbr0El1();
+    gMmuConfig.ttbr1 = AA64ReadTtbr1El1();
+    gMmuConfig.tcr   = AA64ReadTcr1();
+    gMmuConfig.mair  = AA64ReadMair1();
+    gMmuConfig.sctlr = AA64ReadSctlr1();
+  }
+
+  print(ACS_PRINT_INFO,  "  MMU Config captured at EL%d\n", gMmuConfig.current_el);
+  print(ACS_PRINT_DEBUG, "    TTBR0: 0x%lx\n", gMmuConfig.ttbr0);
+  print(ACS_PRINT_DEBUG, "    TTBR1: 0x%lx\n", gMmuConfig.ttbr1);
+  print(ACS_PRINT_DEBUG, "    TCR:   0x%lx\n", gMmuConfig.tcr);
+  print(ACS_PRINT_DEBUG, "    MAIR:  0x%lx\n", gMmuConfig.mair);
+  print(ACS_PRINT_DEBUG, "    SCTLR: 0x%lx\n", gMmuConfig.sctlr);
+
+  /* Clean cache to ensure secondary PEs see the config */
+  pal_pe_data_cache_ops_by_va((uint64_t)&gMmuConfig, CLEAN_AND_INVALIDATE);
+}
+
+/**
+  @brief   Returns the address of the MMU configuration structure.
+           This function is called by secondary PE entry code to get
+           the primary PE's MMU configuration.
+
+  @param   None
+  @return  Address of PE_MMU_CONFIG structure
+**/
+uint64_t
+PalGetMmuConfigAddr(void)
+{
+  return (uint64_t)&gMmuConfig;
+}
+
+/**
   @brief  This API fills in the PE_INFO Table with information about the PEs in the
           system. This is achieved by parsing the ACPI - MADT table.
 
@@ -184,6 +263,10 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
   pal_pe_data_cache_ops_by_va((uint64_t)PeTable, CLEAN_AND_INVALIDATE);
   pal_pe_data_cache_ops_by_va((uint64_t)&gMpidrMax, CLEAN_AND_INVALIDATE);
   PalAllocateSecondaryStack(gMpidrMax);
+
+  /* Capture primary PE's MMU configuration for secondary PE initialization */
+  PalCaptureMmuConfig();
+
 
 }
 

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -195,10 +195,12 @@ typedef struct {
 **/
 typedef struct {
   uint64_t ttbr0;      ///< Translation Table Base Register 0
+  uint64_t ttbr1;      ///< Translation Table Base Register 1
   uint64_t tcr;        ///< Translation Control Register
   uint64_t mair;       ///< Memory Attribute Indirection Register
   uint64_t sctlr;      ///< System Control Register
   uint32_t current_el; ///< Current Exception Level (1 or 2)
+  uint32_t reserved;   ///< Reserved for alignment
 } PE_MMU_CONFIG;
 
 void pal_pe_create_info_table(PE_INFO_TABLE *pe_info_table);


### PR DESCRIPTION
 - Capture primary PE's MMU configuration during PE info table creation
 - Secondary PEs now enable MMU and caches using primary PE's configuration
 - Disable MMU and caches before PSCI CPU_OFF on secondary PEs
 - This ensures consistent memory behavior across all PEs during test execution


Change-Id: I8bd56c1f40a37f23d080de05cb7c6e2bfea57c8b