### PR TITLE
(improv) Handle cases where test interrupt and failsafe interrupt arrives around same time

### DIFF
--- a/test_pool/power_wakeup/u002.c
+++ b/test_pool/power_wakeup/u002.c
@@ -39,7 +39,14 @@ isr_failsafe()
   val_timer_set_phy_el1(0);
   val_print(ACS_PRINT_ERR, "       Received Failsafe interrupt\n", 0);
   g_failsafe_int_rcvd = 1;
-  val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
+
+  /* On some system the failsafe is rcvd just after test interrupt and resulting
+     in incorrect fail, to avoid this ensure set test as fail only when failsafe
+     is hit and test interrupt is not rcvd
+  */
+  if (g_el1vir_int_received == 0) {
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 2));
+  }
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
 }
@@ -76,6 +83,8 @@ isr2()
   val_set_status(index, RESULT_PASS(TEST_NUM, 1));
   intid = val_timer_get_info(TIMER_INFO_VIR_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
+  val_timer_set_phy_el1(0);
+  val_print(ACS_PRINT_DEBUG, "       Clear Failsafe interrupt\n", 0);
 }
 
 static
@@ -119,6 +128,7 @@ payload2()
    * 5. Hang, if PE didn't exit WFI (FAIL)
   */
   wakeup_clear_failsafe();
+
   if (!(g_el1vir_int_received || g_failsafe_int_rcvd)) {
       val_timer_set_vir_el1(0);
       intid = val_timer_get_info(TIMER_INFO_VIR_EL1_INTID, 0);

--- a/test_pool/power_wakeup/u003.c
+++ b/test_pool/power_wakeup/u003.c
@@ -39,7 +39,13 @@ isr_failsafe()
   val_timer_set_phy_el1(0);
   val_print(ACS_PRINT_ERR, "       Received Failsafe interrupt\n", 0);
   g_failsafe_int_rcvd = 1;
-  val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+  /* On some system the failsafe is rcvd just after test interrupt and resulting
+     in incorrect fail, to avoid this ensure set test as fail only when failsafe
+     is hit and test interrupt is not rcvd
+  */
+  if (g_el2phy_int_rcvd == 0) {
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+  }
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
 }
@@ -58,6 +64,8 @@ isr3()
   val_set_status(index, RESULT_PASS(TEST_NUM, 1));
   intid = val_timer_get_info(TIMER_INFO_PHY_EL2_INTID, 0);
   val_gic_end_of_interrupt(intid);
+  val_timer_set_phy_el1(0);
+  val_print(ACS_PRINT_DEBUG, "       Clear Failsafe interrupt\n", 0);
 }
 
 static

--- a/test_pool/power_wakeup/u004.c
+++ b/test_pool/power_wakeup/u004.c
@@ -40,7 +40,13 @@ isr_failsafe()
   val_timer_set_phy_el1(0);
   val_print(ACS_PRINT_ERR, "       Received Failsafe interrupt\n", 0);
   g_failsafe_int_received = 1;
-  val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+  /* On some system the failsafe is rcvd just after test interrupt and resulting
+     in incorrect fail, to avoid this ensure set test as fail only when failsafe
+     is hit and test interrupt is not rcvd
+  */
+  if (g_wd_int_received == 0) {
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+  }
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
 }
@@ -54,9 +60,10 @@ isr4()
   val_wd_set_ws0(wd_num, 0);
   val_print(ACS_PRINT_INFO, "       Received WS0 interrupt\n", 0);
   g_wd_int_received = 1;
-
   intid = val_wd_get_info(wd_num, WD_INFO_GSIV);
   val_gic_end_of_interrupt(intid);
+  val_timer_set_phy_el1(0);
+  val_print(ACS_PRINT_DEBUG, "       Clear Failsafe interrupt\n", 0);
 }
 
 static

--- a/test_pool/power_wakeup/u005.c
+++ b/test_pool/power_wakeup/u005.c
@@ -40,6 +40,13 @@ isr_failsafe()
   val_timer_set_phy_el1(0);
   val_print(ACS_PRINT_ERR, "       Received Failsafe interrupt\n", 0);
   g_failsafe_int_rcvd = 1;
+  /* On some system the failsafe is rcvd just after test interrupt and resulting
+     in incorrect fail, to avoid this ensure set test as fail only when failsafe
+     is hit and test interrupt is not rcvd
+  */
+  if (g_timer_int_rcvd == 0) {
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
+  }
   val_set_status(index, RESULT_FAIL(TEST_NUM, 1));
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
@@ -59,6 +66,8 @@ isr5()
   val_set_status(index, RESULT_PASS(TEST_NUM, 1));
   intid = val_timer_get_info(TIMER_INFO_SYS_INTID, timer_num);
   val_gic_end_of_interrupt(intid);
