### PR TITLE
Unify common LibC helpers in VAL

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -786,7 +786,6 @@ typedef enum {
 
 /* LibC functions declaration */
 
-int32_t pal_mem_compare(void *Src, void *Dest, uint32_t Len);
 void *pal_memcpy(void *DestinationBuffer, const void *SourceBuffer, uint32_t Length);
 void *pal_strncpy(void *DestinationStr, const void *SourceStr, uint32_t Length);
 uint32_t pal_strncmp(const char8_t *str1, const char8_t *str2, uint32_t len);

--- a/pal/baremetal/base/src/pal_misc.c
+++ b/pal/baremetal/base/src/pal_misc.c
@@ -417,20 +417,6 @@ void *pal_strncpy(void *DestinationStr, const void *SourceStr, uint32_t Length)
   return ptr;
 }
 
-int32_t
-pal_mem_compare(void *Src, void *Dest, uint32_t Len)
-{
-    if (Len != 0) {
-    register const unsigned char *p1 = Dest, *p2 = Src;
-
-    do {
-      if (*p1++ != *p2++)
-        return (*--p1 - *--p2);
-    } while (--Len != 0);
-  }
-  return (0);
-}
-
 void
 pal_mem_set(void *buf, uint32_t size, uint8_t value)
 {

--- a/pal/uefi_acpi/src/pal_misc.c
+++ b/pal/uefi_acpi/src/pal_misc.c
@@ -294,42 +294,6 @@ pal_mem_free(VOID *Buffer)
 }
 
 /**
-  @brief  Compare the contents of the src and dest buffers
-  @param  Src   - source buffer to be compared
-  @param  Dest  - destination buffer to be compared
-  @param  Len   - Length of the comparison to be performed
-
-  @return Zero if the buffer contecnts are same, else Nonzero
-**/
-UINT32
-pal_mem_compare (
-  VOID *Src,
-  VOID *Dest,
-  UINT32 Len
-  )
-{
-  return CompareMem (Src, Dest, Len);
-}
-
-/**
-  @brie a buffer with a known specified input value
-  @param  Buf   - Pointer to the buffer to fill
-  @param  Size  - Number of bytes in buffer to fill
-  @param  Value - Value to fill buffer with
-
-  @return None
-**/
-VOID
-pal_mem_set (
-  VOID *Buf,
-  UINT32 Size,
-  UINT8 Value
-  )
-{
-  SetMem(Buf, Size, Value);
-}
-
-/**
   @brief  Allocate memory which is to be used to share data across PEs
 
   @param  num_pe      - Number of PEs in the system
@@ -477,45 +441,6 @@ pal_mem_phys_to_virt (
   )
 {
   return (VOID*)Pa;
-}
-
-/**
-  @brief  Compares two strings
-
-  @param  FirstString   The pointer to a Null-terminated ASCII string.
-  @param  SecondString  The pointer to a Null-terminated ASCII string.
-  @param  Length        The maximum number of ASCII characters for compare.
-
-  @return Zero if strings are identical, else non-zero value
-**/
-UINT32
-pal_strncmp (
-  CHAR8 *FirstString,
-  CHAR8 *SecondString,
-  UINT32 Length
-  )
-{
-  return AsciiStrnCmp(FirstString, SecondString, Length);
-}
-
-/**
-  Copies a source buffer to a destination buffer, and returns the destination buffer.
-
-  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
-  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
-  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
-
-  @return DestinationBuffer.
-
-**/
-VOID *
-pal_memcpy (
-  VOID *DestinationBuffer,
-  VOID *SourceBuffer,
-  UINT32 Length
-  )
-{
-  return CopyMem (DestinationBuffer, SourceBuffer, Length);
 }
 
 /**

--- a/pal/uefi_dt/src/pal_misc.c
+++ b/pal/uefi_dt/src/pal_misc.c
@@ -294,42 +294,6 @@ pal_mem_free(VOID *Buffer)
 }
 
 /**
-  @brief  Compare the contents of the src and dest buffers
-  @param  Src   - source buffer to be compared
-  @param  Dest  - destination buffer to be compared
-  @param  Len   - Length of the comparison to be performed
-
-  @return Zero if the buffer contecnts are same, else Nonzero
-**/
-UINT32
-pal_mem_compare (
-  VOID *Src,
-  VOID *Dest,
-  UINT32 Len
-  )
-{
-  return CompareMem (Src, Dest, Len);
-}
-
-/**
-  @brie a buffer with a known specified input value
-  @param  Buf   - Pointer to the buffer to fill
-  @param  Size  - Number of bytes in buffer to fill
-  @param  Value - Value to fill buffer with
-
-  @return None
-**/
-VOID
-pal_mem_set (
-  VOID *Buf,
-  UINT32 Size,
-  UINT8 Value
-  )
-{
-  SetMem(Buf, Size, Value);
-}
-
-/**
   @brief  Allocate memory which is to be used to share data across PEs
 
   @param  num_pe      - Number of PEs in the system
@@ -551,26 +515,6 @@ pal_strncmp (
   )
 {
   return AsciiStrnCmp(FirstString, SecondString, Length);
-}
-
-/**
-  Copies a source buffer to a destination buffer, and returns the destination buffer.
-
-  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
-  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
-  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
-
-  @return DestinationBuffer.
-
-**/
-VOID *
-pal_memcpy (
-  VOID *DestinationBuffer,
-  VOID *SourceBuffer,
-  UINT32 Length
-  )
-{
-  return CopyMem (DestinationBuffer, SourceBuffer, Length);
 }
 
 /**

--- a/val/Makefile
+++ b/val/Makefile
@@ -56,7 +56,7 @@ bsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_peripherals.o $(VAL_SRC)/acs_dma.o  $(VAL_SRC)/acs_smmu.o \
     $(VAL_SRC)/acs_test_infra.o  $(VAL_SRC)/acs_pcie.o  $(VAL_SRC)/acs_pe_infra.o \
     $(VAL_SRC)/acs_iovirt.o $(VAL_SRC)/bsa_execute_test.o\
-    $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o \
+    $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o $(VAL_SRC)/val_libc.o \
     $(VAL_SRC)/../driver/smmu_v3/smmu_v3.o $(VAL_SRC)/../driver/pcie/pcie.o \
     $(VAL_SRC)/rule_based_execution_helpers.o \
     $(VAL_SRC)/rule_based_orchestrator.o \
@@ -71,7 +71,7 @@ sbsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_peripherals.o  $(VAL_SRC)/acs_smmu.o $(VAL_SRC)/acs_dma.o \
     $(VAL_SRC)/acs_test_infra.o  $(VAL_SRC)/acs_pcie.o $(VAL_SRC)/acs_pe_infra.o \
     $(VAL_SRC)/acs_iovirt.o $(VAL_SRC)/../driver/smmu_v3/smmu_v3.o \
-    $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o \
+    $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o $(VAL_SRC)/val_libc.o \
     $(VAL_SRC)/sbsa_execute_test.o $(VAL_SRC)/../driver/pcie/pcie.o \
     $(VAL_SRC)/rule_based_execution_helpers.o \
     $(VAL_SRC)/rule_based_orchestrator.o \
@@ -85,7 +85,7 @@ pcbsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_peripherals.o  $(VAL_SRC)/acs_smmu.o $(VAL_SRC)/acs_dma.o\
     $(VAL_SRC)/acs_test_infra.o  $(VAL_SRC)/acs_pcie.o $(VAL_SRC)/acs_pe_infra.o \
     $(VAL_SRC)/acs_iovirt.o    $(VAL_SRC)/../driver/smmu_v3/smmu_v3.o \
-    $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o \
+    $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o $(VAL_SRC)/val_libc.o \
     $(VAL_SRC)/pc_bsa_execute_test.o $(VAL_SRC)/../driver/pcie/pcie.o
 endif
 

--- a/val/SbsaValNistLib.inf
+++ b/val/SbsaValNistLib.inf
@@ -78,6 +78,7 @@
   src/mpam_execute_test.c
   src/drtm_execute_test.c
   src/val_logger.c
+  src/val_libc.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/val/ValLib.inf
+++ b/val/ValLib.inf
@@ -60,6 +60,7 @@
   src/acs_pfdi.c
   src/acs_msc_error.c
   src/acs_tpm.c
+  src/val_libc.c
   driver/smmu_v3/smmu_v3.c
   driver/gic/gic.c
   driver/gic/acs_exception.c

--- a/val/ValLibRB.inf
+++ b/val/ValLibRB.inf
@@ -84,6 +84,7 @@
   src/rule_lookup.c
   src/test_wrappers.c
   src/val_logger.c
+  src/val_libc.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/val/include/acs_memory.h
+++ b/val/include/acs_memory.h
@@ -19,6 +19,7 @@
 #define __ACS_MEMORY_H__
 
 #include "val_sysreg.h"
+#include "val_libc.h"
 
 #define MEM_MAP_SUCCESS  0x0
 #define MEM_MAP_NO_MEM   0x1
@@ -35,8 +36,6 @@ void val_memory_unmap(void *ptr);
 void *val_memory_alloc(uint32_t size);
 void *val_memory_calloc(uint32_t num, uint32_t size);
 void val_memory_free(void *addr);
-int  val_memory_compare(void *src, void *dest, uint32_t len);
-void val_memory_set(void *buf, uint32_t size, uint8_t value);
 void *val_memory_virt_to_phys(void *va);
 void *val_memory_phys_to_virt(uint64_t pa);
 void *val_memory_alloc_pages(uint32_t num_pages);

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -23,6 +23,7 @@
 #include "acs_pfdi.h"
 #include "acs_cxl.h"
 #include "val_status.h"
+#include "val_libc.h"
 
 extern uint32_t g_print_level;
 
@@ -112,7 +113,6 @@ void val_print_test_start(char8_t *string);
 void val_print_test_end(uint32_t status, char8_t *string);
 void val_set_test_data(uint32_t index, uint64_t addr, uint64_t test_data);
 void val_get_test_data(uint32_t index, uint64_t *data0, uint64_t *data1);
-void *val_memcpy(void *dest_buffer, void *src_buffer, uint32_t len);
 void val_dump_dtb(void);
 void view_print_info(uint32_t view);
 void val_log_context(char8_t *file, char8_t *func, uint32_t line);
@@ -122,7 +122,6 @@ uint32_t val_exit_acs(void);
 void val_print_acs_test_status_summary(void);
 
 uint32_t execute_tests(void);
-uint32_t val_strncmp(char8_t *str1, char8_t *str2, uint32_t len);
 uint64_t val_time_delay_ms(uint64_t time_ms);
 
 /* VAL PE APIs */

