### PR TITLE
feat(vbsa): introduce -el1skiptrap CLI parameter

### DIFF
--- a/apps/uefi/acs.h
+++ b/apps/uefi/acs.h
@@ -165,7 +165,7 @@ extern UINT32  g_num_modules;
 extern UINT32 *g_skip_modules;
 extern UINT32  g_num_skip_modules;
 extern UINT32  g_sys_last_lvl_cache;
-extern UINT32  g_el1physkip;
+extern UINT32  g_el1skiptrap_mask;
 extern SHELL_FILE_HANDLE g_acs_log_file_handle;
 extern SHELL_FILE_HANDLE g_dtb_log_file_handle;
 extern RULE_ID_e *g_rule_list;

--- a/apps/uefi/acs_globals.c
+++ b/apps/uefi/acs_globals.c
@@ -50,10 +50,9 @@ UINT32  *g_skip_modules;
 UINT32  g_num_skip_modules = 0;
 UINT32  g_sys_last_lvl_cache;
 
-/* VE systems run acs at EL1 and in some systems crash is observed during access
-   of EL1 phy and virt timer, Below command line option is added only for debug
-   purpose to complete BSA run on these systems */
-UINT32  g_el1physkip = FALSE;
+/* Bitmask of EL1 register accesses to skip (workarounds for EL1 traps)
+   Configured via -el1skiptrap CLI option. */
+UINT32  g_el1skiptrap_mask = 0;
 
 /* File handles */
 SHELL_FILE_HANDLE g_acs_log_file_handle;

--- a/apps/uefi/acs_helpers.c
+++ b/apps/uefi/acs_helpers.c
@@ -982,10 +982,56 @@ command_init (void)
         g_pcie_cache_present = FALSE;
     }
 
