### PR TITLE
fix(presilicon): Implemented a solution to override val_print

### DIFF
--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -35,12 +35,15 @@ extern uint32_t g_print_level;
 #define ACS_STATUS_PASS    STATUS_SUCCESS
 #define ACS_STATUS_SKIP    STATUS_SKIP
 #define ACS_STATUS_UNKNOWN STATUS_UNKNOWN
-
+/*Note: val_print can be overriden in platform_override_fvp.h, to
+enable implementation specific prints in PAL*/
+#ifndef val_print
 #define val_print(level, ...)                     \
     do {                                          \
         if ((level) >= g_print_level)             \
             val_printf((level), __VA_ARGS__);     \
     } while (0)
+#endif
 
 #define ACS_STATUS_PAL_NOT_IMPLEMENTED 0x4B1D  /* PAL reports feature/API not implemented */
 #ifndef NOT_IMPLEMENTED


### PR DESCRIPTION
    Implemented a way to override the val_print,
    such that it is redirected to a new impdef function in PAL layer which uses FASTPRINT

Change-Id: If7f5a2bf81b34a9d0248ccb5bb23965875d5e131