### PR TITLE
coverity - fix issues in test_pool for coverity reported issues

### DIFF
--- a/test_pool/exerciser/e002.c
+++ b/test_pool/exerciser/e002.c
@@ -91,7 +91,6 @@ get_target_exer_bdf(uint32_t req_rp_bdf, uint32_t *tgt_e_bdf,
 static
 uint32_t
 create_va_pa_mapping (uint64_t txn_va, uint64_t txn_pa,
-                      smmu_master_attributes_t *smmu_master,
                       pgt_descriptor_t *pgt_desc, uint32_t req_instance,
                       uint32_t req_rp_bdf, uint32_t pgt_ap)
 {
@@ -105,8 +104,6 @@ create_va_pa_mapping (uint64_t txn_va, uint64_t txn_pa,
   uint32_t status, dma_status;
   uint64_t bar_value;
   uint32_t old_val, new_val;
-
-  master = *smmu_master;
 
   val_memory_set(&master, sizeof(master), 0);
   val_memory_set(mem_desc_array, sizeof(mem_desc_array), 0);
@@ -244,7 +241,6 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
   uint32_t instance;
   uint32_t num_smmus;
   uint32_t status;
-  smmu_master_attributes_t master;
   pgt_descriptor_t pgt_desc;
 
   /* Sequence 1 : No Write Permission, Trigger a DMA Write to bar address
@@ -259,7 +255,7 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
 
   num_smmus = val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
 
-  status = create_va_pa_mapping(txn_va, bar_base, &master,
+  status = create_va_pa_mapping(txn_va, bar_base,
                                 &pgt_desc, req_instance,
                                 req_rp_bdf, PGT_STAGE1_AP_RO);
   if (status) {
@@ -286,7 +282,7 @@ check_redirected_req_validation (uint32_t req_instance, uint32_t req_rp_bdf, uin
    */
 
   /* Create VA-PA Mapping in SMMU with PGT permissions as Read Write */
-  status = create_va_pa_mapping(txn_va, bar_base, &master,
+  status = create_va_pa_mapping(txn_va, bar_base,
                                 &pgt_desc, req_instance,
                                 req_rp_bdf, PGT_STAGE1_AP_RW);
   if (status) {

--- a/test_pool/exerciser/e039.c
+++ b/test_pool/exerciser/e039.c
@@ -50,7 +50,7 @@ static
 void
 payload(void)
 {
-  char *baseptr;
+  char *baseptr = NULL;
   uint32_t idx;
   uint32_t pe_index;
   uint32_t bdf;
@@ -101,6 +101,7 @@ payload(void)
 
         /* Map the mmio space to ARM normal memory in MMU page tables */
         for (idx = 0; idx < sizeof(ARM_NORMAL_MEM_ARRAY)/sizeof(ARM_NORMAL_MEM_ARRAY[0]); idx++) {
+          baseptr = NULL;
             status = val_memory_ioremap((void *)e_data.bar_space.base_addr,
                                                     512,
                                                     ARM_NORMAL_MEM_ARRAY[idx], (void **)&baseptr);
@@ -129,6 +130,7 @@ payload(void)
 
             /* Remove BAR mapping from MMU page tables */
             val_memory_unmap(baseptr);
+            baseptr = NULL;
         }
     }
   }
@@ -144,12 +146,14 @@ payload(void)
   return;
 
 test_warn_unimplemented:
-  val_memory_unmap(baseptr);
+  if (baseptr != NULL)
+      val_memory_unmap(baseptr);
   val_set_status(pe_index, RESULT_WARNING(01));
   return;
 
 test_fail:
-  val_memory_unmap(baseptr);
+  if (baseptr != NULL)
+      val_memory_unmap(baseptr);
   val_set_status(pe_index, RESULT_FAIL(03));
   return;
 

--- a/test_pool/gic/its004.c
+++ b/test_pool/gic/its004.c
@@ -104,20 +104,22 @@ payload()
       continue;
   }
 
-  val_print(DEBUG,
-                  "\n       Checking ReqID-StreamID-DeviceID Association, Bdf : %x", bdf);
-  /* Check for stream_id & device_id */
-  if (curr_grp_sid_cons != (stream_id - req_id)) {
-      /* StreamID Constant Base Failure */
-      val_print(ERROR, "\n       ReqID-StreamID Association Fail for Bdf : %x", bdf);
-      test_fail++;
-  }
+  if (!test_skip) {
+      val_print(DEBUG,
+                      "\n       Checking ReqID-StreamID-DeviceID Association, Bdf : %x", bdf);
+      /* Check for stream_id & device_id */
+      if (curr_grp_sid_cons != (stream_id - req_id)) {
+          /* StreamID Constant Base Failure */
+          val_print(ERROR, "\n       ReqID-StreamID Association Fail for Bdf : %x", bdf);
+          test_fail++;
+      }
 
-  if (curr_grp_did_cons != (device_id - stream_id)) {
-      /* DeviceID Constant Base Failure */
-      val_print(ERROR,
-                    "\n       StreamID-DeviceID Association Fail for Bdf : %x", bdf);
-      test_fail++;
+      if (curr_grp_did_cons != (device_id - stream_id)) {
+          /* DeviceID Constant Base Failure */
+          val_print(ERROR,
+                        "\n       StreamID-DeviceID Association Fail for Bdf : %x", bdf);
+          test_fail++;
+      }
   }
 
   if (test_skip == 1)

--- a/test_pool/pcie/p002.c
+++ b/test_pool/pcie/p002.c
@@ -72,8 +72,10 @@ calculate_vf(uint32_t seg, uint32_t bdf, uint32_t sriov_base)
   val_print(TRACE, "\n    Number of VF's is 0x%x", num_vf);
 
   vf_rid = pf_rid + first_vf_offset;
-  if (num_vf > MAX_VFS)
-     val_print(WARN, "\n    Number of VF's present is more than 256");
+  if (num_vf > MAX_VFS) {
+     val_print(WARN, "\n    Number of VF's present is more than 256. Limiting to 256 entries");
+     num_vf = MAX_VFS;
+  }
 
   for (index = 0; index < num_vf; index++)
   {
@@ -83,8 +85,6 @@ calculate_vf(uint32_t seg, uint32_t bdf, uint32_t sriov_base)
      val_print(TRACE, "\n    vf bdf is 0x%x", vf_bdf);
      skip_rid_list[index] = vf_bdf;
      vf_rid += vf_stride;
-     if (index > MAX_VFS)
-         val_print(WARN, "\n    Index value is more than 255");
   }
 }
 

--- a/test_pool/timer/t001.c
+++ b/test_pool/timer/t001.c
@@ -54,7 +54,7 @@ static
 void
 payload_check_system_timer_freq()
 {
-  uint64_t counter_freq, print_freq;
+  uint64_t counter_freq, print_freq = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t print_mhz = 0;
 
@@ -62,12 +62,10 @@ payload_check_system_timer_freq()
   counter_freq = val_timer_get_info(TIMER_INFO_CNTFREQ, 0);
 
   /* Convert frequency into MHz or KHz unit */
-  if (counter_freq != 0) {
-      print_freq = counter_freq/1000;
-      if (print_freq > 1000) {
-          print_freq = print_freq/1000;
-          print_mhz = 1;
-      }
+  print_freq = counter_freq/1000;
+  if (print_freq > 1000) {
+      print_freq = print_freq/1000;
+      print_mhz = 1;
   }
 
   /* Print counter frequency in DEBUG verbosity */


### PR DESCRIPTION
 - coverity scan found issues in the acs test code, around un-initialised variables
    and un-initialised pinter reads in different tests, they are fixed.

Change-Id: I0937130130e03d1550937556a3d33e8e830bcdcf