-    if (ShellCommandLineGetFlag (ParamPackage, L"-el1physkip")) {
-        /* Flag is applicable when ACS is running at EL1 */
+    /* -el1skiptrap <params>: skip specific EL1 register accesses known to trap under hypervisors */
+    CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-el1skiptrap");
+    if (CmdLineArg != NULL) {
+
+        /* -el1skiptrap only applicable while running ACS at EL1 */
         if (val_pe_reg_read(CurrentEL) == AARCH64_EL1) {
-            g_el1physkip = TRUE;
+
+            UINTN arg_len = StrLen(CmdLineArg);
+            UINTN token_start = 0;
+            UINTN token_end = 0;
+            BOOLEAN invalid_token = FALSE;
+
+            while (token_start < arg_len) {
+                /* find end of token (comma or newline/CR) */
+                token_end = token_start;
+                while (token_end < arg_len && CmdLineArg[token_end] != L','
+                                && CmdLineArg[token_end] != L'\n'
+                                && CmdLineArg[token_end] != L'\r')
+                    token_end++;
+                /* trim */
+                while (token_start < token_end &&
+                    (CmdLineArg[token_start] == L' ' || CmdLineArg[token_start] == L'\t'))
+                    token_start++;
+                while (token_end > token_start &&
+                    (CmdLineArg[token_end-1] == L' ' || CmdLineArg[token_end-1] == L'\t'))
+                    token_end--;
+                if (token_end > token_start) {
+                    CHAR16 token[32];
+                    UINTN  tlen = token_end - token_start;
+                    UINTN  ii;
+                    if (tlen >= (sizeof(token)/sizeof(token[0])))
+                        tlen = (sizeof(token)/sizeof(token[0])) - 1;
+                    for (ii = 0; ii < tlen; ii++) token[ii] = CmdLineArg[token_start + ii];
+                    token[tlen] = L'\0';
+
+                    if (w_ascii_streq_caseins(token, L"pmsidr")) {
+                        g_el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
+                    } else if (w_ascii_streq_caseins(token, L"cntpct")) {
+                        g_el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
+                    } else if (w_ascii_streq_caseins(token, L"devmem")) {
+                        g_el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
+                    } else {
+                        Print(L"Invalid -el1skiptrap token: %s\n", token);
+                        invalid_token = TRUE;
+                    }
+                }
+                token_start = (token_end < arg_len) ? token_end + 1 : token_end;
+            }
+            if (invalid_token)
+                return SHELL_INVALID_PARAMETER;
         }
     }
 

--- a/apps/uefi/bsa_main.c
+++ b/apps/uefi/bsa_main.c
@@ -31,7 +31,7 @@
 CONST SHELL_PARAM_ITEM ParamList[] = {
     {L"-cache", TypeFlag},
     {L"-dtb", TypeValue},
-    {L"-el1physkip", TypeFlag},
+    {L"-el1skiptrap", TypeValue},
     {L"-f", TypeValue},
     {L"-fr", TypeFlag},
     {L"-h", TypeFlag},
@@ -64,11 +64,9 @@ HelpMsg (VOID)
         "-cache  Pass this flag to indicate that if the test system supports\n"
         "        PCIe address translation cache\n"
         "-dtb    Pass this flag to dump DTB file (Device Tree Blob) \n"
-        "-el1physkip \n"
-        "        Skips EL1 register checks\n"
-        "        VE systems run ACS at EL1 and in some systems crash is observed\n"
-        "        during access of EL1 registers, this flag was introduced\n"
-        "        for debugging purposes only.\n"
+        "-el1skiptrap <list>\n"
+        "        Skip specific EL1 register reads known to trap by the hypervisor.\n"
+        "        Tokens: cntpct, devmem, pmsidr\n"
         "-f      Name of the log file to record the test results in\n"
         "-fr     Run rules up to the Future requirements (FR) level.\n"
         "-h, -help\n"

--- a/apps/uefi/mem_test_main.c
+++ b/apps/uefi/mem_test_main.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,13 +62,35 @@ UINT32  g_crypto_support = TRUE;
 UINT32  g_num_tests = 0;
 UINT32  *g_execute_modules;
 UINT32  g_num_modules = 0;
-/* VE systems run acs at EL1 and in some systems crash is observed during acess
-   of EL1 phy and virt timer, Below command line option is added only for debug
-   purpose to complete BSA run on these systems */
-UINT32  g_el1physkip = FALSE;
+UINT32  g_el1skiptrap_mask = 0;
 
 SHELL_FILE_HANDLE g_acs_log_file_handle;
 SHELL_FILE_HANDLE g_dtb_log_file_handle;
+
+static BOOLEAN
+w_ascii_streq_caseins(const CHAR16 *a, const CHAR16 *b)
+{
+  CHAR16 ca;
+  CHAR16 cb;
+
+  if (a == NULL || b == NULL)
+    return FALSE;
+
+  while (*a && *b) {
+    ca = *a;
+    cb = *b;
+    if (ca >= L'A' && ca <= L'Z')
+      ca = (CHAR16)(ca - L'A' + L'a');
+    if (cb >= L'A' && cb <= L'Z')
+      cb = (CHAR16)(cb - L'A' + L'a');
+    if (ca != cb)
+      return FALSE;
+    a++;
+    b++;
+  }
+
+  return (*a == L'\0' && *b == L'\0');
+}
 
 VOID
 HelpMsg (
@@ -109,7 +131,9 @@ HelpMsg (
          "-ps     Enable the execution of platform security tests\n"
          "-dtb    Enable the execution of dtb dump\n"
          "-sbsa   Enable sbsa requirements for bsa binary\n"
-         "-el1physkip Skips EL1 register checks\n"
+         "-el1skiptrap <list>\n"
+         "        Skip specific EL1 register reads known to trap by the hypervisor.\n"
+         "        Tokens: cntpct, devmem, pmsidr\n"
          "-skip-dp-nic-ms Skip PCIe tests for DisplayPort, Network, Mass Storage devices and Unclassified devices\n"
 );
 }
@@ -136,7 +160,7 @@ CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-sbsa", TypeFlag},  // -sbsa # Enable sbsa requirements for bsa binary\n"
   {L"-no_crypto_ext", TypeFlag},  // -no_crypto_ext  # Skip tests which have export restrictions
   {L"-mmio", TypeFlag}, // -mmio # Enable pal_mmio prints
-  {L"-el1physkip", TypeFlag}, // -el1physkip # Skips EL1 register checks
+  {L"-el1skiptrap", TypeValue}, // -el1skiptrap <list> # Skip specific EL1 register reads
   {NULL, TypeMax}
   };
 
@@ -495,8 +519,52 @@ command_init ()
     g_pcie_cache_present = FALSE;
   }
 
