### PR TITLE
(fix) Capture the unimplemented API log msg in xBSA output log

### DIFF
--- a/pal/uefi_acpi/src/pal_misc.c
+++ b/pal/uefi_acpi/src/pal_misc.c
@@ -217,10 +217,10 @@ pal_warn_not_implemented(const CHAR8 *api_name)
   if (api_name == NULL)
     return;
 
-  acs_print(ACS_PRINT_WARN, L"\n       %a is not implemented."
-                             "\n       Please implement the PAL function in test suite or"
-                             "\n       conduct an offline review for this rule.\n",
-                            api_name);
+  pal_print("\n       %a is not implemented."
+            "\n       Please implement the PAL function in test suite or"
+            "\n       conduct an offline review for this rule.\n",
+              (UINT64)(UINTN)api_name);
 }
 
 /**

--- a/pal/uefi_dt/src/pal_misc.c
+++ b/pal/uefi_dt/src/pal_misc.c
@@ -218,10 +218,10 @@ pal_warn_not_implemented(const CHAR8 *api_name)
   if (api_name == NULL)
     return;
 
-  acs_print(ACS_PRINT_WARN, L"\n       %a is not implemented."
-                             "\n       Please implement the PAL function in test suite or"
-                             "\n       conduct an offline review for this rule.\n",
-                            api_name);
+  pal_print("\n       %a is not implemented."
+            "\n       Please implement the PAL function in test suite or"
+            "\n       conduct an offline review for this rule.\n",
+              (UINT64)(UINTN)api_name);
 }
 
 /**


### PR DESCRIPTION
 - the unimplemented API log msg was not coming in the xBSA log with -f (file) option, since the print was using acs_print
 - change not applicable to BM, as no file output option for BM run

Change-Id: I7dccd14bcf3853b61b9f186c4dff4e47b18c1fb4