--- a/val/include/val_libc.h
+++ b/val/include/val_libc.h
@@ -1,0 +1,48 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#ifndef __VAL_LIBC_H__
+#define __VAL_LIBC_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "pal_interface.h"
+#include "pal_common_intf.h"
+
+int val_memory_compare(void *s1, void *s2, uint32_t len);
+
+void *val_memcpy(void *dst, void *src, uint32_t len);
+
+void val_memory_set(void *dst, uint32_t size, uint8_t value);
+
+uint32_t val_strncmp(char8_t *str1, char8_t *str2, uint32_t length);
+
+char *val_strcat(char *dest, const char *src, size_t output_buff_size);
+
+size_t val_strlen(char *str);
+
+char *val_strcpy(char *dest, const char *src);
+
+char *val_strncpy(char *dest, const char *src, size_t n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __VAL_LIBC_H__ */

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -308,37 +308,6 @@ val_memory_free(void *addr)
 }
 
 /**
-  @brief  Compare two buffers of length len
-
-  @param  *src  Source Buffer
-  @param  *dest Destination Buffer
-  @param  len   Length
-
-  @return 0 If contents are same
-  @return 1 Otherwise
-**/
-int
-val_memory_compare(void *src, void *dest, uint32_t len)
-{
-  return pal_mem_compare(src, dest, len);
-}
-
-/**
-  @brief  Set buffer with value given in arguments
-
-  @param  *buf  Buffer
-  @param  size  size
-  @param  value value to be written
-
-  @return None
-**/
-void
-val_memory_set(void *buf, uint32_t size, uint8_t value)
-{
-  pal_mem_set(buf, size, value);
-}
-
-/**
   @brief  Returns the physical address for virtual address space.
 
   @param  *va   pointer to virtual address space

--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -860,37 +860,6 @@ val_debug_brk(uint32_t data)
 }
 
 /**
-  @brief  Compares two strings
-
-  @param  str1  The pointer to a Null-terminated ASCII string.
-  @param  str2  The pointer to a Null-terminated ASCII string.
-  @param  len   The maximum number of ASCII characters for compare.
-
-  @return Zero if strings are identical, else non-zero value
-**/
-uint32_t
-val_strncmp(char8_t *str1, char8_t *str2, uint32_t len)
-{
-  return pal_strncmp(str1, str2, len);
-}
-
-/**
-  Copies a source buffer to a destination buffer, and returns the destination buffer.
-
-  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
-  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
-  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
-
-  @return DestinationBuffer.
-
-**/
-void*
-val_memcpy(void *dst_buffer, void *src_buffer, uint32_t len)
-{
-  return pal_memcpy(dst_buffer, src_buffer, len);
-}
-
-/**
   Stalls the CPU for the number of microseconds specified by MicroSeconds.
 
   @param  MicroSeconds  The minimum number of microseconds to delay.

--- a/val/src/val_libc.c
+++ b/val/src/val_libc.c
@@ -1,0 +1,209 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val_libc.h"
+
+/**
+  @brief  Compare two memory buffers
+
+  @param  s1   First buffer
+  @param  s2   Second buffer
+  @param  len  Number of bytes to compare
+
+  @return 0  If buffers are identical
+  @return Non-zero  If buffers differ
+**/
+int val_memory_compare(void *s1, void *s2, uint32_t len)
+{
+    const unsigned char *p1 = s1;
+    const unsigned char *p2 = s2;
+
+    while (len--) {
+        if (*p1 != *p2)
+            return (int)(*p1 - *p2);
+        p1++;
+        p2++;
+    }
+    return 0;
+}
+
+/**
+  @brief  Copy memory from source to destination
+
+  @param  dst  Destination buffer
+  @param  src  Source buffer
+  @param  len  Number of bytes to copy
+
+  @return Pointer to destination buffer
+**/
+void *val_memcpy(void *dst, void *src, uint32_t len)
+{
+    const unsigned char *s = src;
+    unsigned char *d = dst;
+
+    while (len--) {
+        *d++ = *s++;
+    }
+
+    return dst;  // ␛return start of destination
+}
+
+/**
+  @brief  Set memory with a byte value
+
+  @param  dst    Buffer to fill
+  @param  value  Byte value to set
+  @param  count  Number of bytes to set
+
+  @return Pointer to destination buffer
+**/
+void val_memory_set(void *dst, uint32_t size, uint8_t value)
+{
+    unsigned char *ptr = dst;
+    while (size--)
+        *ptr++ = (unsigned char)value;
+
+    return (void) dst;
+}
+
+/**
+  @brief  Compare two strings up to given length
+
+  @param  str1    First string
+  @param  str2    Second string
+  @param  length  Maximum characters to compare
+
+  @return 0  If strings match within length
+  @return Non-zero  If strings differ
+**/
+uint32_t val_strncmp(char8_t *str1, char8_t *str2, uint32_t length)
+{
+    while (length && *str1 && (*str1 == *str2))
+    {
+        ++str1;
+        ++str2;
+        --length;
+    }
+
+    if (length == 0)
+    {
+        // Reached comparison limit — considered equal up to 'length'
+        return 0;
+    }
+
+    return (*(const unsigned char *)str1 - *(const unsigned char *)str2);
+}
+
+/**
+  @brief  Append source string to destination buffer
+
+  @param  dest              Destination buffer
+  @param  src               Source string
+  @param  output_buff_size  Size of destination buffer
+
+  @return Pointer to destination buffer
+**/
+char *val_strcat(char *dest, const char *src, size_t output_buff_size)
+{
+    size_t dest_len = 0;
+
+    // Find the end of the destination string
+    while (dest_len < output_buff_size && dest[dest_len] != '\0')
+        dest_len++;
+
+    // If dest is already full, do nothing
+    if (dest_len == output_buff_size)
+        return dest;
+
+    size_t i = 0;
+    // Append src to dest while ensuring buffer space remains
+    while (src[i] != '\0' && dest_len < output_buff_size - 1)
+    {
+        dest[dest_len++] = src[i++];
+    }
+
+    // Null-terminate the resulting string
+    dest[dest_len] = '\0';
+
+    return dest;
+}
+
+/**
+  @brief  Get length of a string
+
+  @param  str  Input string
+
+  @return Length of string (excluding null terminator)
+**/
+size_t val_strlen(char *str)
+{
+  size_t length = 0;
+
+  while (str[length] != '\0')
+  {
+    ++length;
+  }
+
+  return length;
+}
+
+/**
+  @brief  Copy source string to destination
+
+  @param  dest  Destination buffer
+  @param  src   Source string
+
+  @return Pointer to destination buffer
+**/
+char *val_strcpy(char *dest, const char *src)
+{
+    char *ret = dest;
+
+    while ((*dest++ = *src++));
+
+    return ret;
+}
+
+/**
+  @brief  Copy string with length limit
+
+  @param  dest  Destination buffer
+  @param  src   Source string
+  @param  n     Maximum number of characters
+
+  @return Pointer to destination buffer
+**/
+char *val_strncpy(char *dest, const char *src, size_t n)
+{
+    char *ret = dest;
+
+    if (!dest || !src)
+        return NULL;
+
+    if (n == 0)
+        return ret;
+
+    while ((n > 1) && (*src != '\0'))
+    {
+        *dest++ = *src++;
+        n--;
+    }
+
+    *dest = '\0';
+
+    return ret;
+}


### PR DESCRIPTION
  - Move LibC related functions to a single common file
  - Add a shared VAL LibC layer for memory and string helpers
  - Remove the old PAL-backed wrapper implementations from infrastructure
  - Drop the redundant PAL interface declarations/implementations