### PR TITLE
Documentation enhancements for VBSA ACS

### DIFF
--- a/docs/vbsa/arm_vbsa_architecture_compliance_test_scenario.md
+++ b/docs/vbsa/arm_vbsa_architecture_compliance_test_scenario.md
@@ -158,7 +158,7 @@ Purpose: capture ACS scenario outlines for each VBSA rule. Each section:
 ---
 
 ### V_L1SM_03 — Boot devices not blocked by SMMU
-**Summary**: Test to cover this rule is not implemented and requires manual verification by the VE owner
+**Summary**: For compliance with this rule, ACS recommends that the VE owner be able to boot an off-the-shelf OS successfully on the virtual environment.
 
 ---
 

--- a/docs/vbsa/arm_vbsa_testcase_checklist.md
+++ b/docs/vbsa/arm_vbsa_testcase_checklist.md
@@ -331,7 +331,7 @@ The checklist provides information about:
       <td></td>
       <td></td>
       <td></td>
-      <td></td>
+      <td>Manual testing required</td>
     </tr>
     <tr>
       <td>L1</td>


### PR DESCRIPTION
- clarify ACS guidance that VE owners must manually verify V_L1SM_03 by booting OS on VE
- update testcase checklist and scenario doc to call out manual testing requirement
- add missing subrules for V_L1TM_03, V_L1WK_04, V_L1WK_06
- include details of "related rules from other specifications" to better align with and reflect VBSA specification