### PR TITLE
Remove redundant preprocessor checks in VAL files

### DIFF
--- a/val/include/val_logger.h
+++ b/val/include/val_logger.h
@@ -8,15 +8,8 @@
 #ifndef VAL_LOG_H
 #define VAL_LOG_H
 
-#ifdef TARGET_UEFI
-#include <stddef.h>
-#elif !defined(TARGET_LINUX)
-#include <stdint.h>
-#include <stddef.h>
-#include <stdarg.h>
-#endif
-
 #include "pal_interface.h"
+#include "pal_common_intf.h"
 
 /* Verbosity enums, Lower the value, higher the verbosity */
 typedef enum {

--- a/val/include/val_status.h
+++ b/val/include/val_status.h
@@ -17,8 +17,8 @@
 #ifndef VAL_STATUS_H
 #define VAL_STATUS_H
 
-#if !defined(TARGET_UEFI) && !defined(TARGET_LINUX)
-#include <stdint.h>
+#if !defined(TARGET_LINUX)
+#include <stdbool.h>
 #endif
 
 #include "pal_interface.h"

--- a/val/include/val_sysreg.h
+++ b/val/include/val_sysreg.h
@@ -8,16 +8,9 @@
 #ifndef VAL_SYSREG_H
 #define VAL_SYSREG_H
 
-#ifdef TARGET_UEFI
-#include <stddef.h>
-#elif !defined(TARGET_LINUX)
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
-#endif
-
 #include "val_arch.h"
 #include "pal_interface.h"
+#include "pal_common_intf.h"
 
 typedef unsigned long u_register_t;
 

--- a/val/src/val_logger.c
+++ b/val/src/val_logger.c
@@ -5,8 +5,7 @@
  *
  */
 
-#include "include/val_logger.h"
-#include "include/pal_common_intf.h"
+#include "val_logger.h"
 
 static void val_putc(char c)
 {


### PR DESCRIPTION
Optimized preprocessor include directives in VAL files

Change-Id: Ie6a5437588bc53b262357e342321c083f85b9b90