### PR TITLE
test status aggregation changes

### DIFF
--- a/val/src/rule_based_orchestrator.c
+++ b/val/src/rule_based_orchestrator.c
@@ -410,6 +410,7 @@ run_tests(RULE_ID_e *rule_list, uint32_t list_size)
 {
     bool test_ns_flag;
     bool test_pass_flag;
+    bool test_warn_flag;
     uint32_t i, j;
     uint32_t alias_rule_map_index;
     uint32_t rule_test_status;
@@ -495,6 +496,8 @@ run_tests(RULE_ID_e *rule_list, uint32_t list_size)
             test_ns_flag = 0;
             /* track whether any base rule completed with PASS */
             test_pass_flag = 0;
+            /* track whether any base rule completed with WARN */
+            test_warn_flag = 0;
             /* convenience alias to the base rule list for this alias */
             base_rule_list = alias_rule_map[alias_rule_map_index].base_rule_list;
 
@@ -541,6 +544,8 @@ run_tests(RULE_ID_e *rule_list, uint32_t list_size)
                 rule_status_map[base_rule_id] = base_rule_status;
                 if (base_rule_status == TEST_PASS)
                     test_pass_flag = 1;
+                if (base_rule_status == TEST_WARN)
+                    test_warn_flag = 1;
                 /* report status of base rule run */
                 print_rule_test_status(base_rule_list[j], 1, base_rule_status);
                 /* update overall alias rule status */
@@ -559,6 +564,10 @@ run_tests(RULE_ID_e *rule_list, uint32_t list_size)
                   (rule_test_status == TEST_WARN))) ||
                 (test_ns_flag && (rule_test_status == TEST_PASS))) {
                 rule_test_status = TEST_PART_COV;
+            }
+            /* If the alias only saw WARN/SKIP outcomes, prefer WARN over SKIP. */
+            if (test_warn_flag && (rule_test_status == TEST_SKIP)) {
+                rule_test_status = TEST_WARN;
             }
 
             /* Print end header for alias rule */

--- a/val/src/test_wrappers.c
+++ b/val/src/test_wrappers.c
@@ -41,6 +41,7 @@ static uint32_t run_test_entries(TEST_ENTRY_ID_e *tst_entry_list, uint32_t num_p
     uint32_t rule_status = TEST_STATUS_UNKNOWN;
     bool test_pass_flag = 0;
     bool test_ns_flag = 0;
+    bool test_warn_flag = 0;
 
     for (i = 0; tst_entry_list[i] != TEST_ENTRY_SENTINEL ; i++) {
         if (test_entry_func_table[tst_entry_list[i]] != NULL) {
@@ -55,6 +56,10 @@ static uint32_t run_test_entries(TEST_ENTRY_ID_e *tst_entry_list, uint32_t num_p
         if (entry_status == TEST_PASS) {
             test_pass_flag = 1;
         }
+        /* Track atleast one warn */
+        if (entry_status == TEST_WARN) {
+            test_warn_flag = 1;
+        }
 
         /* Update overall status for the rule */
         if ((entry_status > rule_status) || (rule_status == TEST_STATUS_UNKNOWN)) {
@@ -68,6 +73,11 @@ static uint32_t run_test_entries(TEST_ENTRY_ID_e *tst_entry_list, uint32_t num_p
         ((rule_status == TEST_SKIP) || (rule_status == TEST_WARN))) ||
         (test_ns_flag && (rule_status == TEST_PASS))) {
         rule_status = TEST_PART_COV;
+    }
+
+    /* If the combined result only saw WARN/SKIP outcomes, prefer WARN over SKIP. */
+    if (test_warn_flag && (rule_status == TEST_SKIP)) {
+        rule_status = TEST_WARN;
     }
 
     return rule_status;
@@ -85,6 +95,7 @@ static uint32_t run_pcie_static_and_exerciser(TEST_ENTRY_ID_e *static_list,
 {
     uint32_t static_status = run_test_entries(static_list, num_pe);
     uint32_t exr_status    = run_test_entries(exr_list,   num_pe);
+    uint32_t rule_status;
 
     /* Report partial coverage for mixed PASS+SKIP/WARN aggregated results. */
     if (((static_status == TEST_PASS) &&
@@ -93,7 +104,15 @@ static uint32_t run_pcie_static_and_exerciser(TEST_ENTRY_ID_e *static_list,
         ((static_status == TEST_SKIP) || (static_status == TEST_WARN))))
         return TEST_PART_COV;
 
-    return max_status(static_status, exr_status);
+    /* For all other combinations, fall back to severity-based aggregation. */
+    rule_status = max_status(static_status, exr_status);
+    /* If the combined result only saw WARN/SKIP outcomes, prefer WARN over SKIP. */
+    if (((static_status == TEST_WARN) || (exr_status == TEST_WARN)) &&
+        (rule_status == TEST_SKIP)) {
+        rule_status = TEST_WARN;
+    }
+
+    return rule_status;
 }
 
 /* B_PPI_00 */


### PR DESCRIPTION
- run_test_entries() now returns TEST_PART_COV for mixed PASS+SKIP/WARN results.
- run_pcie_static_and_exerciser() now applies the same rule to combined aggregated statuses.
- Existing FAIL precedence and max-status behavior remain unchanged for other combinations.
- track warning outcomes during alias and wrapper aggregation
- return TEST_WARN instead of TEST_SKIP when aggregated results contain only warn/skip statuses
- keep existing FAIL and TEST_PART_COV handling unchanged