-  if (ShellCommandLineGetFlag (ParamPackage, L"-el1physkip")) {
-    g_el1physkip = TRUE;
+  CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-el1skiptrap");
+  if (CmdLineArg != NULL) {
+    UINTN arg_len = StrLen(CmdLineArg);
+    UINTN token_start = 0;
+    UINTN token_end = 0;
+
+    while (token_start < arg_len) {
+      token_end = token_start;
+      while (token_end < arg_len && CmdLineArg[token_end] != L','
+                                 && CmdLineArg[token_end] != L'\n'
+                                 && CmdLineArg[token_end] != L'\r')
+        token_end++;
+
+      while (token_start < token_end &&
+             (CmdLineArg[token_start] == L' ' || CmdLineArg[token_start] == L'\t'))
+        token_start++;
+      while (token_end > token_start &&
+             (CmdLineArg[token_end - 1] == L' ' || CmdLineArg[token_end - 1] == L'\t'))
+        token_end--;
+
+      if (token_end > token_start) {
+        CHAR16 token[32];
+        UINTN tlen = token_end - token_start;
+        UINTN ii;
+
+        if (tlen >= (sizeof(token) / sizeof(token[0])))
+          tlen = (sizeof(token) / sizeof(token[0])) - 1;
+        for (ii = 0; ii < tlen; ii++)
+          token[ii] = CmdLineArg[token_start + ii];
+        token[tlen] = L'\0';
+
+        if (w_ascii_streq_caseins(token, L"pmsidr")) {
+          g_el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
+        } else if (w_ascii_streq_caseins(token, L"cntpct")) {
+          g_el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
+        } else if (w_ascii_streq_caseins(token, L"devmem")) {
+          g_el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
+        } else {
+          Print(L"Invalid -el1skiptrap token: %s\n", token);
+          HelpMsg();
+          return SHELL_INVALID_PARAMETER;
+        }
+      }
+
+      token_start = (token_end < arg_len) ? token_end + 1 : token_end;
+    }
   }
   //
   // Initialize global counters

--- a/apps/uefi/pc_bsa_main.c
+++ b/apps/uefi/pc_bsa_main.c
@@ -30,7 +30,7 @@
 
 /* CLI parameter table for PCBSA ACS, for description refer HelpMsg */
 CONST SHELL_PARAM_ITEM ParamList[] = {
-    {L"-el1physkip", TypeFlag},
+    {L"-el1skiptrap", TypeValue},
     {L"-f", TypeValue},
     {L"-fr", TypeValue},
     {L"-h", TypeFlag},
@@ -54,11 +54,9 @@ HelpMsg (VOID)
 {
     Print (L"\nUsage: PcBsa.efi [options]\n"
         "Options:\n"
-        "-el1physkip \n"
-        "        Skips EL1 register checks\n"
-        "        VE systems run ACS at EL1 and in some systems crash is observed\n"
-        "        during access of EL1 registers, this flag was introduced\n"
-        "        for debugging purposes only.\n"
+        "-el1skiptrap <list>\n"
+        "        Skip specific EL1 register reads known to trap by the hypervisor.\n"
+        "        Tokens: cntpct, devmem, pmsidr\n"
         "-f      Name of the log file to record the test results in\n"
         "-fr     Run rules up to the Future requirements (FR) level.\n"
         "-h, -help\n"

--- a/apps/uefi/sbsa_main.c
+++ b/apps/uefi/sbsa_main.c
@@ -30,7 +30,7 @@
 /* CLI parameter table for SBSA ACS, for description refer HelpMsg */
 CONST SHELL_PARAM_ITEM ParamList[] = {
     {L"-cache", TypeFlag},
-    {L"-el1physkip", TypeFlag},
+    {L"-el1skiptrap", TypeValue},
     {L"-f", TypeValue},
     {L"-fr", TypeValue},
     {L"-h", TypeFlag},
@@ -60,11 +60,9 @@ HelpMsg (VOID)
         "Options:\n"
         "-cache  Pass this flag to indicate that if the test system supports\n"
         "        PCIe address translation cache\n"
-        "-el1physkip \n"
-        "        Skips EL1 register checks\n"
-        "        VE systems run ACS at EL1 and in some systems crash is observed\n"
-        "        during access of EL1 registers, this flag was introduced\n"
-        "        for debugging purposes only.\n"
+        "-el1skiptrap <list>\n"
+        "        Skip specific EL1 register reads known to trap by the hypervisor.\n"
+        "        Tokens: cntpct, devmem, pmsidr\n"
         "-f      Name of the log file to record the test results in\n"
         "-fr     Run rules up to the Future requirements (FR) level.\n"
         "-h, -help\n"

--- a/apps/uefi/sbsa_nist_main.c
+++ b/apps/uefi/sbsa_nist_main.c
@@ -55,10 +55,9 @@ UINT32  g_wakeup_timeout;
 UINT32 g_its_init = 0;
 UINT32  g_sys_last_lvl_cache;
 SHELL_FILE_HANDLE g_acs_log_file_handle;
-/* VE systems run acs at EL1 and in some systems crash is observed during acess
-   of EL1 phy and virt timer, Below command line option is added only for debug
-   purpose to complete SBSA run on these systems */
-UINT32  g_el1physkip = FALSE;
+/* Bitmask of EL1 register accesses to skip in environments where those
+   specific reads are expected to trap. */
+UINT32  g_el1skiptrap_mask = 0;
 UINT32  g_build_sbsa = TRUE;
 
 #define SBSA_LEVEL_PRINT_FORMAT(level, only) ((level > SBSA_MAX_LEVEL_SUPPORTED) ? \
@@ -285,6 +284,31 @@ freeBsaAcsMem()
   val_free_shared_mem();
 }
 
+static BOOLEAN
+w_ascii_streq_caseins(const CHAR16 *a, const CHAR16 *b)
+{
+  CHAR16 ca;
+  CHAR16 cb;
+
+  if (a == NULL || b == NULL)
+    return FALSE;
+
+  while (*a && *b) {
+    ca = *a;
+    cb = *b;
+    if (ca >= L'A' && ca <= L'Z')
+      ca = (CHAR16)(ca - L'A' + L'a');
+    if (cb >= L'A' && cb <= L'Z')
+      cb = (CHAR16)(cb - L'A' + L'a');
+    if (ca != cb)
+      return FALSE;
+    a++;
+    b++;
+  }
+
+  return (*a == L'\0' && *b == L'\0');
+}
+
 VOID
 HelpMsg (
   VOID
@@ -321,7 +345,9 @@ HelpMsg (
          "-slc    Provide system last level cache type\n"
          "        1 - PPTT PE-side cache,  2 - HMAT mem-side cache\n"
          "         defaults to 0, if not set depicting SLC type unknown\n"
-         "-el1physkip Skips EL1 register checks\n"
+         "-el1skiptrap <list>\n"
+         "        Skip specific EL1 register reads known to trap by the hypervisor.\n"
+         "        Tokens: cntpct, devmem, pmsidr\n"
          "-skip-dp-nic-ms Skip PCIe tests for DisplayPort, Network, and Mass Storage devices\n"
   );
 }
@@ -345,7 +371,7 @@ CONST SHELL_PARAM_ITEM ParamList[] = {
   {L"-no_crypto_ext", TypeFlag},  //-no_crypto_ext # Skip tests which have export restrictions
   {L"-timeout" , TypeValue}, // -timeout # Set timeout multiple for wakeup tests
   {L"-slc"  , TypeValue},    // -slc  # system last level cache type
-  {L"-el1physkip", TypeFlag}, // -el1physkip # Skips EL1 register checks
+  {L"-el1skiptrap", TypeValue}, // -el1skiptrap <list> # Skip specific EL1 register reads
   {NULL     , TypeMax}
   };
 
@@ -587,8 +613,52 @@ command_init ()
     g_execute_nist = FALSE;
   }
 
-  if (ShellCommandLineGetFlag (ParamPackage, L"-el1physkip")) {
-    g_el1physkip = TRUE;
+  CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-el1skiptrap");
+  if (CmdLineArg != NULL) {
+    UINTN arg_len = StrLen(CmdLineArg);
+    UINTN token_start = 0;
+    UINTN token_end = 0;
+
+    while (token_start < arg_len) {
+      token_end = token_start;
+      while (token_end < arg_len && CmdLineArg[token_end] != L','
+                                 && CmdLineArg[token_end] != L'\n'
+                                 && CmdLineArg[token_end] != L'\r')
+        token_end++;
+
+      while (token_start < token_end &&
+             (CmdLineArg[token_start] == L' ' || CmdLineArg[token_start] == L'\t'))
+        token_start++;
+      while (token_end > token_start &&
+             (CmdLineArg[token_end - 1] == L' ' || CmdLineArg[token_end - 1] == L'\t'))
+        token_end--;
+
+      if (token_end > token_start) {
+        CHAR16 token[32];
+        UINTN tlen = token_end - token_start;
+        UINTN ii;
+
+        if (tlen >= (sizeof(token) / sizeof(token[0])))
+          tlen = (sizeof(token) / sizeof(token[0])) - 1;
+        for (ii = 0; ii < tlen; ii++)
+          token[ii] = CmdLineArg[token_start + ii];
+        token[tlen] = L'\0';
+
+        if (w_ascii_streq_caseins(token, L"pmsidr")) {
+          g_el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
+        } else if (w_ascii_streq_caseins(token, L"cntpct")) {
+          g_el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
+        } else if (w_ascii_streq_caseins(token, L"devmem")) {
+          g_el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
+        } else {
+          Print(L"Invalid -el1skiptrap token: %s\n", token);
+          HelpMsg();
+          return SHELL_INVALID_PARAMETER;
+        }
+      }
+
+      token_start = (token_end < arg_len) ? token_end + 1 : token_end;
+    }
   }
   //
   // Initialize global counters

--- a/apps/uefi/vbsa_main.c
+++ b/apps/uefi/vbsa_main.c
@@ -30,7 +30,7 @@
 /* CLI parameter table for VBSA ACS, for description refer HelpMsg */
 CONST SHELL_PARAM_ITEM ParamList[] = {
     {L"-cache", TypeFlag},
-    {L"-el1physkip", TypeFlag},
+    {L"-el1skiptrap", TypeValue},
     {L"-f", TypeValue},
     {L"-fr", TypeFlag},
     {L"-h", TypeFlag},
@@ -59,11 +59,9 @@ HelpMsg (VOID)
         "Options:\n"
         "-cache  Pass this flag to indicate that if the test system supports\n"
         "        PCIe address translation cache\n"
-        "-el1physkip \n"
-        "        Skips EL1 register checks\n"
-        "        VE systems run ACS at EL1 and in some systems crash is observed\n"
-        "        during access of EL1 registers, this flag was introduced\n"
-        "        for debugging purposes only.\n"
+        "-el1skiptrap <list>\n"
+        "        Skip specific EL1 register reads known to trap under hypervisors.\n"
+        "        Tokens: cntpct, devmem, pmsidr\n"
         "-f      Name of the log file to record the test results in\n"
         "-fr     Run rules up to the Future requirements (FR) level.\n"
         "-h|-help\n"

--- a/apps/uefi/xbsa_main.c
+++ b/apps/uefi/xbsa_main.c
@@ -34,7 +34,7 @@ CONST SHELL_PARAM_ITEM ParamList[] = {
     {L"-a", TypeValue},
     {L"-cache", TypeFlag},
     {L"-dtb", TypeValue},
-    {L"-el1physkip", TypeFlag},
+    {L"-el1skiptrap", TypeValue},
     {L"-f", TypeValue},
     {L"-fr", TypeFlag},
     {L"-h", TypeFlag},
@@ -72,11 +72,9 @@ HelpMsg (VOID)
         "-cache  Pass this flag to indicate that if the test system supports\n"
         "        PCIe address translation cache\n"
         "-dtb    Pass this flag to dump DTB file (Device Tree Blob) \n"
-        "-el1physkip \n"
-        "        Skips EL1 register checks\n"
-        "        VE systems run ACS at EL1 and in some systems crash is observed\n"
-        "        during access of EL1 registers, this flag was introduced\n"
-        "        for debugging purposes only.\n"
+        "-el1skiptrap <list>\n"
+        "        Skip specific EL1 register reads known to trap by the hypervisor.\n"
+        "        Tokens: cntpct, devmem, pmsidr\n"
         "-f      Name of the log file to record the test results in\n"
         "-fr     Run rules up to the Future requirements (FR) level.\n"
         "        The flag will be validated against -a selected,\n"

--- a/docs/common/cli_args.md
+++ b/docs/common/cli_args.md
@@ -13,7 +13,7 @@ semantics so individual READMEs can simply reference it.
 | `-a {bsa\|sbsa\|pcbsa}` | xBSA | Choose which checklist the composite binary validates; also gates the level validation for `-l`, `-only`, and `-fr`. |
 | `-cache` | BSA & SBSA | Declare that the PCIe hierarchy exposes an address translation cache so PAL enables the related exerciser tests. |
 | `-dtb` | BSA | Dump the platform Device Tree Blob to the active filesystem for debug review. |
-| `-el1physkip` | VBSA | Skip EL1 register accesses when ACS runs at EL1 (for example, under a hypervisor). Use strictly for debug and document the coverage gap. |
+| `-el1skiptrap <tokens>` | VBSA | Skip specific EL1 register reads that trap in the current environment.<br>Supported tokens include `cntpct` for EL1 physical counter accesses, `pmsidr` for `PMSIDR_EL1`, and `devmem` to skip the device-memory phase of `B_MEM_01` and continue with the normal-memory checks;<br>use only when the trap is expected and document the coverage gap. |
 | `-f <path>` | All | Copy UART output to the specified file on the active filesystem (for example, `-f fs0:\logs\run.txt`). |
 | `-fr` | All | Include future-requirement (FR) rules for the selected specification. |
 | `-help`, `-h` | All | Display the full usage banner inside the UEFI shell. |

--- a/docs/vbsa/README.md
+++ b/docs/vbsa/README.md
@@ -96,14 +96,14 @@ lists tailor the coverage to VBSA rules (see the Linux run steps below).
 
 **Example**
 
-`Shell> Vbsa.efi -v 1 -skip V_L2PE_01 -el1physkip -f vbsa.log`
+`Shell> Vbsa.efi -v 1 -skip V_L2PE_01 -el1skiptrap cntpct -f vbsa.log`
 
-Runs at INFO level, skips rule `V_L2PE_01`, enables `-el1physkip` for
+Runs at INFO level, skips rule `V_L2PE_01`, enables `-el1skiptrap cntpct` for
 hypervisors trapping EL1 timers, and captures logs in `vbsa.log`.
 
 > Use VBSA rule IDs that follow the `V_L<level><module>_<nn>` pattern from the
 	[VBSA checklist](arm_vbsa_testcase_checklist.md)
-	(for example, `V_L2PE_01`) with `-skip`/`-r`, and enable `-el1physkip` only when
+	(for example, `V_L2PE_01`) with `-skip`/`-r`, and enable `-el1skiptrap cntpct` only when
 	the hypervisor traps EL1 physical timer accesses; document any coverage gaps.
 
 **Creating a bootable `.img` (Linux host)**
@@ -137,7 +137,7 @@ the specification evolves.
 ### Application arguments
 Refer to [Common CLI arguments](../common/cli_args.md) for the complete
 flag list, including VBSA-specific guidance on skip lists and logging options.\
-That guide also documents VBSA-specific behavior such as the extended module list and the `-el1physkip`
+That guide also documents VBSA-specific behavior such as the extended module list and the `-el1skiptrap`
 option for hypervisor scenarios.
 
 ## Limitations
@@ -149,8 +149,8 @@ option for hypervisor scenarios.
 	available virtual platform.
 
 ## Troubleshoot guide
-- Some hypervisors trap EL1 physical timer access, causing exceptions during
-	VBSA ACS runs. Use `-el1physkip` when necessary, but document the resulting
+- Some hypervisors trap EL1 register accesses, causing exceptions during
+	VBSA ACS runs. Use `-el1skiptrap <register list>` when necessary, but document the resulting
 	coverage gap.
 
 ## Feedback, contributions and support

--- a/docs/vbsa/arm_vbsa_architecture_compliance_test_scenario.md
+++ b/docs/vbsa/arm_vbsa_architecture_compliance_test_scenario.md
@@ -194,7 +194,7 @@ Purpose: capture ACS scenario outlines for each VBSA rule. Each section:
 
 **Scenario**:
 - Detect whether FEAT_ECV is present by reading ID_AA64MMFR0_EL1.ECV and branch accordingly; the run covers 2,000,000 samples to stress the counter monotonicity
-- If physical counter accesses are permitted (g_el1physkip unset), repeatedly read CNTPCTSS_EL0 when FEAT_ECV is implemented, or CNTPCT_EL0 with an ISB barrier otherwise, and fail immediately if any new value is less than the previous sample.
+- If physical counter accesses are permitted (`-el1skiptrap` does not include `cntpct`), repeatedly read CNTPCTSS_EL0 when FEAT_ECV is implemented, or CNTPCT_EL0 with an ISB barrier otherwise, and fail immediately if any new value is less than the previous sample.
 - Always reset the iteration counter and validate the matching virtual counter (CNTVCTSS_EL0 with FEAT_ECV, else CNTVCT_EL0 plus ISB), again flagging any regression.
 - If any decrement is observed the payload records a failure; otherwise the rule passes once all iterations complete.
 

--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -45,6 +45,10 @@ extern uint32_t g_enable_module;
 #define MEM_ALIGN_32K      0x8000
 #define MEM_ALIGN_64K      0x10000
 
+#define EL1SKIPTRAP_PMSIDR   (1u << 0)
+#define EL1SKIPTRAP_CNTPCT   (1u << 1)
+#define EL1SKIPTRAP_DEVMEM   (1u << 2)
+
 #define TRUE 1
 #define FALSE 0
 

--- a/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
@@ -56,11 +56,9 @@ uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules
 uint32_t  g_skip_modules_arr[] = {};
 uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
 
-/* VE systems run acs at EL1 and in some systems crash is observed during access
-   of EL1 phy and virt timer, Below command line option is added only for debug
-   purpose to complete BSA run on these systems
-*/
-uint32_t  g_el1physkip       = FALSE;
+/* Bitmask of EL1 register accesses to skip. For example:
+   g_el1skiptrap_mask = EL1SKIPTRAP_CNTPCT; */
+uint32_t  g_el1skiptrap_mask = 0;
 
 /* B_PE_06 and S_L5PE_05 rules are conditional implementation based on export restrictions
    In case due to export restrictions, cryptography algorithm support is not present, set

--- a/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
@@ -56,11 +56,9 @@ uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules
 uint32_t  g_skip_modules_arr[] = {};
 uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
 
-/* VE systems run acs at EL1 and in some systems crash is observed during access
-   of EL1 phy and virt timer, Below command line option is added only for debug
-   purpose to complete BSA run on these systems
-*/
-uint32_t  g_el1physkip       = FALSE;
+/* Bitmask of EL1 register accesses to skip. For example:
+   g_el1skiptrap_mask = EL1SKIPTRAP_CNTPCT; */
+uint32_t  g_el1skiptrap_mask = 0;
 
 /* B_PE_06 and S_L5PE_05 rules are conditional implementation based on export restrictions
    In case due to export restrictions, cryptography algorithm support is not present, set

--- a/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
@@ -56,11 +56,9 @@ uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules
 uint32_t  g_skip_modules_arr[] = {};
 uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
 
-/* VE systems run acs at EL1 and in some systems crash is observed during access
-   of EL1 phy and virt timer, Below command line option is added only for debug
-   purpose to complete BSA run on these systems
-*/
-uint32_t  g_el1physkip       = FALSE;
+/* Bitmask of EL1 register accesses to skip. For example:
+   g_el1skiptrap_mask = EL1SKIPTRAP_CNTPCT; */
+uint32_t  g_el1skiptrap_mask = 0;
 
 /* B_PE_06 and S_L5PE_05 rules are conditional implementation based on export restrictions
    In case due to export restrictions, cryptography algorithm support is not present, set

--- a/test_pool/gic/g013.c
+++ b/test_pool/gic/g013.c
@@ -37,7 +37,7 @@ payload()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
 
-  if (!g_el1physkip) {
+  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
    /* Check non-secure physical timer interrupt */
    intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
    if (IS_PPI_RESERVED(intid))

--- a/test_pool/memory_map/m002.c
+++ b/test_pool/memory_map/m002.c
@@ -58,6 +58,12 @@ payload()
   val_pe_install_esr(EXCEPT_AARCH64_SERROR, esr);
   val_set_status(index, RESULT_SKIP(TEST_NUM, 1));
 
+  if (g_el1skiptrap_mask & EL1SKIPTRAP_DEVMEM) {
+      val_print(ACS_PRINT_DEBUG,
+                "\n       Skipping device memory access due to -el1skiptrap devmem", 0);
+      goto normal_mem_test;
+  }
+
   branch_to_test = (uint64_t)&&exception_taken_d;
   while (loop_var) {
       timeout = TIMEOUT_SMALL;

--- a/test_pool/pe/pe001.c
+++ b/test_pool/pe/pe001.c
@@ -103,6 +103,13 @@ return_reg_value(uint32_t reg, uint8_t dependency)
 {
   uint64_t temp=0;
 
+  /* Skip specific EL1 register reads if requested via -el1skiptrap */
+  if (reg == PMSIDR_EL1) {
+      if (g_el1skiptrap_mask & EL1SKIPTRAP_PMSIDR) {
+          return 0;
+      }
+  }
+
   if(dependency == 0)
       return val_pe_reg_read(reg);
 

--- a/test_pool/power_wakeup/u001.c
+++ b/test_pool/power_wakeup/u001.c
@@ -96,7 +96,7 @@ u001_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-  if (!g_el1physkip) {
+  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
       val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
       status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
 

--- a/test_pool/power_wakeup/u002.c
+++ b/test_pool/power_wakeup/u002.c
@@ -138,7 +138,7 @@ u002_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-  if (!g_el1physkip) {
+  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
       val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
       status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
 

--- a/test_pool/timer/t008.c
+++ b/test_pool/timer/t008.c
@@ -45,7 +45,7 @@ void payload(void)
         val_print_primary_pe(ACS_PRINT_DEBUG, "\n       FEAT_ECV is Implemented, Reading CntPctSS",
                                                                                         0, index);
 
-        if (g_el1physkip)
+        if (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)
             goto read_virt_ss_timer;
 
         while (iter) {
@@ -89,7 +89,7 @@ read_virt_ss_timer:
     }
     else {
 
-        if (g_el1physkip)
+        if (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)
             goto read_virt_timer;
 
         val_print_primary_pe(ACS_PRINT_DEBUG, "\n       FEAT_ECV isn't Implemented, Reading CntPct",

--- a/val/include/acs_cfg.h
+++ b/val/include/acs_cfg.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2018, 2022-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2018, 2022-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,11 +41,11 @@ extern uint32_t g_num_modules;
 extern uint32_t g_build_sbsa;
 extern uint32_t g_build_pcbsa;
 extern uint32_t g_curr_module;
-extern uint32_t g_el1physkip;
 extern uint32_t g_sys_last_lvl_cache;
 extern uint32_t g_crypto_support;
 extern uint32_t g_drtm_acs_dlme[];
 extern uint64_t g_drtm_acs_dlme_size;
+extern uint32_t g_el1skiptrap_mask;
 
 
 #endif

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -54,6 +54,12 @@
                                                          under test*/
 #define WAKEUP_WD_PASS_TIMEOUT_DEFAULT        1000       /*minimum timeout set
                                                          by default (1ms)*/
+
+/* EL1 skip-trap param defines (-el1skiptrap) */
+#define EL1SKIPTRAP_PMSIDR   (1u << 0)
+#define EL1SKIPTRAP_CNTPCT   (1u << 1)
+#define EL1SKIPTRAP_DEVMEM   (1u << 2)
+
 /* Test status counters visible across ACS */
 typedef struct {
     uint32_t total_rules_run;     /* Total rules/tests that reported a status */

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -247,7 +247,7 @@ val_timer_create_info_table(uint64_t *timer_info_table)
   /* UEFI or other EL1 software may have enabled the EL1 physical/virtual timer.
      Disable the timers to prevent interrupts at un-expected times */
 
-  if (!g_el1physkip) {
+  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
      val_timer_set_phy_el1(0);
      val_timer_set_vir_el1(0);
   }

--- a/val/src/bsa_execute_test.c
+++ b/val/src/bsa_execute_test.c
@@ -228,7 +228,7 @@ val_bsa_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
           }
 
           status |= g005_entry(num_pe);
-          if (!g_el1physkip)
+          if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT))
               status |= g006_entry(num_pe);
 
           status |= g007_entry(num_pe);

--- a/val/src/test_wrappers.c
+++ b/val/src/test_wrappers.c
@@ -378,7 +378,7 @@ v_l1wk_02_05_entry(uint32_t num_pe)
     return TEST_SKIP;
 #endif
 
-    if (g_el1physkip) {
+    if (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT) {
         val_print(ACS_PRINT_TEST,
                     "\n       Skipping rule as EL1 physical timer access not supported", 0);
         return TEST_SKIP;
@@ -408,7 +408,8 @@ v_l1pp_00_entry(uint32_t num_pe)
     TEST_ENTRY_ID_e skip_list[] = {G007_ENTRY, TEST_ENTRY_SENTINEL};
     TEST_ENTRY_ID_e default_list[] = {G006_ENTRY, G007_ENTRY, TEST_ENTRY_SENTINEL};
 
-    TEST_ENTRY_ID_e *entry_list = g_el1physkip ? skip_list : default_list;
+    TEST_ENTRY_ID_e *entry_list =
+        (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT) ? skip_list : default_list;
 
     return run_test_entries(entry_list, num_pe);
 }


### PR DESCRIPTION
 - Introduce VBSA CLI option -el1skiptrap pmsidr and g_el1skiptrap_mask to bypass PMSIDR_EL1 reads that may trap at EL1
 - Guard the reg access in pe001.c. Behaviour of the test is unchanged unless CLI parameter is passed
 - deprecate -el1physkip option that dupclicates -el1skiptrap functionality
 - guard EL1 physical counter accesses using -el1skiptrap


Change-Id: If194066e876fb06d9fa308c4f0526a6d88801f05