### PR TITLE
cleanup(baremetal): remove stale globals and clarify sbsa-level params

### DIFF
--- a/apps/baremetal/acs.h
+++ b/apps/baremetal/acs.h
@@ -103,8 +103,6 @@ extern uint32_t g_timeout_pass;
 extern uint32_t g_timeout_fail;
 
 /* Globals from apps/baremetal/acs_globals.c */
-extern RULE_ID_e *g_rule_tests;
-extern uint32_t  g_rule_tests_num;
 extern RULE_ID_e *g_rule_list;
 extern RULE_ID_e *g_skip_rule_list;
 extern uint32_t  *g_execute_modules;

--- a/apps/baremetal/acs_globals.c
+++ b/apps/baremetal/acs_globals.c
@@ -38,8 +38,6 @@ uint64_t  g_stack_pointer;
 uint64_t  g_exception_ret_addr;
 uint64_t  g_ret_addr;
 
-uint32_t  g_sbsa_level;
-uint32_t  g_execute_nist;
 uint64_t  g_el3_param_magic = 0;
 uint64_t  g_el3_param_addr  = 0;
 

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -638,7 +638,7 @@ uint32_t val_sbsa_ras_execute_tests(uint32_t level, uint32_t num_pe);
 uint32_t val_sbsa_nist_execute_tests(uint32_t level, uint32_t num_pe);
 
 uint32_t val_bsa_execute_tests(uint32_t *g_sw_view);
-uint32_t val_sbsa_execute_tests(uint32_t g_sbsa_level);
+uint32_t val_sbsa_execute_tests(uint32_t level);
 
 /* TPM2 API */
 
@@ -654,7 +654,7 @@ uint64_t val_tpm2_get_info(TPM2_INFO_e info_type);
 uint64_t val_tpm2_get_version(void);
 
 /* PC-BSA Related API's */
-uint32_t val_pcbsa_execute_tests(uint32_t g_pcbsa_level);
+uint32_t val_pcbsa_execute_tests(uint32_t level);
 uint32_t val_pcbsa_pe_execute_tests(uint32_t level, uint32_t num_pe);
 uint32_t val_pcbsa_gic_execute_tests(uint32_t level, uint32_t num_pe);
 uint32_t val_pcbsa_smmu_execute_tests(uint32_t level, uint32_t num_pe);

--- a/val/src/pc_bsa_execute_test.c
+++ b/val/src/pc_bsa_execute_test.c
@@ -387,30 +387,30 @@ val_pcbsa_pcie_execute_tests(uint32_t level, uint32_t num_pe)
 #ifndef TARGET_LINUX
 
 uint32_t
-val_pcbsa_execute_tests(uint32_t g_pcbsa_level)
+val_pcbsa_execute_tests(uint32_t level)
 {
 
   uint32_t Status;
   /***         Starting PE tests                     ***/
-  Status = val_pcbsa_pe_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status = val_pcbsa_pe_execute_tests(level, val_pe_get_num());
 
   /***         Starting Memory tests                ***/
-  Status |= val_pcbsa_memory_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status |= val_pcbsa_memory_execute_tests(level, val_pe_get_num());
 
   /***         Starting GIC tests                    ***/
-  Status |= val_pcbsa_gic_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status |= val_pcbsa_gic_execute_tests(level, val_pe_get_num());
 
   /***         Starting SMMU tests                   ***/
-  Status |= val_pcbsa_smmu_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status |= val_pcbsa_smmu_execute_tests(level, val_pe_get_num());
 
   /***         Starting PCIe tests                   ***/
-  Status |= val_pcbsa_pcie_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status |= val_pcbsa_pcie_execute_tests(level, val_pe_get_num());
 
   /***         Starting Watchdog tests               ***/
-  Status |= val_pcbsa_wd_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status |= val_pcbsa_wd_execute_tests(level, val_pe_get_num());
 
   /***         Starting TPM2 tests               ***/
-  Status |= val_pcbsa_tpm2_execute_tests(g_pcbsa_level, val_pe_get_num());
+  Status |= val_pcbsa_tpm2_execute_tests(level, val_pe_get_num());
 
   return Status;
 

--- a/val/src/sbsa_execute_test.c
+++ b/val/src/sbsa_execute_test.c
@@ -983,47 +983,47 @@ val_sbsa_nist_execute_tests(uint32_t level, uint32_t num_pe)
 
 
 uint32_t
-val_sbsa_execute_tests(uint32_t g_sbsa_level)
+val_sbsa_execute_tests(uint32_t level)
 {
 
   uint32_t Status;
   uint32_t num_pe = val_pe_get_num();
 
   /***         Starting PE tests                     ***/
-  Status = val_sbsa_pe_execute_tests(g_sbsa_level, num_pe);
+  Status = val_sbsa_pe_execute_tests(level, num_pe);
 
   /***         Starting Memory tests                 ***/
-  Status |= val_sbsa_memory_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_memory_execute_tests(level, num_pe);
 
   /***         Starting GIC tests                    ***/
-  Status |= val_sbsa_gic_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_gic_execute_tests(level, num_pe);
 
   /***         Starting SMMU tests                   ***/
-  Status |= val_sbsa_smmu_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_smmu_execute_tests(level, num_pe);
 
   /***         Starting Timer tests               ***/
-  Status |= val_sbsa_timer_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_timer_execute_tests(level, num_pe);
 
   /***         Starting Watchdog tests               ***/
-  Status |= val_sbsa_wd_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_wd_execute_tests(level, num_pe);
 
   /***         Starting PCIe tests                   ***/
-  Status |= val_sbsa_pcie_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_pcie_execute_tests(level, num_pe);
 
   /***         Starting Exerciser tests              ***/
-  Status |= val_sbsa_exerciser_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_exerciser_execute_tests(level, num_pe);
 
   /***         Starting MPAM tests                   ***/
-  Status |= val_sbsa_mpam_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_mpam_execute_tests(level, num_pe);
 
   /***         Starting PMU tests                    ***/
-  Status |= val_sbsa_pmu_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_pmu_execute_tests(level, num_pe);
 
   /***         Starting RAS tests                    ***/
-  Status |= val_sbsa_ras_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_ras_execute_tests(level, num_pe);
 
   /***         Starting ETE tests                    ***/
-  Status |= val_sbsa_ete_execute_tests(g_sbsa_level, num_pe);
+  Status |= val_sbsa_ete_execute_tests(level, num_pe);
 
   return Status;
 


### PR DESCRIPTION
Remove stale baremetal global leftovers that are no longer used by the current rule-based flow, and rename misleading function parameters that used global-style names despite being ordinary locals.

Changes:
- remove stale baremetal declarations of g_rule_tests and g_rule_tests_num
- remove unused baremetal definitions of g_sbsa_level and g_execute_nist
- rename val_sbsa_execute_tests() and val_pcbsa_execute_tests() parameters from g_* names to plain level

Change-Id: Ica8d10dc7937a6094513e7e9f775b0f3bec5dc90