+  val_timer_set_phy_el1(0);
+  val_print(ACS_PRINT_DEBUG, "       Clear Failsafe interrupt\n", 0);
 }
 
 static
@@ -125,7 +134,7 @@ payload5()
           wakeup_set_failsafe();
           /* enable System timer */
           val_timer_set_system_timer((addr_t)cnt_base_n, timer_expire_val);
-	  val_power_enter_semantic(BSA_POWER_SEM_B);
+          val_power_enter_semantic(BSA_POWER_SEM_B);
 
           /* Add a delay loop after WFI called in case PE needs some time to enter WFI state
            * exit in case test or failsafe int is received
@@ -148,13 +157,13 @@ payload5()
           wakeup_clear_failsafe();
           if (!(g_timer_int_rcvd || g_failsafe_int_rcvd)) {
               intid = val_timer_get_info(TIMER_INFO_SYS_INTID, timer_num);
-	      val_gic_clear_interrupt(intid);
+              val_gic_clear_interrupt(intid);
               val_set_status(index, RESULT_SKIP(TEST_NUM, 4));
               val_print(ACS_PRINT_DEBUG,
                         "\n       PE wakeup by some other events/int or didn't enter WFI", 0);
           }
           val_print(ACS_PRINT_INFO, "\n       delay loop remainig value %d", delay_loop);
-	  return;
+          return;
 
       } else{
           val_print(ACS_PRINT_WARN, "\n       GIC Install Handler Failed...", 0);

--- a/test_pool/watchdog/w002.c
+++ b/test_pool/watchdog/w002.c
@@ -41,12 +41,13 @@ static
 void
 isr()
 {
-
     val_wd_set_ws0(wd_num, 0);
     g_wd_int_received = 1;
     val_print(ACS_PRINT_DEBUG, "\n       Received WS0 interrupt                ", 0);
-
     val_gic_end_of_interrupt(int_id);
+
+    val_timer_set_phy_el1(0);
+    val_print(ACS_PRINT_DEBUG, "       Clear Failsafe interrupt\n", 0);
 }
 
 static
@@ -59,7 +60,14 @@ isr_failsafe()
   val_timer_set_phy_el1(0);
   val_print(ACS_PRINT_ERR, "       Received Failsafe interrupt\n", 0);
   g_failsafe_int_received = 1;
-  val_set_status(index, RESULT_FAIL(TEST_NUM, 7));
+
+  /* On some system the failsafe is rcvd just after test interrupt and resulting
+     in incorrect fail, to avoid this ensure set test as fail only when failsafe
+     is hit and test interrupt is not rcvd
+  */
+  if (g_wd_int_received == 0) {
+      val_set_status(index, RESULT_FAIL(TEST_NUM, 7));
+  }
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
 }
@@ -152,18 +160,18 @@ payload()
           val_data_cache_ops_by_va((addr_t)&g_failsafe_int_received, INVALIDATE);
           timeout--;
         }
-        wakeup_clear_failsafe();
 
+        wakeup_clear_failsafe();
         val_wd_set_ws0(wd_num, 0);
 
-        if (g_failsafe_int_received) {
+        if (g_failsafe_int_received && (g_wd_int_received == 0)) {
           val_print(ACS_PRINT_ERR, "\n       Failsafe interrupt received, no WS0 interrupt", 0);
           val_set_status(index, RESULT_FAIL(TEST_NUM, 7));
           return;
         }
 
-        if (timeout == 0) {
-            val_print(ACS_PRINT_ERR, "\n       WS0 Interrupt not received on %d   ", int_id);
+        if ((timeout == 0) && (g_wd_int_received == 0)) {
+            val_print(ACS_PRINT_ERR, "\n       WS0 Interrupt not rcvd within timeout %d", int_id);
             val_set_status(index, RESULT_FAIL(TEST_NUM, 5));
             return;
         }

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -49,7 +49,7 @@
                                                          set for wakeup and wd tests*/
 #define WAKEUP_WD_PASS_TIMEOUT_MAX_THRESHOLD  2000000    /*minimum timeout that can be
                                                          set for wakeup and wd tests*/
-#define WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER 2          /*fail safe timeout multipler
+#define WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER 100        /*fail safe timeout multipler
                                                          multiplied to timeout of ISR
                                                          under test*/
 #define WAKEUP_WD_PASS_TIMEOUT_DEFAULT        1000       /*minimum timeout set


### PR DESCRIPTION


 - On some systems with higher verbosity run, the wd and wakeup tests fails due to test and failsafe interrupt both coming together
 - Handle this case by marking test fail only when failsafe has arrived but test interrupt is not received
 - Increase the failsafe interrupt timeout relative to test interrupt to work on Silicon systems

Fixes #292 
Change-Id: Ic7c4985a7ee09ea25eee32dc02a0c0a1f210e030