### PR TITLE
fix(arch): redefine PMSELR_EL0_SEL_MASK safely

### DIFF
--- a/val/include/val_arch.h
+++ b/val/include/val_arch.h
@@ -15,6 +15,10 @@
 #define DAIF_DBG_BIT        (1U << 3)
 #define DAIF_CONFIG         (0x7U)
 
+#ifdef PMSELR_EL0_SEL_MASK
+#undef PMSELR_EL0_SEL_MASK
+#endif
+
 #define PMSELR_EL0_SEL_MASK (0x1fU)
 
 #define EL_IMPL_NONE        (0ULL)


### PR DESCRIPTION
- Undefine existing PMSELR_EL0_SEL_MASK before redefining
- Prevent potential macro redefinition conflicts during build


Change-Id: I9e4f35c5d86ce07bcf7da6a97b22d3ed839e448f