### PR TITLE
refactor(policy): centralize shared execution policy state

### DIFF
--- a/apps/baremetal/acs.h
+++ b/apps/baremetal/acs.h
@@ -98,17 +98,9 @@ extern uint32_t g_num_modules;
 extern uint32_t g_skip_modules_arr[];
 extern uint32_t g_num_skip_modules;
 extern uint32_t g_level_filter_mode;
-extern uint32_t g_sys_last_lvl_cache;
-extern uint32_t g_timeout_pass;
-extern uint32_t g_timeout_fail;
 
-/* Globals from apps/baremetal/acs_globals.c */
-extern uint32_t  g_pcie_cache_present;
+/* Remaining baremetal execution globals from apps/baremetal/acs_globals.c */
 extern uint32_t  g_el1physkip;
-extern uint32_t  g_pcie_p2p;
-extern uint32_t  g_crypto_support;
-extern uint32_t  g_print_level;
-extern uint32_t  g_print_mmio;
 extern uint32_t  g_curr_module;
 extern uint32_t  g_enable_module;
 extern uint32_t  g_acs_tests_total;
@@ -117,7 +109,6 @@ extern uint32_t  g_acs_tests_fail;
 extern uint64_t  g_stack_pointer;
 extern uint64_t  g_exception_ret_addr;
 extern uint64_t  g_ret_addr;
-extern bool      g_pcie_skip_dp_nic_ms;
 extern uint32_t  g_build_sbsa;
 extern uint32_t  g_build_pcbsa;
 extern uint32_t  g_its_init;

--- a/apps/baremetal/acs_common.c
+++ b/apps/baremetal/acs_common.c
@@ -18,6 +18,7 @@
 #include "acs.h"
 #include <stdint.h>
 #include <stdbool.h>
+#include "pal/baremetal/base/include/pal_execution_policy.h"
 #include "val/include/val_interface.h"
 #include "val/include/acs_el3_param.h"
 #include "val/include/rule_based_execution_enum.h"
@@ -63,6 +64,57 @@ acs_list_contains(const uint32_t *list, uint32_t count, uint32_t value)
 }
 
 void
+acs_load_execution_policy_defaults(acs_execution_policy_t *policy)
+{
+  const acs_execution_policy_t *defaults;
+  const acs_execution_policy_t *platform_defaults;
+
+  if (policy == NULL)
+      return;
+
+  acs_reset_execution_policy();
+  defaults = acs_get_execution_policy();
+  /*
+   * Baremetal entry paths currently pass the shared execution-policy singleton,
+   * so acs_reset_execution_policy() has already seeded `policy` with the base
+   * defaults. Keep support for detached policy objects without needlessly
+   * self-assigning the singleton fields here.
+   */
+  if (policy != defaults) {
+      policy->pcie_p2p = defaults->pcie_p2p;
+      policy->pcie_cache_present = defaults->pcie_cache_present;
+      policy->pcie_skip_dp_nic_ms = defaults->pcie_skip_dp_nic_ms;
+      policy->print_level = defaults->print_level;
+      policy->print_mmio = defaults->print_mmio;
+      policy->timeout_pass = defaults->timeout_pass;
+      policy->timeout_fail = defaults->timeout_fail;
+      policy->timer_timeout_us = defaults->timer_timeout_us;
+      policy->crypto_support = defaults->crypto_support;
+      policy->sys_last_lvl_cache = defaults->sys_last_lvl_cache;
+      policy->el1skiptrap_mask = defaults->el1skiptrap_mask;
+  }
+
+  platform_defaults = acs_get_platform_execution_policy_defaults();
+  if (platform_defaults == NULL)
+      return;
+
+  /* Overlay baremetal platform-specific defaults on top of the generic reset defaults. */
+  policy->pcie_p2p = platform_defaults->pcie_p2p;
+  policy->pcie_cache_present = platform_defaults->pcie_cache_present;
+  policy->pcie_skip_dp_nic_ms = platform_defaults->pcie_skip_dp_nic_ms;
+  policy->crypto_support = platform_defaults->crypto_support;
+  policy->sys_last_lvl_cache = platform_defaults->sys_last_lvl_cache;
+  policy->el1skiptrap_mask = platform_defaults->el1skiptrap_mask;
+
+  if (platform_defaults->timeout_pass != 0u)
+      policy->timeout_pass = platform_defaults->timeout_pass;
+  if (platform_defaults->timeout_fail != 0u)
+      policy->timeout_fail = platform_defaults->timeout_fail;
+  if (platform_defaults->timer_timeout_us != 0u)
+      policy->timer_timeout_us = platform_defaults->timer_timeout_us;
+}
+
+void
 acs_load_run_request_defaults(acs_run_request_t *ctx)
 {
   if (ctx == NULL)
@@ -104,11 +156,11 @@ acs_load_run_request_defaults(acs_run_request_t *ctx)
 }
 
 void
-acs_apply_el3_params(acs_run_request_t *ctx)
+acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 {
   acs_el3_params *params;
 
-  if (ctx == NULL)
+  if (ctx == NULL || policy == NULL)
     return;
 
   /* If magic doesn't match, ignore X20 completely */
@@ -168,14 +220,14 @@ acs_apply_el3_params(acs_run_request_t *ctx)
     }
 
     /* Override shared runtime knobs and context filter settings from EL3 parameters. */
-    g_pcie_p2p            = params->p2p;
-    g_pcie_skip_dp_nic_ms = params->skip_dp_nic_ms;
-    g_print_mmio          = params->mmio;
-    g_crypto_support      = params->no_crypto_ext;
-    g_el1skiptrap_mask    = params->el1skiptrap_mask;
+    policy->pcie_p2p            = params->p2p;
+    policy->pcie_skip_dp_nic_ms = params->skip_dp_nic_ms;
+    policy->print_mmio          = params->mmio;
+    policy->crypto_support      = params->no_crypto_ext ? 0u : 1u;
+    policy->el1skiptrap_mask    = params->el1skiptrap_mask;
     ctx->bsa_sw_view_mask = params->software_view_filter;
-    g_pcie_cache_present  = params->cache;
-    g_sys_last_lvl_cache  = params->sys_cache;
+    policy->pcie_cache_present  = params->cache;
+    policy->sys_last_lvl_cache  = params->sys_cache;
     ctx->level_value = params->level;
 
     if (params->level_selection >= LVL_FILTER_NONE &&
@@ -186,7 +238,7 @@ acs_apply_el3_params(acs_run_request_t *ctx)
                 "Override skipped for level filter mode  %d\n", params->level_selection);
 
     if (params->verbose >= TRACE && params->verbose <= FATAL)
-      g_print_level         = params->verbose;
+      policy->print_level = params->verbose;
     else
       val_print(WARN,
                 "Override skipped for verbose  %d\n", params->verbose);
@@ -194,9 +246,10 @@ acs_apply_el3_params(acs_run_request_t *ctx)
     if (params->timeout >= TIMEOUT_THRESHOLD
        && params->timeout <= TIMEOUT_MAX_THRESHOLD)
     {
-      g_timeout_pass        = params->timeout;
-      g_timer_timeout_us    = params->timeout;
-      g_timeout_fail        = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+      policy->timeout_pass = params->timeout;
+      policy->timer_timeout_us = params->timeout;
+      policy->timeout_fail =
+          policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
     }
     else
       val_print(WARN,
@@ -205,9 +258,9 @@ acs_apply_el3_params(acs_run_request_t *ctx)
 }
 
 void
-acs_apply_compile_params(acs_run_request_t *ctx)
+acs_apply_compile_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 {
-  if (ctx == NULL)
+  if (ctx == NULL || policy == NULL)
       return;
 
 #if ACS_HAS_ENABLED_MODULE_LIST
@@ -220,12 +273,12 @@ acs_apply_compile_params(acs_run_request_t *ctx)
   /*
    * Allow compile-time override of the default print verbosity.
    */
-  g_print_level = ACS_VERBOSE_LEVEL;
+  policy->print_level = ACS_VERBOSE_LEVEL;
 
-  if (g_print_level < TRACE)
-    g_print_level = TRACE;
-  else if (g_print_level > FATAL)
-    g_print_level = FATAL;
+  if (policy->print_level < TRACE)
+    policy->print_level = TRACE;
+  else if (policy->print_level > FATAL)
+    policy->print_level = FATAL;
 #endif
 
   return;

--- a/apps/baremetal/acs_globals.c
+++ b/apps/baremetal/acs_globals.c
@@ -21,10 +21,6 @@
 #include "acs.h"
 
 /* Global Variables */
-bool      g_pcie_skip_dp_nic_ms = 0;
-uint32_t  g_pcie_p2p;
-uint32_t  g_print_level;
-uint32_t  g_print_mmio;
 uint32_t  g_curr_module;
 uint32_t  g_enable_module;
 uint32_t  g_acs_tests_total;
@@ -33,7 +29,6 @@ uint32_t  g_acs_tests_fail;
 uint32_t  g_build_sbsa = 0;
 uint32_t  g_build_pcbsa = 0;
 uint32_t  g_its_init = 0;
-uint32_t  g_pcie_cache_present;
 uint64_t  g_stack_pointer;
 uint64_t  g_exception_ret_addr;
 uint64_t  g_ret_addr;

--- a/apps/baremetal/bsa_main.c
+++ b/apps/baremetal/bsa_main.c
@@ -65,20 +65,21 @@ freeAcsMeM(void)
 
 /* This routine will furnish global variables with user defined config and set any
    default values for the ACS */
-uint32_t apply_user_config_and_defaults(acs_run_request_t *ctx)
+uint32_t apply_user_config_and_defaults(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 {
-    if (ctx == NULL)
+    if (ctx == NULL || policy == NULL)
         return ACS_STATUS_FAIL;
 
     acs_load_run_request_defaults(ctx);
+    acs_load_execution_policy_defaults(policy);
 
     /* Set user defined compliance level to be run for
        as defined pal/baremetal/target/../include/platform_override_fvp.h  */
     ctx->level_value = PLATFORM_OVERRIDE_BSA_LEVEL;
-    g_print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
+    policy->print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
 
-    /* Set default values for g_print_mmio */
-    g_print_mmio = 0;
+    /* Disable MMIO trace prints by default for standalone baremetal runs. */
+    policy->print_mmio = 0;
     /* If selected rule count is zero, default to BSA */
     if (ctx->rule_count == 0) {
         /* Standalone BSA Baremetal app, default the run request to BSA */
@@ -87,24 +88,24 @@ uint32_t apply_user_config_and_defaults(acs_run_request_t *ctx)
 
     /* Check sanity of value of level if not valid default to extremes */
     if (ctx->level_value < BSA_LEVEL_1) {
-        val_print(g_print_level, "\nBSA Level %d is not supported.\n", ctx->level_value);
-        val_print(g_print_level, "\nSetting BSA level to %d\n", BSA_LEVEL_1);
+        val_print(policy->print_level, "\nBSA Level %d is not supported.\n", ctx->level_value);
+        val_print(policy->print_level, "\nSetting BSA level to %d\n", BSA_LEVEL_1);
         ctx->level_value = BSA_LEVEL_1;
     } else if (ctx->level_value >= BSA_LEVEL_SENTINEL) {
-        val_print(g_print_level, "\nBSA Level %d is not supported.\n", ctx->level_value);
-        val_print(g_print_level, "\nSetting BSA level FR", BSA_LEVEL_FR);
+        val_print(policy->print_level, "\nBSA Level %d is not supported.\n", ctx->level_value);
+        val_print(policy->print_level, "\nSetting BSA level FR", BSA_LEVEL_FR);
         ctx->level_value = BSA_LEVEL_FR;
     }
 
     /* Check sanity of print level, default accordingly */
-    if (g_print_level < TRACE) {
-        val_print(ERROR, "\nPrint Level %d is not supported.\n", g_print_level);
+    if (policy->print_level < TRACE) {
+        val_print(ERROR, "\nPrint Level %d is not supported.\n", policy->print_level);
         val_print(ERROR, "\nSetting Print level to %d\n", TRACE);
-        g_print_level = TRACE;
-    } else if (g_print_level > ERROR) {
-        val_print(ERROR, "\nPrint Level %d is not supported.\n", g_print_level);
+        policy->print_level = TRACE;
+    } else if (policy->print_level > ERROR) {
+        val_print(ERROR, "\nPrint Level %d is not supported.\n", policy->print_level);
         val_print(ERROR, "\nSetting Print level to %d\n", ERROR);
-        g_print_level = ERROR;
+        policy->print_level = ERROR;
     }
 
     return ACS_STATUS_PASS;
@@ -126,20 +127,22 @@ ShellAppMainbsa()
     uint32_t             Status;
     void                 *branch_label;
     acs_run_request_t    *ctx;
+    acs_execution_policy_t *policy;
 
     acs_reset_run_request();
     ctx = acs_get_run_request_mut();
+    policy = acs_get_execution_policy_mut();
 
-    Status = apply_user_config_and_defaults(ctx);
+    Status = apply_user_config_and_defaults(ctx, policy);
     if (Status != ACS_STATUS_PASS) {
         val_print(ERROR, "\napply_user_config_and_defaults() failed, Exiting...\n");
         goto exit_acs;
     }
 
     /* Apply any compile-time rule/module overrides before we consume the run request. */
-    acs_apply_compile_params(ctx);
+    acs_apply_compile_params(ctx, policy);
     /* Apply any EL3-supplied selection overrides before we consume the run request. */
-    acs_apply_el3_params(ctx);
+    acs_apply_el3_params(ctx, policy);
 
     val_print(INFO, "\n\n BSA Architecture Compliance Suite\n");
     val_print(INFO, "\n          Version %d.", BSA_ACS_MAJOR_VER);
@@ -149,7 +152,7 @@ ShellAppMainbsa()
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 BSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", policy->print_level);
 
 #if ACS_ENABLE_MMU
     val_print(INFO, " Enabling MMU\n");

--- a/apps/baremetal/pc_bsa_main.c
+++ b/apps/baremetal/pc_bsa_main.c
@@ -75,20 +75,21 @@ freeAcsMem(void)
 /* This routine will furnish global variables with user defined config and set any
    default values for the ACS */
 static uint32_t
-apply_user_config_and_defaults(acs_run_request_t *ctx)
+apply_user_config_and_defaults(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 {
-    if (ctx == NULL)
+    if (ctx == NULL || policy == NULL)
         return ACS_STATUS_FAIL;
 
     acs_load_run_request_defaults(ctx);
+    acs_load_execution_policy_defaults(policy);
 
     /* Set user defined compliance level to be run for
        as defined pal/baremetal/target/../include/platform_override_fvp.h  */
     ctx->level_value = PLATFORM_OVERRIDE_PCBSA_LEVEL;
-    g_print_level  = PLATFORM_OVERRIDE_PRINT_LEVEL;
+    policy->print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
 
-    /* Set default values for g_print_mmio */
-    g_print_mmio = 0;
+    /* Disable MMIO trace prints by default for standalone baremetal runs. */
+    policy->print_mmio = 0;
 
     /* If selected rule count is zero, default to PCBSA */
     if (ctx->rule_count == 0) {
@@ -98,24 +99,24 @@ apply_user_config_and_defaults(acs_run_request_t *ctx)
 
     /* Check sanity of value of level if not valid default to extremes */
     if (ctx->level_value < PCBSA_LEVEL_1) {
-        val_print(g_print_level, "\nPCBSA Level %d is not supported.\n", ctx->level_value);
-        val_print(g_print_level, "\nSetting PCBSA level to %d\n", PCBSA_LEVEL_1);
+        val_print(policy->print_level, "\nPCBSA Level %d is not supported.\n", ctx->level_value);
+        val_print(policy->print_level, "\nSetting PCBSA level to %d\n", PCBSA_LEVEL_1);
         ctx->level_value = PCBSA_LEVEL_1;
     } else if (ctx->level_value >= PCBSA_LEVEL_SENTINEL) {
-        val_print(g_print_level, "\nPCBSA Level %d is not supported.\n", ctx->level_value);
-        val_print(g_print_level, "\nSetting PCBSA level to %d\n", PCBSA_LEVEL_1);
+        val_print(policy->print_level, "\nPCBSA Level %d is not supported.\n", ctx->level_value);
+        val_print(policy->print_level, "\nSetting PCBSA level to %d\n", PCBSA_LEVEL_1);
         ctx->level_value = PCBSA_LEVEL_1;
     }
 
     /* Check sanity of print level, default accordingly */
-    if (g_print_level < TRACE) {
-        val_print(ERROR, "\nPrint Level %d is not supported.\n", g_print_level);
+    if (policy->print_level < TRACE) {
+        val_print(ERROR, "\nPrint Level %d is not supported.\n", policy->print_level);
         val_print(ERROR, "\nSetting Print level to %d\n", TRACE);
-        g_print_level = TRACE;
-    } else if (g_print_level > ERROR) {
-        val_print(ERROR, "\nPrint Level %d is not supported.\n", g_print_level);
+        policy->print_level = TRACE;
+    } else if (policy->print_level > ERROR) {
+        val_print(ERROR, "\nPrint Level %d is not supported.\n", policy->print_level);
         val_print(ERROR, "\nSetting Print level to %d\n", ERROR);
-        g_print_level = ERROR;
+        policy->print_level = ERROR;
     }
 
     return ACS_STATUS_PASS;
@@ -135,20 +136,22 @@ ShellAppMainpcbsa(void)
     uint32_t Status;
     void     *branch_label;
     acs_run_request_t *ctx;
+    acs_execution_policy_t *policy;
 
     acs_reset_run_request();
     ctx = acs_get_run_request_mut();
+    policy = acs_get_execution_policy_mut();
 
-    Status = apply_user_config_and_defaults(ctx);
+    Status = apply_user_config_and_defaults(ctx, policy);
     if (Status != ACS_STATUS_PASS) {
         val_print(ERROR, "\napply_user_config_and_defaults() failed, Exiting...\n");
         goto exit_acs;
     }
 
     /* Apply any compile-time test/module overrides before we consume the run request. */
-    acs_apply_compile_params(ctx);
+    acs_apply_compile_params(ctx, policy);
     /* Apply any EL3-supplied selection overrides before we consume the run request. */
-    acs_apply_el3_params(ctx);
+    acs_apply_el3_params(ctx, policy);
 
 #if ACS_ENABLE_MMU
     val_print(INFO, " Enabling MMU\n");
@@ -176,7 +179,7 @@ ShellAppMainpcbsa(void)
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 PCBSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", policy->print_level);
 
     val_print(INFO, " Creating Platform Information Tables\n");
 

--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -93,20 +93,21 @@ freeAcsMeM(void)
 
 /* This routine will furnish global variables with user defined config and set any
    default values for the ACS */
-uint32_t apply_user_config_and_defaults(acs_run_request_t *ctx)
+uint32_t apply_user_config_and_defaults(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 {
-    if (ctx == NULL)
+    if (ctx == NULL || policy == NULL)
         return ACS_STATUS_FAIL;
 
     acs_load_run_request_defaults(ctx);
+    acs_load_execution_policy_defaults(policy);
 
     /* Set user defined compliance level to be run for
        as defined pal/baremetal/target/../include/platform_override_fvp.h  */
     ctx->level_value = PLATFORM_OVERRIDE_SBSA_LEVEL;
-    g_print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
+    policy->print_level = PLATFORM_OVERRIDE_PRINT_LEVEL;
 
-    /* Set default values for g_print_mmio */
-    g_print_mmio = 0;
+    /* Disable MMIO trace prints by default for standalone baremetal runs. */
+    policy->print_mmio = 0;
 
     /* If selected rule count is zero, default to SBSA */
     if (ctx->rule_count == 0) {
@@ -116,24 +117,24 @@ uint32_t apply_user_config_and_defaults(acs_run_request_t *ctx)
 
     /* Check sanity of value of level if not valid default to extremes */
     if (ctx->level_value < SBSA_LEVEL_3) {
-        val_print(g_print_level, "\nSBSA Level %d is not supported.\n", ctx->level_value);
-        val_print(g_print_level, "\nSetting SBSA level to %d\n", SBSA_LEVEL_3);
+        val_print(policy->print_level, "\nSBSA Level %d is not supported.\n", ctx->level_value);
+        val_print(policy->print_level, "\nSetting SBSA level to %d\n", SBSA_LEVEL_3);
         ctx->level_value = SBSA_LEVEL_3;
     } else if (ctx->level_value >= SBSA_LEVEL_SENTINEL) {
-        val_print(g_print_level, "\nSBSA Level %d is not supported.\n", ctx->level_value);
-        val_print(g_print_level, "\nSetting SBSA level FR", SBSA_LEVEL_FR);
+        val_print(policy->print_level, "\nSBSA Level %d is not supported.\n", ctx->level_value);
+        val_print(policy->print_level, "\nSetting SBSA level FR", SBSA_LEVEL_FR);
         ctx->level_value = SBSA_LEVEL_FR;
     }
 
     /* Check sanity of print level, default accordingly */
-    if (g_print_level < TRACE) {
-        val_print(ERROR, "\nPrint Level %d is not supported.\n", g_print_level);
+    if (policy->print_level < TRACE) {
+        val_print(ERROR, "\nPrint Level %d is not supported.\n", policy->print_level);
         val_print(ERROR, "\nSetting Print level to %d\n", TRACE);
-        g_print_level = TRACE;
-    } else if (g_print_level > ERROR) {
-        val_print(ERROR, "\nPrint Level %d is not supported.\n", g_print_level);
+        policy->print_level = TRACE;
+    } else if (policy->print_level > ERROR) {
+        val_print(ERROR, "\nPrint Level %d is not supported.\n", policy->print_level);
         val_print(ERROR, "\nSetting Print level to %d\n", ERROR);
-        g_print_level = ERROR;
+        policy->print_level = ERROR;
     }
 
     /* Set g_build_sbsa hint for test */
@@ -157,11 +158,13 @@ ShellAppMainsbsa()
     uint32_t             Status = ACS_STATUS_SKIP;
     void                 *branch_label;
     acs_run_request_t    *ctx;
+    acs_execution_policy_t *policy;
 
     acs_reset_run_request();
     ctx = acs_get_run_request_mut();
+    policy = acs_get_execution_policy_mut();
 
-    Status = apply_user_config_and_defaults(ctx);
+    Status = apply_user_config_and_defaults(ctx, policy);
     if (Status != ACS_STATUS_PASS) {
         val_print(ERROR, "\napply_user_config_and_defaults() failed, Exiting...\n");
         goto exit_acs;
@@ -184,9 +187,9 @@ ShellAppMainsbsa()
   val_print(INFO, "Skipping MMU setup/enable (ACS_ENABLE_MMU=0)\n");
 #endif
     /* Apply any compile-time test/module overrides before we consume the run request. */
-    acs_apply_compile_params(ctx);
+    acs_apply_compile_params(ctx, policy);
     /* Apply any EL3-supplied selection overrides before we consume the run request. */
-    acs_apply_el3_params(ctx);
+    acs_apply_el3_params(ctx, policy);
 
     val_print(INFO, "\n\n SBSA Architecture Compliance Suite\n");
     val_print(INFO, "    Version %d.", SBSA_ACS_MAJOR_VER);
@@ -197,7 +200,7 @@ ShellAppMainsbsa()
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 SBSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", policy->print_level);
 
     val_print(INFO, " Creating Platform Information Tables\n");
 

--- a/apps/linux/bsa-acs-app/bsa_drv_intf.c
+++ b/apps/linux/bsa-acs-app/bsa_drv_intf.c
@@ -174,7 +174,7 @@ call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
 }
 
 int
-call_update_skip_list(unsigned int api_num, int *p_skip_test_num)
+call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num)
 {
     FILE             *fd = NULL;
     bsa_drv_parms_t test_params;
@@ -201,7 +201,7 @@ call_update_skip_list(unsigned int api_num, int *p_skip_test_num)
 }
 
 int
-call_update_sw_view(unsigned int api_num, int *p_sw_view)
+call_update_sw_view(unsigned int api_num, uint32_t *p_sw_view)
 {
     FILE             *fd = NULL;
     bsa_drv_parms_t test_params;

--- a/apps/linux/bsa-acs-app/include/bsa_drv_intf.h
+++ b/apps/linux/bsa-acs-app/include/bsa_drv_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,25 +53,25 @@ typedef struct bsa_array_update_u {
 /* Function Prototypes */
 
 int
-call_drv_init_test_env();
+call_drv_init_test_env(unsigned int print_level);
 
 int
-call_drv_clean_test_env();
+call_drv_clean_test_env(void);
 
 int
 call_drv_execute_test(unsigned int test_num, unsigned int num_pe,
   unsigned int print_level, unsigned long int test_input);
 
 int
-call_update_skip_list(unsigned int api_num, int *p_skip_test_num);
+call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num);
 
 int
-call_update_sw_view(unsigned int api_num, int *p_sw_view);
+call_update_sw_view(unsigned int api_num, uint32_t *p_sw_view);
 
 int
-call_drv_wait_for_completion();
+call_drv_wait_for_completion(void);
 
-int read_from_proc_bsa_msg();
+int read_from_proc_bsa_msg(void);
 
 /* send a u32 array to the driver via ioctl */
 int bsa_send_array_u32(uint32_t hint, const uint32_t *arr, uint32_t count);

--- a/apps/linux/pcbsa-acs-app/include/pcbsa_drv_intf.h
+++ b/apps/linux/pcbsa-acs-app/include/pcbsa_drv_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,10 @@
  * limitations under the License.
  **/
 
-
 #ifndef __SBSA_DRV_INTF_H__
 #define __SBSA_DRV_INTF_H__
+
+#include <stdint.h>
 
 
 /* API NUMBERS to COMMUNICATE with DRIVER */
@@ -36,17 +37,17 @@
 /* Function Prototypes */
 
 int
-call_drv_init_test_env();
+call_drv_init_test_env(unsigned int print_level);
 
 int
-call_drv_clean_test_env();
+call_drv_clean_test_env(void);
 
 int
 call_drv_execute_test(unsigned int test_num, unsigned int num_pe,
   unsigned int level, unsigned int print_level, unsigned long int test_input);
 
 int
-call_update_skip_list(unsigned int api_num, int *p_skip_test_num);
+call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num);
 
 int call_drv_wait_for_completion(void);
 

--- a/apps/linux/pcbsa-acs-app/pcbsa_drv_intf.c
+++ b/apps/linux/pcbsa-acs-app/pcbsa_drv_intf.c
@@ -159,7 +159,7 @@ call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
 }
 
 int
-call_update_skip_list(unsigned int api_num, int *p_skip_test_num)
+call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num)
 {
     FILE             *fd = NULL;
     pcbsa_drv_parms_t test_params;
@@ -213,4 +213,3 @@ int read_from_proc_pcbsa_msg(void)
   fclose(fd);
   return 0;
 }
-

--- a/apps/linux/sbsa-acs-app/include/sbsa_drv_intf.h
+++ b/apps/linux/sbsa-acs-app/include/sbsa_drv_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2016-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,22 +52,22 @@ typedef struct sbsa_array_update_u {
 /* Function Prototypes */
 
 int
-call_drv_init_test_env();
+call_drv_init_test_env(unsigned int print_level);
 
 int
-call_drv_clean_test_env();
+call_drv_clean_test_env(void);
 
 int
 call_drv_execute_test(unsigned int test_num, unsigned int num_pe,
   unsigned int level, unsigned int print_level, unsigned long int test_input);
 
 int
-call_update_skip_list(unsigned int api_num, int *p_skip_test_num);
+call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num);
 
 int
-call_drv_wait_for_completion();
+call_drv_wait_for_completion(void);
 
-int read_from_proc_sbsa_msg();
+int read_from_proc_sbsa_msg(void);
 
 /* Helper: send a u32 array to the driver via ioctl */
 int sbsa_send_array_u32(uint32_t hint, const uint32_t *arr, uint32_t count);

--- a/apps/linux/sbsa-acs-app/sbsa_drv_intf.c
+++ b/apps/linux/sbsa-acs-app/sbsa_drv_intf.c
@@ -70,7 +70,7 @@ call_drv_get_status(unsigned long int *arg0, unsigned long int *arg1, unsigned l
 }
 
 int
-call_drv_wait_for_completion()
+call_drv_wait_for_completion(void)
 {
   unsigned long int arg0, arg1, arg2;
 
@@ -114,7 +114,7 @@ call_drv_init_test_env(unsigned int print_level)
 }
 
 int
-call_drv_clean_test_env()
+call_drv_clean_test_env(void)
 {
     FILE             *fd = NULL;
     sbsa_drv_parms_t test_params;
@@ -135,7 +135,7 @@ call_drv_clean_test_env()
 
     fclose(fd);
 
-    call_drv_wait_for_completion();
+    return call_drv_wait_for_completion();
 }
 
 int
@@ -170,11 +170,11 @@ call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
     fwrite(&test_params,1,sizeof(test_params),fd);
 
     fclose(fd);
-
+    return 0;
 }
 
 int
-call_update_skip_list(unsigned int api_num, int *p_skip_test_num)
+call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num)
 {
     FILE             *fd = NULL;
     sbsa_drv_parms_t test_params;
@@ -197,7 +197,7 @@ call_update_skip_list(unsigned int api_num, int *p_skip_test_num)
     fwrite(&test_params,1,sizeof(test_params),fd);
 
     fclose(fd);
-
+    return 0;
 }
 
 typedef struct __SBSA_MSG__ {
@@ -205,7 +205,8 @@ typedef struct __SBSA_MSG__ {
     unsigned long data;
 }sbsa_msg_parms_t;
 
-int read_from_proc_sbsa_msg() {
+int read_from_proc_sbsa_msg(void)
+{
 
   char buf_msg[sizeof(sbsa_msg_parms_t)];
 
@@ -225,6 +226,7 @@ int read_from_proc_sbsa_msg() {
   }
 
   fclose(fd);
+  return 0;
 }
 
 int sbsa_send_array_u32(uint32_t hint, const uint32_t *arr, uint32_t count)

--- a/apps/uefi/acs.h
+++ b/apps/uefi/acs.h
@@ -147,25 +147,14 @@ uint32_t command_init(void);
 /* TODO remove #if once all ACS app using this header moves to rule based infra.*/
 #ifndef EXCLUDE_RBX
 /* Extern declarations */
-extern UINT32  g_pcie_p2p;
-extern UINT32  g_pcie_cache_present;
-extern bool    g_pcie_skip_dp_nic_ms;
-extern UINT32  g_print_level;
 extern UINT32  g_num_skip;
 extern UINT64  g_stack_pointer;
 extern UINT64  g_exception_ret_addr;
 extern UINT64  g_ret_addr;
-extern UINT32  g_timeout_pass;
-extern UINT32  g_timeout_fail;
-extern UINT32  g_timer_timeout_us; /* Timer timeout (us) */
 extern UINT32  g_build_sbsa;
 extern UINT32  g_build_pcbsa;
-extern UINT32  g_print_mmio;
 extern UINT32  g_curr_module;
 extern UINT32  g_enable_module;
-extern UINT32  g_crypto_support;
-extern UINT32  g_sys_last_lvl_cache;
-extern UINT32  g_el1skiptrap_mask;
 extern SHELL_FILE_HANDLE g_acs_log_file_handle;
 extern SHELL_FILE_HANDLE g_dtb_log_file_handle;
 extern BOOLEAN    g_invalid_arg_seen;

--- a/apps/uefi/acs_globals.c
+++ b/apps/uefi/acs_globals.c
@@ -23,33 +23,19 @@
 #include "acs.h"
 
 /* Global Variables */
-UINT32  g_pcie_p2p;
-UINT32  g_pcie_cache_present;
-bool    g_pcie_skip_dp_nic_ms = 0;
-UINT32  g_print_level;
 UINT32  *g_skip_test_num;
 UINT32  g_num_skip;
 UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
-UINT32  g_timeout_pass;
-UINT32  g_timeout_fail;
-UINT32  g_timer_timeout_us;            /* Timer timeout (us) */
 
 /* Following g_build_* is retained to have compatibility with tests which use it, and used pass
    on -a selection hint to tests */
 UINT32  g_build_sbsa = 0;
 UINT32  g_build_pcbsa = 0;
 
-UINT32  g_print_mmio;
 UINT32  g_curr_module;
 UINT32  g_enable_module;
-UINT32  g_crypto_support = TRUE;
-UINT32  g_sys_last_lvl_cache;
-
-/* Bitmask of EL1 register accesses to skip (workarounds for EL1 traps)
-   Configured via -el1skiptrap CLI option. */
-UINT32  g_el1skiptrap_mask = 0;
 
 /* File handles */
 SHELL_FILE_HANDLE g_acs_log_file_handle;

--- a/apps/uefi/acs_helpers.c
+++ b/apps/uefi/acs_helpers.c
@@ -409,9 +409,12 @@ command_init (void)
     CHAR16             *seg;
     CHAR16              last;
     acs_run_request_t  *ctx;
+    acs_execution_policy_t *policy;
 
     ctx = acs_get_run_request_mut();
     acs_release_run_request(ctx);
+    acs_reset_execution_policy();
+    policy = acs_get_execution_policy_mut();
 
     /* Process Command Line arguments */
     Status = ShellInitialize();
@@ -550,9 +553,10 @@ command_init (void)
     /* Parse -timeout */
     CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-timeout");
     if (CmdLineArg == NULL) {
-        g_timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT;
-        g_timeout_fail = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
-        g_timer_timeout_us = TIMER_TIMEOUT_DEFAULT;
+        policy->timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT;
+        policy->timeout_fail =
+            policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+        policy->timer_timeout_us = TIMER_TIMEOUT_DEFAULT;
     } else {
         /* Accept a single value; ignore any trailing delimiters */
         CHAR16 buf[64];
@@ -582,38 +586,40 @@ command_init (void)
             i--;
         }
 
-        g_timeout_pass = (UINT32)StrDecimalToUintn(buf);
-        g_timeout_fail = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
-        g_timer_timeout_us = g_timeout_pass;
-        if (!(g_timeout_pass >= TIMEOUT_THRESHOLD &&
-              g_timeout_pass <= TIMEOUT_MAX_THRESHOLD)) {
+        policy->timeout_pass = (UINT32)StrDecimalToUintn(buf);
+        policy->timeout_fail =
+            policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+        policy->timer_timeout_us = policy->timeout_pass;
+        if (!(policy->timeout_pass >= TIMEOUT_THRESHOLD &&
+              policy->timeout_pass <= TIMEOUT_MAX_THRESHOLD)) {
             Print(L"Invalid -timeout: pass timeout range should be within 500ms and 2sec\n");
             return SHELL_INVALID_PARAMETER;
         }
 
-        Print(L"Timeouts (us): PASS=%d, FAIL=%d\n", g_timeout_pass, g_timeout_fail);
+        Print(L"Timeouts (us): PASS=%d, FAIL=%d\n",
+              policy->timeout_pass, policy->timeout_fail);
     }
 
     /* Parse verbosity level */
     CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-v");
     if (CmdLineArg == NULL) {
-        g_print_level = G_PRINT_LEVEL;
+        policy->print_level = G_PRINT_LEVEL;
     } else {
         ReadVerbosity = StrDecimalToUintn(CmdLineArg);
         while (ReadVerbosity/10) {
             g_enable_module |= (1 << ReadVerbosity%10);
             ReadVerbosity /= 10;
         }
-        g_print_level = ReadVerbosity;
-        if (g_print_level > 5) {
-            g_print_level = G_PRINT_LEVEL;
+        policy->print_level = ReadVerbosity;
+        if (policy->print_level > 5) {
+            policy->print_level = G_PRINT_LEVEL;
         }
     }
 
     if (ShellCommandLineGetFlag (ParamPackage, L"-mmio")) {
-        g_print_mmio = TRUE;
+        policy->print_mmio = TRUE;
     } else {
-        g_print_mmio = FALSE;
+        policy->print_mmio = FALSE;
     }
 
     /* -f logfile option */
@@ -632,12 +638,13 @@ command_init (void)
     /* get System Last-level cache info */
     CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-slc");
     if (CmdLineArg == NULL) {
-        g_sys_last_lvl_cache = 0; /* default value. SLC unknown */
+        policy->sys_last_lvl_cache = 0; /* default value. SLC unknown */
     } else {
-        g_sys_last_lvl_cache = StrDecimalToUintn(CmdLineArg);
-        if (g_sys_last_lvl_cache > 2 || g_sys_last_lvl_cache < 1) {
-            Print(L"Invalid value provided for -slc, Value = %d\n", g_sys_last_lvl_cache);
-            g_sys_last_lvl_cache = 0; /* default value. SLC unknown */
+        policy->sys_last_lvl_cache = StrDecimalToUintn(CmdLineArg);
+        if (policy->sys_last_lvl_cache > 2 || policy->sys_last_lvl_cache < 1) {
+            Print(L"Invalid value provided for -slc, Value = %d\n",
+                  policy->sys_last_lvl_cache);
+            policy->sys_last_lvl_cache = 0; /* default value. SLC unknown */
         }
     }
 
@@ -666,7 +673,7 @@ command_init (void)
 
     /* no_crypto_ext */
     if ((ShellCommandLineGetFlag (ParamPackage, L"-no_crypto_ext")))
-        g_crypto_support = FALSE;
+        policy->crypto_support = FALSE;
 
 
     /* Options with Values: -r <comma-separated rule IDs or rules file> */
@@ -980,21 +987,21 @@ command_init (void)
     }
 
     if (ShellCommandLineGetFlag (ParamPackage, L"-skip-dp-nic-ms")) {
-        g_pcie_skip_dp_nic_ms = TRUE;
+        policy->pcie_skip_dp_nic_ms = TRUE;
     } else {
-        g_pcie_skip_dp_nic_ms = FALSE;
+        policy->pcie_skip_dp_nic_ms = FALSE;
     }
 
     if (ShellCommandLineGetFlag (ParamPackage, L"-p2p")) {
-        g_pcie_p2p = TRUE;
+        policy->pcie_p2p = TRUE;
     } else {
-        g_pcie_p2p = FALSE;
+        policy->pcie_p2p = FALSE;
     }
 
     if (ShellCommandLineGetFlag (ParamPackage, L"-cache")) {
-        g_pcie_cache_present = TRUE;
+        policy->pcie_cache_present = TRUE;
     } else {
-        g_pcie_cache_present = FALSE;
+        policy->pcie_cache_present = FALSE;
     }
 
     /* -el1skiptrap <params>: skip specific EL1 register accesses known to trap under hypervisors */
@@ -1032,13 +1039,13 @@ command_init (void)
                     for (ii = 0; ii < tlen; ii++) token[ii] = CmdLineArg[token_start + ii];
                     token[tlen] = L'\0';
 
-                    if (w_ascii_streq_caseins(token, L"pmsidr")) {
-                        g_el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
-                    } else if (w_ascii_streq_caseins(token, L"cntpct")) {
-                        g_el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
-                    } else if (w_ascii_streq_caseins(token, L"devmem")) {
-                        g_el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
-                    } else {
+        if (w_ascii_streq_caseins(token, L"pmsidr")) {
+                        policy->el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
+        } else if (w_ascii_streq_caseins(token, L"cntpct")) {
+                        policy->el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
+        } else if (w_ascii_streq_caseins(token, L"devmem")) {
+                        policy->el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
+        } else {
                         Print(L"Invalid -el1skiptrap token: %s\n", token);
                         invalid_token = TRUE;
                     }

--- a/apps/uefi/bsa_main.c
+++ b/apps/uefi/bsa_main.c
@@ -170,7 +170,7 @@ execute_tests()
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
               BSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
     val_print(INFO, "\n Creating Platform Information Tables\n");
 
     /* Modifying default memory attributes of UEFI*/

--- a/apps/uefi/drtm_main.c
+++ b/apps/uefi/drtm_main.c
@@ -30,7 +30,6 @@
 
 extern VOID* g_acs_log_file_handle;
 
-UINT32  g_print_level;
 UINT32  g_acs_tests_pass;
 UINT32  g_acs_tests_fail;
 UINT32  *g_skip_test_num;
@@ -39,7 +38,6 @@ UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
 UINT32  g_wakeup_timeout;
-UINT32  g_print_mmio;
 UINT32  g_curr_module;
 UINT32  g_enable_module;
 UINT32  *g_execute_tests;
@@ -103,6 +101,10 @@ command_init ()
   UINT32             Status;
   UINT32             i;
   UINT32             ReadVerbosity;
+  acs_execution_policy_t *policy;
+
+  acs_reset_execution_policy();
+  policy = acs_get_execution_policy_mut();
 
   //
   // Process Command Line arguments
@@ -150,16 +152,16 @@ command_init ()
     // Options with Values
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-v");
   if (CmdLineArg == NULL) {
-    g_print_level = 3;
+    policy->print_level = 3;
   } else {
     ReadVerbosity = StrDecimalToUintn(CmdLineArg);
     while (ReadVerbosity/10) {
       g_enable_module |= (1 << ReadVerbosity%10);
       ReadVerbosity /= 10;
     }
-    g_print_level = ReadVerbosity;
-    if (g_print_level > 5) {
-      g_print_level = 3;
+    policy->print_level = ReadVerbosity;
+    if (policy->print_level > 5) {
+      policy->print_level = 3;
     }
   }
 
@@ -306,7 +308,7 @@ execute_tests()
   val_print(INFO, "\n          Version %d.", DRTM_ACS_MAJOR_VER);
   val_print(INFO, "%d\n", DRTM_ACS_MINOR_VER);
 
-  val_print(INFO, "\n Starting tests with print level : %2d\n\n", g_print_level);
+  val_print(INFO, "\n Starting tests with print level : %2d\n\n", acs_policy_get_print_level());
   val_print(INFO, "\n Creating Platform Information Tables\n");
 
   Status = createPeInfoTable();

--- a/apps/uefi/mem_test_main.c
+++ b/apps/uefi/mem_test_main.c
@@ -26,7 +26,6 @@
 #include "val/include/acs_val.h"
 #include "val/include/acs_memory.h"
 
-bool   g_pcie_skip_dp_nic_ms = 0;
 extern EFI_SYSTEM_TABLE *mySystemTable;
 extern EFI_HANDLE myImageHandle;
 extern char _textbsa;
@@ -34,13 +33,10 @@ typedef unsigned long efi_status_t;
 efi_status_t  mem_model_execute_tests(EFI_HANDLE myImageHandle, EFI_SYSTEM_TABLE *mySystemTable);
 
 #include "acs.h"
-UINT32  g_pcie_p2p;
-UINT32  g_pcie_cache_present;
 UINT32  g_bsa_level;
 UINT32  g_bsa_only_level = 0;
 UINT32  g_sbsa_level;
 UINT32  g_sbsa_only_level = 0;
-UINT32  g_print_level;
 UINT32  g_sw_view[3] = {1, 1, 1}; //Operating System, Hypervisor, Platform Security
 UINT32  *g_skip_test_num;
 UINT32  g_num_skip;
@@ -50,20 +46,14 @@ UINT32  g_acs_tests_fail;
 UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
-UINT32  g_timeout_pass;
-UINT32  g_timeout_fail;
-UINT32  g_timer_timeout_us;
 UINT32  g_build_sbsa = 0;
 UINT32  g_build_pcbsa = 0;
-UINT32  g_print_mmio;
 UINT32  g_curr_module;
 UINT32  g_enable_module;
 UINT32  *g_execute_tests;
-UINT32  g_crypto_support = TRUE;
 UINT32  g_num_tests = 0;
 UINT32  *g_execute_modules;
 UINT32  g_num_modules = 0;
-UINT32  g_el1skiptrap_mask = 0;
 
 SHELL_FILE_HANDLE g_acs_log_file_handle;
 SHELL_FILE_HANDLE g_dtb_log_file_handle;
@@ -183,6 +173,10 @@ command_init ()
   UINT32             Status;
   UINT32             i;
   UINT32             ReadVerbosity;
+  acs_execution_policy_t *policy;
+
+  acs_reset_execution_policy();
+  policy = acs_get_execution_policy_mut();
 
   //
   // Process Command Line arguments
@@ -234,9 +228,10 @@ command_init ()
   /* Parse -timeout */
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-timeout");
   if (CmdLineArg == NULL) {
-      g_timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT;
-      g_timeout_fail = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
-      g_timer_timeout_us = TIMER_TIMEOUT_DEFAULT;
+      policy->timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT;
+      policy->timeout_fail =
+          policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+      policy->timer_timeout_us = TIMER_TIMEOUT_DEFAULT;
   } else {
       /* Accept a single value; ignore any trailing delimiters */
       CHAR16 buf[64];
@@ -266,38 +261,40 @@ command_init ()
           i--;
       }
 
-      g_timeout_pass = (UINT32)StrDecimalToUintn(buf);
-      g_timeout_fail = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
-      g_timer_timeout_us = g_timeout_pass;
-      if (!(g_timeout_pass >= TIMEOUT_THRESHOLD &&
-            g_timeout_pass <= TIMEOUT_MAX_THRESHOLD)) {
+      policy->timeout_pass = (UINT32)StrDecimalToUintn(buf);
+      policy->timeout_fail =
+          policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+      policy->timer_timeout_us = policy->timeout_pass;
+      if (!(policy->timeout_pass >= TIMEOUT_THRESHOLD &&
+            policy->timeout_pass <= TIMEOUT_MAX_THRESHOLD)) {
           Print(L"Invalid -timeout: pass timeout range should be within 500ms and 2sec\n");
           return SHELL_INVALID_PARAMETER;
       }
 
-      Print(L"Timeouts (us): PASS=%d, FAIL=%d\n", g_timeout_pass, g_timeout_fail);
+      Print(L"Timeouts (us): PASS=%d, FAIL=%d\n",
+            policy->timeout_pass, policy->timeout_fail);
   }
 
     // Options with Values
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-v");
   if (CmdLineArg == NULL) {
-    g_print_level = G_PRINT_LEVEL;
+    policy->print_level = G_PRINT_LEVEL;
   } else {
     ReadVerbosity = StrDecimalToUintn(CmdLineArg);
     while (ReadVerbosity/10) {
       g_enable_module |= (1 << ReadVerbosity%10);
       ReadVerbosity /= 10;
     }
-    g_print_level = ReadVerbosity;
-    if (g_print_level > 5) {
-      g_print_level = G_PRINT_LEVEL;
+    policy->print_level = ReadVerbosity;
+    if (policy->print_level > 5) {
+      policy->print_level = G_PRINT_LEVEL;
     }
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-mmio")) {
-    g_print_mmio = TRUE;
+    policy->print_mmio = TRUE;
   } else {
-    g_print_mmio = FALSE;
+    policy->print_mmio = FALSE;
   }
 
   g_bsa_level = G_BSA_LEVEL;
@@ -424,7 +421,7 @@ command_init ()
 
   // Options with Flags
   if ((ShellCommandLineGetFlag (ParamPackage, L"-no_crypto_ext")))
-     g_crypto_support = FALSE;
+     policy->crypto_support = FALSE;
 
   // Options with Values
   if (ShellCommandLineGetFlag (ParamPackage, L"-t")) {
@@ -505,21 +502,21 @@ command_init ()
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-skip-dp-nic-ms")) {
-    g_pcie_skip_dp_nic_ms = TRUE;
+    policy->pcie_skip_dp_nic_ms = TRUE;
   } else {
-    g_pcie_skip_dp_nic_ms = FALSE;
+    policy->pcie_skip_dp_nic_ms = FALSE;
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-p2p")) {
-    g_pcie_p2p = TRUE;
+    policy->pcie_p2p = TRUE;
   } else {
-    g_pcie_p2p = FALSE;
+    policy->pcie_p2p = FALSE;
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-cache")) {
-    g_pcie_cache_present = TRUE;
+    policy->pcie_cache_present = TRUE;
   } else {
-    g_pcie_cache_present = FALSE;
+    policy->pcie_cache_present = FALSE;
   }
 
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-el1skiptrap");
@@ -554,11 +551,11 @@ command_init ()
         token[tlen] = L'\0';
 
         if (w_ascii_streq_caseins(token, L"pmsidr")) {
-          g_el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
+          policy->el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
         } else if (w_ascii_streq_caseins(token, L"cntpct")) {
-          g_el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
+          policy->el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
         } else if (w_ascii_streq_caseins(token, L"devmem")) {
-          g_el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
+          policy->el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
         } else {
           Print(L"Invalid -el1skiptrap token: %s\n", token);
           HelpMsg();
@@ -723,7 +720,7 @@ execute_tests()
   if (g_bsa_only_level)
     g_bsa_level = 0;
 
-  val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+  val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
   val_print(INFO, "\n Creating Platform Information Tables\n");
 
 

--- a/apps/uefi/mpam_main.c
+++ b/apps/uefi/mpam_main.c
@@ -31,7 +31,6 @@
 
 #include "acs.h"
 
-UINT32  g_print_level;
 UINT32  g_execute_secure;
 UINT32  *g_skip_test_num;
 UINT32  g_num_skip;
@@ -41,7 +40,6 @@ UINT32  g_acs_tests_fail;
 UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
-UINT32  g_print_mmio;
 UINT32  g_curr_module;
 UINT32  g_enable_module;
 UINT32  *g_execute_tests;
@@ -225,6 +223,10 @@ command_init ()
     CHAR16             *ProbParam;
     UINT32             Status;
     UINT32             i;
+    acs_execution_policy_t *policy;
+
+    acs_reset_execution_policy();
+    policy = acs_get_execution_policy_mut();
 
     /* Process Command Line arguments */
     Status = ShellInitialize();
@@ -270,11 +272,11 @@ command_init ()
     /* Options with Values */
     CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-v");
     if (CmdLineArg == NULL) {
-        g_print_level = G_PRINT_LEVEL;
+        policy->print_level = G_PRINT_LEVEL;
     } else {
-        g_print_level = StrDecimalToUintn(CmdLineArg);
-        if (g_print_level > 5) {
-            g_print_level = G_PRINT_LEVEL;
+        policy->print_level = StrDecimalToUintn(CmdLineArg);
+        if (policy->print_level > 5) {
+            policy->print_level = G_PRINT_LEVEL;
         }
     }
 
@@ -396,7 +398,7 @@ execute_tests()
     Print(L"    Version %d.%d.", MPAM_ACS_MAJOR_VER, MPAM_ACS_MINOR_VER);
     Print(L"%d  \n", MPAM_ACS_SUBMINOR_VER);
 
-    Print(L"\n Starting tests for Print level %2d\n\n", g_print_level);
+    Print(L"\n Starting tests for Print level %2d\n\n", acs_policy_get_print_level());
 
     Print(L" Creating Platform Information Tables \n");
     Status = createPeInfoTable();

--- a/apps/uefi/pc_bsa_main.c
+++ b/apps/uefi/pc_bsa_main.c
@@ -152,7 +152,7 @@ execute_tests()
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
               BSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
     val_print(INFO, "\n Creating Platform Information Tables\n");
 
     /* Modifying default memory attributes of UEFI*/

--- a/apps/uefi/pfdi_main.c
+++ b/apps/uefi/pfdi_main.c
@@ -108,7 +108,7 @@ execute_tests()
   val_print(INFO, "%d.", PFDI_ACS_MINOR_VER);
   val_print(INFO, "%d\n", PFDI_ACS_SUBMINOR_VER);
 
-  val_print(INFO, "\n Starting tests with print level : %2d\n\n", g_print_level);
+  val_print(INFO, "\n Starting tests with print level : %2d\n\n", acs_policy_get_print_level());
   val_print(INFO, "\n Creating Platform Information Tables\n");
 
   Status = createPeInfoTable();

--- a/apps/uefi/sbsa_main.c
+++ b/apps/uefi/sbsa_main.c
@@ -176,7 +176,7 @@ execute_tests()
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
               SBSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
     val_print(INFO, "\n Creating Platform Information Tables\n");
 
     /* Modifying default memory attributes of UEFI*/

--- a/apps/uefi/sbsa_nist_main.c
+++ b/apps/uefi/sbsa_nist_main.c
@@ -28,14 +28,9 @@
 
 #include "acs.h"
 
-UINT32  g_pcie_p2p;
-UINT32  g_pcie_cache_present;
-bool    g_pcie_skip_dp_nic_ms = 0;
 UINT32  g_sbsa_level;
 UINT32  g_sbsa_only_level = 0;
-UINT32  g_print_level;
 UINT32  g_execute_nist;
-UINT32  g_print_mmio = FALSE;
 UINT32  g_curr_module = 0;
 UINT32  g_enable_module = 0;
 UINT32  *g_skip_test_num;
@@ -47,19 +42,11 @@ UINT32  g_num_modules = 0;
 UINT32  g_acs_tests_total;
 UINT32  g_acs_tests_pass;
 UINT32  g_acs_tests_fail;
-UINT32  g_crypto_support = TRUE;
 UINT64  g_stack_pointer;
 UINT64  g_exception_ret_addr;
 UINT64  g_ret_addr;
-UINT32  g_timeout_pass;
-UINT32  g_timeout_fail;
-UINT32  g_timer_timeout_us;
 UINT32 g_its_init = 0;
-UINT32  g_sys_last_lvl_cache;
 SHELL_FILE_HANDLE g_acs_log_file_handle;
-/* Bitmask of EL1 register accesses to skip in environments where those
-   specific reads are expected to trap. */
-UINT32  g_el1skiptrap_mask = 0;
 UINT32  g_build_sbsa = TRUE;
 
 #define SBSA_LEVEL_PRINT_FORMAT(level, only) ((level > SBSA_MAX_LEVEL_SUPPORTED) ? \
@@ -399,6 +386,10 @@ command_init ()
   UINT32             Status;
   UINT32             i;
   UINT32             ReadVerbosity;
+  acs_execution_policy_t *policy;
+
+  acs_reset_execution_policy();
+  policy = acs_get_execution_policy_mut();
 
   //
   // Process Command Line arguments
@@ -446,9 +437,10 @@ command_init ()
   /* Parse -timeout */
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-timeout");
   if (CmdLineArg == NULL) {
-      g_timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT;
-      g_timeout_fail = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
-      g_timer_timeout_us = TIMER_TIMEOUT_DEFAULT;
+      policy->timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT;
+      policy->timeout_fail =
+          policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+      policy->timer_timeout_us = TIMER_TIMEOUT_DEFAULT;
   } else {
       /* Accept a single value; ignore any trailing delimiters */
       CHAR16 buf[64];
@@ -478,38 +470,40 @@ command_init ()
           i--;
       }
 
-      g_timeout_pass = (UINT32)StrDecimalToUintn(buf);
-      g_timeout_fail = g_timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
-      g_timer_timeout_us = g_timeout_pass;
-      if (!(g_timeout_pass >= TIMEOUT_THRESHOLD &&
-            g_timeout_pass <= TIMEOUT_MAX_THRESHOLD)) {
+      policy->timeout_pass = (UINT32)StrDecimalToUintn(buf);
+      policy->timeout_fail =
+          policy->timeout_pass * WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER;
+      policy->timer_timeout_us = policy->timeout_pass;
+      if (!(policy->timeout_pass >= TIMEOUT_THRESHOLD &&
+            policy->timeout_pass <= TIMEOUT_MAX_THRESHOLD)) {
           Print(L"Invalid -timeout: pass timeout range should be within 500ms and 2sec\n");
           return SHELL_INVALID_PARAMETER;
       }
 
-      Print(L"Timeouts (us): PASS=%d, FAIL=%d\n", g_timeout_pass, g_timeout_fail);
+      Print(L"Timeouts (us): PASS=%d, FAIL=%d\n",
+            policy->timeout_pass, policy->timeout_fail);
   }
 
     // Options with Values
   CmdLineArg  = ShellCommandLineGetValue (ParamPackage, L"-v");
   if (CmdLineArg == NULL) {
-    g_print_level = G_PRINT_LEVEL;
+    policy->print_level = G_PRINT_LEVEL;
   } else {
     ReadVerbosity = StrDecimalToUintn(CmdLineArg);
     while (ReadVerbosity/10) {
       g_enable_module |= (1 << ReadVerbosity%10);
       ReadVerbosity /= 10;
     }
-    g_print_level = ReadVerbosity;
-    if (g_print_level > 5) {
-      g_print_level = G_PRINT_LEVEL;
+    policy->print_level = ReadVerbosity;
+    if (policy->print_level > 5) {
+      policy->print_level = G_PRINT_LEVEL;
     }
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-mmio")) {
-    g_print_mmio = TRUE;
+    policy->print_mmio = TRUE;
   } else {
-    g_print_mmio = FALSE;
+    policy->print_mmio = FALSE;
   }
 
   g_sbsa_level = G_SBSA_LEVEL;
@@ -639,21 +633,21 @@ command_init ()
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-skip-dp-nic-ms")) {
-    g_pcie_skip_dp_nic_ms = TRUE;
+    policy->pcie_skip_dp_nic_ms = TRUE;
   } else {
-    g_pcie_skip_dp_nic_ms = FALSE;
+    policy->pcie_skip_dp_nic_ms = FALSE;
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-p2p")) {
-    g_pcie_p2p = TRUE;
+    policy->pcie_p2p = TRUE;
   } else {
-    g_pcie_p2p = FALSE;
+    policy->pcie_p2p = FALSE;
   }
 
   if (ShellCommandLineGetFlag (ParamPackage, L"-cache")) {
-    g_pcie_cache_present = TRUE;
+    policy->pcie_cache_present = TRUE;
   } else {
-    g_pcie_cache_present = FALSE;
+    policy->pcie_cache_present = FALSE;
   }
 
   // Options with Flags
@@ -695,11 +689,11 @@ command_init ()
         token[tlen] = L'\0';
 
         if (w_ascii_streq_caseins(token, L"pmsidr")) {
-          g_el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
+          policy->el1skiptrap_mask |= EL1SKIPTRAP_PMSIDR;
         } else if (w_ascii_streq_caseins(token, L"cntpct")) {
-          g_el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
+          policy->el1skiptrap_mask |= EL1SKIPTRAP_CNTPCT;
         } else if (w_ascii_streq_caseins(token, L"devmem")) {
-          g_el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
+          policy->el1skiptrap_mask |= EL1SKIPTRAP_DEVMEM;
         } else {
           Print(L"Invalid -el1skiptrap token: %s\n", token);
           HelpMsg();
@@ -738,7 +732,7 @@ execute_tests()
   if (g_sbsa_only_level)
     g_sbsa_level = 0;
 
-  val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+  val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
   val_print(INFO, "\n Creating Platform Information Tables\n");
 
 

--- a/apps/uefi/vbsa_main.c
+++ b/apps/uefi/vbsa_main.c
@@ -158,7 +158,7 @@ execute_tests()
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
               VBSA_LEVEL_FR), ctx->level_value);
 
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
     val_print(INFO, "\n Creating Platform Information Tables\n");
 
     Status = createPeInfoTable();

--- a/apps/uefi/xbsa_main.c
+++ b/apps/uefi/xbsa_main.c
@@ -203,7 +203,7 @@ execute_tests()
     val_print(INFO, "\n          Version %d.", XBSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", XBSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", XBSA_ACS_SUBMINOR_VER);
-    val_print(INFO, "(Print level is %2d)\n\n", g_print_level);
+    val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
     val_print(INFO, "\n       Creating Platform Information Tables\n");
 
 

--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -23,13 +23,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include "pal_status.h"
+#include "pal_execution_policy.h"
 #include "platform_override_fvp.h"
 
 typedef uintptr_t addr_t;
 typedef char     char8_t;
 
-extern uint32_t g_print_level;
-extern uint32_t g_print_mmio;
 extern uint32_t g_curr_module;
 extern uint32_t g_enable_module;
 
@@ -69,8 +68,11 @@ void *pal_aligned_alloc( uint32_t alignment, uint32_t size );
 void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
 void pal_warn_not_implemented(const char *api_name);
-#define print(verbose, string, ...)  if(verbose >= g_print_level) \
-                                                   pal_uart_print(verbose, string, ##__VA_ARGS__)
+#define print(verbose, string, ...) \
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) \
+            pal_uart_print((verbose), (string), ##__VA_ARGS__); \
+    } while (0)
 
 #define PCIE_CREATE_BDF(Seg, Bus, Dev, Func) ((Seg << 24) | (Bus << 16) | (Dev << 8) | Func)
 

--- a/pal/baremetal/base/include/pal_execution_policy.h
+++ b/pal/baremetal/base/include/pal_execution_policy.h
@@ -1,0 +1,25 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __PAL_EXECUTION_POLICY_H__
+#define __PAL_EXECUTION_POLICY_H__
+
+#include "acs_execution_policy.h"
+
+const acs_execution_policy_t *acs_get_platform_execution_policy_defaults(void);
+
+#endif /* __PAL_EXECUTION_POLICY_H__ */

--- a/pal/baremetal/base/src/pal_hmat.c
+++ b/pal/baremetal/base/src/pal_hmat.c
@@ -96,6 +96,6 @@ void pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
       }
   }
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_hmat_dump_info_table(HmatTable);
 }

--- a/pal/baremetal/base/src/pal_iovirt.c
+++ b/pal/baremetal/base/src/pal_iovirt.c
@@ -290,7 +290,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   block = &(IoVirtTable->blocks[0]);
   print(ACS_PRINT_DEBUG, " Number of IOVIRT blocks = %d\n", IoVirtTable->num_blocks);
 
-  if (g_print_level <= ACS_PRINT_INFO) {
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO) {
       for (i = 0; i < IoVirtTable->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
       {
         dump_block(block);

--- a/pal/baremetal/base/src/pal_misc.c
+++ b/pal/baremetal/base/src/pal_misc.c
@@ -21,7 +21,6 @@
 #include "pal_common_support.h"
 #include "pal_pl011_uart.h"
 
-extern uint32_t  g_print_level;
 extern void* g_sbsa_log_file_handle;
 uint8_t   *gSharedMemory;
 
@@ -49,7 +48,7 @@ pal_mmio_read8(uint64_t addr)
   uint8_t data;
 
   data = (*(volatile uint8_t *)addr);
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_read8 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
@@ -69,7 +68,7 @@ pal_mmio_read16(uint64_t addr)
   uint16_t data;
 
   data = (*(volatile uint16_t *)addr);
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_read16 Address = %llx  Data = %lx\n", addr, data);
 
   return data;
@@ -89,7 +88,7 @@ pal_mmio_read64(uint64_t addr)
   uint64_t data;
 
   data = (*(volatile uint64_t *)addr);
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_read64 Address = %llx  Data = %llx\n", addr, data);
 
   return data;
@@ -110,7 +109,7 @@ pal_mmio_read(uint64_t addr)
   uint32_t data;
 
   data = (*(volatile uint32_t *)addr);
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_read Address = %8x  Data = %x\n", addr, data);
 
   return data;
@@ -129,7 +128,7 @@ pal_mmio_read(uint64_t addr)
 void
 pal_mmio_write8(uint64_t addr, uint8_t data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile uint8_t *)addr = data;
@@ -147,7 +146,7 @@ pal_mmio_write8(uint64_t addr, uint8_t data)
 void
 pal_mmio_write16(uint64_t addr, uint16_t data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile uint16_t *)addr = data;
@@ -165,7 +164,7 @@ pal_mmio_write16(uint64_t addr, uint16_t data)
 void
 pal_mmio_write64(uint64_t addr, uint64_t data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
 
   *(volatile uint64_t *)addr = data;
@@ -184,7 +183,7 @@ void
 pal_mmio_write(uint64_t addr, uint32_t data)
 {
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       print(ACS_PRINT_INFO, " pal_mmio_write Address = %8x  Data = %x\n", addr, data);
 
     *(volatile uint32_t *)addr = data;

--- a/pal/baremetal/base/src/pal_mpam.c
+++ b/pal/baremetal/base/src/pal_mpam.c
@@ -164,7 +164,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
       curr_entry = MPAM_NEXT_MSC(curr_entry);
   }
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_mpam_dump_table(MpamTable);
 }
 
@@ -236,6 +236,6 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr++;
   }
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_srat_dump_table(SratTable);
 }

--- a/pal/baremetal/base/src/pal_pcc.c
+++ b/pal/baremetal/base/src/pal_pcc.c
@@ -130,7 +130,7 @@ pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
     curr_entry++;
   }
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_pcc_dump_info_table(PccInfoTable);
 
   return;

--- a/pal/baremetal/base/src/pal_pmu.c
+++ b/pal/baremetal/base/src/pal_pmu.c
@@ -93,7 +93,7 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
       }
 
       /* Dump PMU info table */
-      if (g_print_level <= ACS_PRINT_INFO)
+      if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
           pal_pmu_dump_info_table(PmuTable);
   }
 }

--- a/pal/baremetal/base/src/pal_pptt.c
+++ b/pal/baremetal/base/src/pal_pptt.c
@@ -141,6 +141,6 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
 
   pal_cache_store_pe_res(CacheTable, PeTable);
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_cache_dump_info_table(CacheTable, PeTable);
 }

--- a/pal/baremetal/base/src/pal_ras.c
+++ b/pal/baremetal/base/src/pal_ras.c
@@ -236,7 +236,7 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
       curr_node++;
   }
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_ras_dump_info_table(RasInfoTable);
 }
 
@@ -333,6 +333,6 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
       RasFeatInfoTable->num_all_block++;
   }
 
-  if (g_print_level <= ACS_PRINT_INFO)
+  if (acs_policy_get_print_level() <= ACS_PRINT_INFO)
       pal_ras2_dump_info_table(RasFeatInfoTable);
 }

--- a/pal/baremetal/run_time_params.rst
+++ b/pal/baremetal/run_time_params.rst
@@ -151,17 +151,18 @@ At boot, ACS:
 
        **shared runtime and filter overrides from EL3 parameters**
 
-      - overrides ``g_pcie_p2p            `` if p2p is set
-      - overrides ``g_pcie_skip_dp_nic_ms `` if pcie skip is set
-      - overrides ``g_print_level         `` if print level is set
-      - overrides timeout-related globals if wakeup timeout is set
-      - overrides ``g_print_mmio          `` if print mmio is set
-      - overrides ``g_crypto_support      `` if crypto support is set
-      - overrides ``ctx->bsa_sw_view_mask `` if software view mask is set
-      - overrides ``g_pcie_cache_present  `` if pcie cache is set
-      - overrides ``g_sys_last_lvl_cache  `` if system level cache is set
+      - overrides ``policy->pcie_p2p`` if p2p is set
+      - overrides ``policy->pcie_skip_dp_nic_ms`` if PCIe skip is set
+      - overrides ``policy->print_level`` if print level is set
+      - overrides ``policy->timeout_pass`` / ``policy->timeout_fail`` /
+        ``policy->timer_timeout_us`` if wakeup timeout is set
+      - overrides ``policy->print_mmio`` if print MMIO is set
+      - clears ``policy->crypto_support`` if the ``no_crypto_ext`` EL3 flag is set
+      - overrides ``ctx->bsa_sw_view_mask`` if software view mask is set
+      - overrides ``policy->pcie_cache_present`` if PCIe cache is set
+      - overrides ``policy->sys_last_lvl_cache`` if system level cache is set
       - overrides ``ctx->level_filter_mode`` if level filter mode is set
-      - overrides ``ctx->level_value      `` if level value is set
+      - overrides ``ctx->level_value`` if level value is set
 3. Uses the (possibly overridden) ``ctx->execute_modules`` / ``ctx->num_modules`` to
    decide which modules and rule filters apply, and then:
    * Creates only the required information tables.

--- a/pal/baremetal/target/RDN2/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDN2/include/pal_exerciser.h
@@ -18,9 +18,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include "acs_execution_policy.h"
 #include "platform_override_fvp.h"
 
-extern uint32_t g_print_level;
 #define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
 #define ACS_PRINT_WARN  4      /* Only warnings & errors. use this to de-clutter the terminal and focus only on specifics */
 #define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
@@ -35,13 +35,19 @@ extern uint32_t g_print_level;
 #ifdef TARGET_BAREMETAL
 void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
-#define print(verbose, string, ...)  if(verbose >= g_print_level) \
-                                                   pal_uart_print(verbose, string, ##__VA_ARGS__)
+#define print(verbose, string, ...) \
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) \
+            pal_uart_print((verbose), (string), ##__VA_ARGS__); \
+    } while (0)
 #else
-/* edk2 print function is used only in Exerciser tests under UEFI */
 #include <Library/UefiLib.h>
-#define print(verbose, string, ...) if(verbose >= g_print_level) \
-                                            Print(L##string, ##__VA_ARGS__)
+
+#define print(verbose, string, ...) \
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) \
+            Print(L##string, ##__VA_ARGS__); \
+    } while (0)
 #endif
 
 #define PCIE_CREATE_BDF(Seg, Bus, Dev, Func) ((Seg << 24) | (Bus << 16) | (Dev << 8) | Func)

--- a/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
@@ -56,16 +56,6 @@ uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules
 uint32_t  g_skip_modules_arr[] = {};
 uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
 
-/* Bitmask of EL1 register accesses to skip. For example:
-   g_el1skiptrap_mask = EL1SKIPTRAP_CNTPCT; */
-uint32_t  g_el1skiptrap_mask = 0;
-
-/* B_PE_06 and S_L5PE_05 rules are conditional implementation based on export restrictions
-   In case due to export restrictions, cryptography algorithm support is not present, set
-   g_crypto_support to FALSE (Default value is TRUE)
-*/
-uint32_t g_crypto_support    = TRUE;
-
 /* The Baremetal app supports three filtering modes
     LVL_FILTER_MAX,    run rules with level <= selected level
     LVL_FILTER_ONLY,   run rules with level == selected level
@@ -73,17 +63,32 @@ uint32_t g_crypto_support    = TRUE;
 */
 uint32_t g_level_filter_mode = LVL_FILTER_MAX; /* Default set to LVL_FILTER_MAX */
 
-/* Specify SLC cache type
-    System Last-Level cache valid values
-    0 - Unknown
-    1 - PPTT PE-side LLC
-    2 - HMAT mem-side LLC
-*/
-uint32_t g_sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC;
+/*
+ * Platform execution-policy defaults overlaid on top of the generic runtime
+ * policy reset.
+ *
+ * sys_last_lvl_cache valid values:
+ *   0 - Unknown
+ *   1 - PPTT PE-side LLC
+ *   2 - HMAT mem-side LLC
+ *
+ * el1skiptrap_mask is a bitmask composed from EL1SKIPTRAP_* flags when a
+ * platform needs specific EL1 register accesses skipped.
+ */
+static const acs_execution_policy_t g_platform_execution_policy = {
+    .timeout_pass = PLATFORM_OVERRIDE_TIMEOUT,
+    .timeout_fail = PLATFORM_OVERRIDE_FAILSAFE_TIMEOUT,
+    .timer_timeout_us = PLATFORM_OVERRIDE_TIMER_TIMEOUT,
+    .crypto_support = TRUE,
+    .sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC,
+    .el1skiptrap_mask = 0,
+};
 
-uint32_t g_timeout_pass = PLATFORM_OVERRIDE_TIMEOUT;
-uint32_t g_timeout_fail = PLATFORM_OVERRIDE_FAILSAFE_TIMEOUT;
-uint32_t g_timer_timeout_us = PLATFORM_OVERRIDE_TIMER_TIMEOUT; /* Timer timeout (us) */
+const acs_execution_policy_t *
+acs_get_platform_execution_policy_defaults(void)
+{
+    return &g_platform_execution_policy;
+}
 
 const PE_SMBIOS_PROCESSOR_INFO_TABLE platform_smbios_cfg = {
     .slot_count = PLATFORM_OVERRIDE_SMBIOS_SLOT_COUNT,

--- a/pal/baremetal/target/RDV3/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3/include/pal_exerciser.h
@@ -18,9 +18,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include "acs_execution_policy.h"
 #include "platform_override_fvp.h"
 
-extern uint32_t g_print_level;
 #define ACS_PRINT_ERR   5      /* Only Errors. Use this to trim output to key info */
 #define ACS_PRINT_WARN  4      /* Only warnings & errors. Use this to trim output to key info */
 #define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
@@ -37,7 +37,7 @@ void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
 #define print(verbose, string, ...) \
     do { \
-        if ((verbose) >= g_print_level) \
+        if ((verbose) >= acs_policy_get_print_level()) \
             pal_uart_print((verbose), (string), ##__VA_ARGS__); \
     } while (0)
 #else
@@ -45,7 +45,7 @@ void *mem_alloc(size_t alignment, size_t size);
 
 #define print(verbose, string, ...) \
     do { \
-        if ((verbose) >= g_print_level) \
+        if ((verbose) >= acs_policy_get_print_level()) \
             Print(L##string, ##__VA_ARGS__); \
     } while (0)
 #endif

--- a/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
@@ -56,16 +56,6 @@ uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules
 uint32_t  g_skip_modules_arr[] = {};
 uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
 
-/* Bitmask of EL1 register accesses to skip. For example:
-   g_el1skiptrap_mask = EL1SKIPTRAP_CNTPCT; */
-uint32_t  g_el1skiptrap_mask = 0;
-
-/* B_PE_06 and S_L5PE_05 rules are conditional implementation based on export restrictions
-   In case due to export restrictions, cryptography algorithm support is not present, set
-   g_crypto_support to FALSE (Default value is TRUE)
-*/
-uint32_t g_crypto_support    = TRUE;
-
 /* The Baremetal app supports three filtering modes
     LVL_FILTER_MAX,    run rules with level <= selected level
     LVL_FILTER_ONLY,   run rules with level == selected level
@@ -73,17 +63,32 @@ uint32_t g_crypto_support    = TRUE;
 */
 uint32_t g_level_filter_mode = LVL_FILTER_MAX; /* Default set to LVL_FILTER_MAX */
 
-/* Specify SLC cache type
-    System Last-Level cache valid values
-    0 - Unknown
-    1 - PPTT PE-side LLC
-    2 - HMAT mem-side LLC
-*/
-uint32_t g_sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC;
+/*
+ * Platform execution-policy defaults overlaid on top of the generic runtime
+ * policy reset.
+ *
+ * sys_last_lvl_cache valid values:
+ *   0 - Unknown
+ *   1 - PPTT PE-side LLC
+ *   2 - HMAT mem-side LLC
+ *
+ * el1skiptrap_mask is a bitmask composed from EL1SKIPTRAP_* flags when a
+ * platform needs specific EL1 register accesses skipped.
+ */
+static const acs_execution_policy_t g_platform_execution_policy = {
+    .timeout_pass = PLATFORM_OVERRIDE_TIMEOUT,
+    .timeout_fail = PLATFORM_OVERRIDE_FAILSAFE_TIMEOUT,
+    .timer_timeout_us = PLATFORM_OVERRIDE_TIMER_TIMEOUT,
+    .crypto_support = TRUE,
+    .sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC,
+    .el1skiptrap_mask = 0,
+};
 
-uint32_t g_timeout_pass = PLATFORM_OVERRIDE_TIMEOUT;
-uint32_t g_timeout_fail = PLATFORM_OVERRIDE_FAILSAFE_TIMEOUT;
-uint32_t g_timer_timeout_us = PLATFORM_OVERRIDE_TIMER_TIMEOUT; /* Timer timeout (us) */
+const acs_execution_policy_t *
+acs_get_platform_execution_policy_defaults(void)
+{
+    return &g_platform_execution_policy;
+}
 
 const PE_SMBIOS_PROCESSOR_INFO_TABLE platform_smbios_cfg = {
     .slot_count = PLATFORM_OVERRIDE_SMBIOS_SLOT_COUNT,

--- a/pal/baremetal/target/RDV3CFG1/README.md
+++ b/pal/baremetal/target/RDV3CFG1/README.md
@@ -43,7 +43,7 @@ Follow the build steps mentioned in [README](../../README.md) with the TARGET pa
 
 ## Known Limitations
 
-**Note:** To run PCIe MSE tests on RDV3-Cfg1 FVP, add `-C pcie_group_0.pcie0.ur_rao_wi=1` to `run_model.sh` so UR handling is enabled and the tests do not trigger an EL3 exception. If PCIe MSE tests still fail, set `g_pcie_skip_dp_nic_ms=1` in `apps/baremetal/acs_globals.c` locally.
+**Note:** To run PCIe MSE tests on RDV3-Cfg1 FVP, add `-C pcie_group_0.pcie0.ur_rao_wi=1` to `run_model.sh` so UR handling is enabled and the tests do not trigger an EL3 exception. If PCIe MSE tests still fail, set `.pcie_skip_dp_nic_ms = true` in `g_platform_execution_policy` in `pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c` locally.
 
 -----------------
 

--- a/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
@@ -18,9 +18,9 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include "acs_execution_policy.h"
 #include "platform_override_fvp.h"
 
-extern uint32_t g_print_level;
 #define ACS_PRINT_ERR   5      /* Only Errors. Use this to trim output to key info */
 #define ACS_PRINT_WARN  4      /* Only warnings & errors. Use this to trim output to key info */
 #define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
@@ -37,7 +37,7 @@ void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
 #define print(verbose, string, ...) \
     do { \
-        if ((verbose) >= g_print_level) \
+        if ((verbose) >= acs_policy_get_print_level()) \
             pal_uart_print((verbose), (string), ##__VA_ARGS__); \
     } while (0)
 #else
@@ -45,7 +45,7 @@ void *mem_alloc(size_t alignment, size_t size);
 
 #define print(verbose, string, ...) \
     do { \
-        if ((verbose) >= g_print_level) \
+        if ((verbose) >= acs_policy_get_print_level()) \
             Print(L##string, ##__VA_ARGS__); \
     } while (0)
 #endif

--- a/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
@@ -56,16 +56,6 @@ uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules
 uint32_t  g_skip_modules_arr[] = {};
 uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
 
-/* Bitmask of EL1 register accesses to skip. For example:
-   g_el1skiptrap_mask = EL1SKIPTRAP_CNTPCT; */
-uint32_t  g_el1skiptrap_mask = 0;
-
-/* B_PE_06 and S_L5PE_05 rules are conditional implementation based on export restrictions
-   In case due to export restrictions, cryptography algorithm support is not present, set
-   g_crypto_support to FALSE (Default value is TRUE)
-*/
-uint32_t g_crypto_support    = TRUE;
-
 /* The Baremetal app supports three filtering modes
     LVL_FILTER_MAX,    run rules with level <= selected level
     LVL_FILTER_ONLY,   run rules with level == selected level
@@ -73,17 +63,32 @@ uint32_t g_crypto_support    = TRUE;
 */
 uint32_t g_level_filter_mode = LVL_FILTER_MAX; /* Default set to LVL_FILTER_MAX */
 
-/* Specify SLC cache type
-    System Last-Level cache valid values
-    0 - Unknown
-    1 - PPTT PE-side LLC
-    2 - HMAT mem-side LLC
-*/
-uint32_t g_sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC;
+/*
+ * Platform execution-policy defaults overlaid on top of the generic runtime
+ * policy reset.
+ *
+ * sys_last_lvl_cache valid values:
+ *   0 - Unknown
+ *   1 - PPTT PE-side LLC
+ *   2 - HMAT mem-side LLC
+ *
+ * el1skiptrap_mask is a bitmask composed from EL1SKIPTRAP_* flags when a
+ * platform needs specific EL1 register accesses skipped.
+ */
+static const acs_execution_policy_t g_platform_execution_policy = {
+    .timeout_pass = PLATFORM_OVERRIDE_TIMEOUT,
+    .timeout_fail = PLATFORM_OVERRIDE_FAILSAFE_TIMEOUT,
+    .timer_timeout_us = PLATFORM_OVERRIDE_TIMER_TIMEOUT,
+    .crypto_support = TRUE,
+    .sys_last_lvl_cache = PLATFORM_OVERRRIDE_SLC,
+    .el1skiptrap_mask = 0,
+};
 
-uint32_t g_timeout_pass = PLATFORM_OVERRIDE_TIMEOUT;
-uint32_t g_timeout_fail = PLATFORM_OVERRIDE_FAILSAFE_TIMEOUT;
-uint32_t g_timer_timeout_us = PLATFORM_OVERRIDE_TIMER_TIMEOUT; /* Timer timeout (us) */
+const acs_execution_policy_t *
+acs_get_platform_execution_policy_defaults(void)
+{
+    return &g_platform_execution_policy;
+}
 
 const PE_SMBIOS_PROCESSOR_INFO_TABLE platform_smbios_cfg = {
     .slot_count = PLATFORM_OVERRIDE_SMBIOS_SLOT_COUNT,

--- a/pal/include/platform_override.h
+++ b/pal/include/platform_override.h
@@ -74,6 +74,3 @@
 
 /*Max timeout set for systimer*/
 #define PLATFORM_OVERRIDE_SYS_TIMEOUT_MAX      0xFFFFFFFF
-
-extern UINT32 g_pcie_p2p;
-extern UINT32 g_pcie_cache_present;

--- a/pal/uefi_acpi/PalLib.inf
+++ b/pal/uefi_acpi/PalLib.inf
@@ -23,7 +23,7 @@
   MODULE_TYPE                    = UEFI_APPLICATION
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = PalLib|UEFI_APPLICATION UEFI_DRIVER
-  DEFINE PAL_UEFI_ACPI_INCLUDE_FLAGS = -I${ACS_PATH}/pal/include -I${ACS_PATH}/pal/uefi_acpi/include -I${ACS_PATH}/pal/baremetal/target/RDN2/include/
+  DEFINE PAL_UEFI_ACPI_INCLUDE_FLAGS = -I${ACS_PATH}/pal/include -I${ACS_PATH}/pal/uefi_acpi/include -I${ACS_PATH}/pal/baremetal/target/RDN2/include/ -I${ACS_PATH}/val/include
 [Sources.common]
   src/AArch64/ArmSmc.S
   src/AArch64/AcsTestInfra.S

--- a/pal/uefi_acpi/SbsaPalNistLib.inf
+++ b/pal/uefi_acpi/SbsaPalNistLib.inf
@@ -22,7 +22,7 @@
   MODULE_TYPE                    = UEFI_APPLICATION
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = SbsaPalNistLib|UEFI_APPLICATION UEFI_DRIVER
-  DEFINE PAL_NIST_INCLUDE_FLAGS     = -I${ACS_PATH}/pal/include -I${ACS_PATH}/pal/uefi_acpi/include -I${ACS_PATH}/pal/baremetal/target/RDN2/include/
+  DEFINE PAL_NIST_INCLUDE_FLAGS     = -I${ACS_PATH}/pal/include -I${ACS_PATH}/pal/uefi_acpi/include -I${ACS_PATH}/pal/baremetal/target/RDN2/include/ -I${ACS_PATH}/val/include
 
 [Sources.common]
   src/AArch64/ArmSmc.S
@@ -86,4 +86,3 @@
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
   GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_NIST_INCLUDE_FLAGS)
-

--- a/pal/uefi_acpi/include/pal_uefi.h
+++ b/pal/uefi_acpi/include/pal_uefi.h
@@ -19,6 +19,7 @@
 #define __PAL_UEFI_H__
 
 #include "pal_status.h"
+#include "acs_execution_policy.h"
 
 /* include ACPI specification headers */
 #include "Include/Guid/Acpi.h"
@@ -32,12 +33,8 @@
 UINT64 pal_get_acpi_table_ptr(UINT32 table_signature);
 
 extern VOID* g_acs_log_file_handle;
-extern UINT32 g_print_level;
-extern UINT32 g_print_mmio;
 extern UINT32 g_curr_module;
 extern UINT32 g_enable_module;
-extern UINT32 g_pcie_p2p;
-extern UINT32 g_pcie_cache_present;
 VOID pal_warn_not_implemented(const CHAR8 *api_name);
 
 #define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
@@ -93,8 +90,11 @@ typedef struct {
   UINT64   Arg7;
 } ARM_SMC_ARGS;
 
-#define acs_print(verbose, string, ...) if(verbose >= g_print_level) \
-                                            Print(string, ##__VA_ARGS__)
+#define acs_print(verbose, string, ...) \
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) \
+            Print((string), ##__VA_ARGS__); \
+    } while (0)
 
 /**
   Conduits for service calls (SMC vs HVC).

--- a/pal/uefi_acpi/src/pal_misc.c
+++ b/pal/uefi_acpi/src/pal_misc.c
@@ -37,7 +37,7 @@ UINT8   *gSharedMemory;
 VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT8 *)addr = data;
@@ -55,7 +55,7 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT16 *)addr = data;
@@ -73,7 +73,7 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
 
   *(volatile UINT64 *)addr = data;
@@ -94,7 +94,7 @@ pal_mmio_read8(UINT64 addr)
 
   data = (*(volatile UINT8 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read8 Address = %lx  Data = %lx\n", addr, data);
 
   return data;
@@ -115,7 +115,7 @@ pal_mmio_read16(UINT64 addr)
 
   data = (*(volatile UINT16 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read16 Address = %lx  Data = %lx\n", addr, data);
 
   return data;
@@ -136,7 +136,7 @@ pal_mmio_read64(UINT64 addr)
 
   data = (*(volatile UINT64 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read64 Address = %lx  Data = %lx\n", addr, data);
 
   return data;
@@ -157,7 +157,7 @@ pal_mmio_read(UINT64 addr)
 
   data = (*(volatile UINT32 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read Address = %lx  Data = %x\n", addr, data);
 
   return data;
@@ -176,7 +176,7 @@ VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x\n", addr, data);
 
   *(volatile UINT32 *)addr = data;

--- a/pal/uefi_acpi/src/pal_pcie.c
+++ b/pal/uefi_acpi/src/pal_pcie.c
@@ -351,7 +351,7 @@ pal_pcie_p2p_support()
    * PCIe support for peer to peer
    * transactions is platform implementation specific
   */
-  if (g_pcie_p2p)
+  if (acs_policy_get_pcie_p2p())
       return 0;
   else {
       pal_warn_not_implemented(__func__);
@@ -486,7 +486,7 @@ pal_pcie_is_cache_present (
   UINT32 Fn
   )
 {
-  if (g_pcie_cache_present)
+  if (acs_policy_get_pcie_cache_present())
       return 1;
   else {
       pal_warn_not_implemented(__func__);

--- a/pal/uefi_dt/PalLib.inf
+++ b/pal/uefi_dt/PalLib.inf
@@ -23,7 +23,7 @@
   MODULE_TYPE                    = UEFI_APPLICATION
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = BsaPalLib|UEFI_APPLICATION UEFI_DRIVER
-  DEFINE PAL_UEFI_DT_INCLUDE_FLAGS   = -I${ACS_PATH}/pal/include -I${ACS_PATH}/pal/uefi_dt/include -I${ACS_PATH}/pal/baremetal/target/RDN2/include/
+  DEFINE PAL_UEFI_DT_INCLUDE_FLAGS   = -I${ACS_PATH}/pal/include -I${ACS_PATH}/pal/uefi_dt/include -I${ACS_PATH}/pal/baremetal/target/RDN2/include/ -I${ACS_PATH}/val/include
   DEFINE BASE_FDT_LIB_INCLUDE_FLAGS  = -I$(WORKSPACE)/MdePkg/Library/BaseFdtLib/libfdt/libfdt
 
 [Sources.common]

--- a/pal/uefi_dt/include/pal_uefi.h
+++ b/pal/uefi_dt/include/pal_uefi.h
@@ -19,14 +19,11 @@
 #define __PAL_UEFI_H__
 
 #include "pal_status.h"
+#include "acs_execution_policy.h"
 
 extern VOID* g_acs_log_file_handle;
-extern UINT32 g_print_level;
-extern UINT32 g_print_mmio;
 extern UINT32 g_curr_module;
 extern UINT32 g_enable_module;
-extern UINT32 g_pcie_p2p;
-extern UINT32 g_pcie_cache_present;
 VOID pal_warn_not_implemented(const CHAR8 *api_name);
 
 #define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
@@ -82,8 +79,11 @@ typedef struct {
   UINT64   Arg7;
 } ARM_SMC_ARGS;
 
-#define acs_print(verbose, string, ...) if(verbose >= g_print_level) \
-                                            Print(string, ##__VA_ARGS__)
+#define acs_print(verbose, string, ...) \
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) \
+            Print((string), ##__VA_ARGS__); \
+    } while (0)
 
 /**
   Conduits for service calls (SMC vs HVC).

--- a/pal/uefi_dt/src/pal_misc.c
+++ b/pal/uefi_dt/src/pal_misc.c
@@ -39,7 +39,7 @@ UINT8   *gSharedMemory;
 VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT8 *)addr = data;
@@ -57,7 +57,7 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
 
   *(volatile UINT16 *)addr = data;
@@ -75,7 +75,7 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
 
   *(volatile UINT64 *)addr = data;
@@ -96,7 +96,7 @@ pal_mmio_read8(UINT64 addr)
 
   data = (*(volatile UINT8 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read8 Address = %lx  Data = %lx\n", addr, data);
 
   return data;
@@ -117,7 +117,7 @@ pal_mmio_read16(UINT64 addr)
 
   data = (*(volatile UINT16 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read16 Address = %lx  Data = %lx\n", addr, data);
 
   return data;
@@ -138,7 +138,7 @@ pal_mmio_read64(UINT64 addr)
 
   data = (*(volatile UINT64 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read64 Address = %lx  Data = %lx\n", addr, data);
 
   return data;
@@ -159,7 +159,7 @@ pal_mmio_read(UINT64 addr)
 
   data = (*(volatile UINT32 *)addr);
 
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_read Address = %lx  Data = %x\n", addr, data);
 
   return data;
@@ -177,7 +177,7 @@ pal_mmio_read(UINT64 addr)
 VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
-  if (g_print_mmio || (g_curr_module & g_enable_module))
+  if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       acs_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x\n", addr, data);
 
   *(volatile UINT32 *)addr = data;

--- a/pal/uefi_dt/src/pal_pcie.c
+++ b/pal/uefi_dt/src/pal_pcie.c
@@ -352,7 +352,7 @@ pal_pcie_p2p_support()
    * PCIe support for peer to peer
    * transactions is platform implementation specific
   */
-  if (g_pcie_p2p)
+  if (acs_policy_get_pcie_p2p())
       return 0;
   else {
       pal_warn_not_implemented(__func__);
@@ -479,7 +479,7 @@ pal_pcie_is_cache_present (
   UINT32 Fn
   )
 {
-  if (g_pcie_cache_present)
+  if (acs_policy_get_pcie_cache_present())
       return 1;
   else {
       pal_warn_not_implemented(__func__);

--- a/test_pool/gic/g013.c
+++ b/test_pool/gic/g013.c
@@ -37,7 +37,7 @@ payload()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
 
-  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
+  if (!(acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT)) {
    /* Check non-secure physical timer interrupt */
    intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
    if (IS_PPI_RESERVED(intid))

--- a/test_pool/memory_map/m002.c
+++ b/test_pool/memory_map/m002.c
@@ -58,7 +58,7 @@ payload()
   val_pe_install_esr(EXCEPT_AARCH64_SERROR, esr);
   val_set_status(index, RESULT_SKIP(1));
 
-  if (g_el1skiptrap_mask & EL1SKIPTRAP_DEVMEM) {
+  if (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_DEVMEM) {
       val_print(DEBUG,
                 "\n       Skipping device memory access due to -el1skiptrap devmem");
       goto normal_mem_test;

--- a/test_pool/mpam/mpam007.c
+++ b/test_pool/mpam/mpam007.c
@@ -187,15 +187,17 @@ static void payload(void)
     /* if both PPTT LLC and mem-side cache MSCs found, read user input to
        know which should be considered as Last level System Cache */
     if (pptt_llc_msc_found && mem_llc_msc_found) {
-        if (g_sys_last_lvl_cache == SLC_TYPE_UNKNOWN) {
+        if (acs_policy_get_sys_last_lvl_cache() == SLC_TYPE_UNKNOWN) {
             val_print(ERROR, "\n       PPTT and memside LLC MSC found, Please provide"
                       "System Last-Level cache info via -slc cmdline option \n");
             val_set_status(index, RESULT_FAIL(03));
             return;
-        } else if (g_sys_last_lvl_cache == SLC_TYPE_PPTT_CACHE && pptt_llc_cpor_supported) {
+        } else if (acs_policy_get_sys_last_lvl_cache() == SLC_TYPE_PPTT_CACHE &&
+                   pptt_llc_cpor_supported) {
             val_set_status(index, RESULT_PASS);
             return;
-        } else if (g_sys_last_lvl_cache == SLC_TYPE_MEMSIDE_CACHE && memside_llc_cpor_supported) {
+        } else if (acs_policy_get_sys_last_lvl_cache() == SLC_TYPE_MEMSIDE_CACHE &&
+                   memside_llc_cpor_supported) {
             val_set_status(index, RESULT_PASS);
             return;
         } else {

--- a/test_pool/pcie/p004.c
+++ b/test_pool/pcie/p004.c
@@ -25,8 +25,6 @@
 #define KNOWN_DATA  0xABABABAB
 
 static void *branch_to_test;
-extern bool g_pcie_skip_dp_nic_ms;
-
 static
 void
 esr(uint64_t interrupt_type, void *context)
@@ -77,7 +75,7 @@ check_bdf_under_rp(uint32_t rp_bdf)
                   val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
                   val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
                   base_cc = reg_value >> TYPE01_BCC_SHIFT;
-                  if (g_pcie_skip_dp_nic_ms &&
+                  if (acs_policy_get_pcie_skip_dp_nic_ms() &&
                       ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
                       || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)))
                       return 1;

--- a/test_pool/pcie/p005.c
+++ b/test_pool/pcie/p005.c
@@ -25,8 +25,6 @@
 #define KNOWN_DATA  0xABABABAB
 
 static void *branch_to_test;
-extern bool g_pcie_skip_dp_nic_ms;
-
 static
 void
 esr(uint64_t interrupt_type, void *context)
@@ -77,7 +75,7 @@ check_bdf_under_rp(uint32_t rp_bdf)
                   val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
                   val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
                   base_cc = reg_value >> TYPE01_BCC_SHIFT;
-                  if (g_pcie_skip_dp_nic_ms &&
+                  if (acs_policy_get_pcie_skip_dp_nic_ms() &&
                       ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
                       || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)))
                       return 1;

--- a/test_pool/pcie/p030.c
+++ b/test_pool/pcie/p030.c
@@ -24,8 +24,6 @@
 #define TEST_DESC  "Check Cmd Reg memory space enable     "
 
 static void *branch_to_test;
-extern bool g_pcie_skip_dp_nic_ms;
-
 static
 void
 esr(uint64_t interrupt_type, void *context)
@@ -79,7 +77,7 @@ get_dsf_bdf(uint32_t rp_bdf, uint32_t *target_bdf)
           val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Downstream class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (g_pcie_skip_dp_nic_ms &&
+          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
               val_print(DEBUG, "\n       Skipping downstream BDF 0x%x", dev_bdf);
@@ -161,7 +159,7 @@ payload(void)
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (g_pcie_skip_dp_nic_ms &&
+          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
               val_print(DEBUG, "\n       Skipping for BDF 0x%x", bdf);

--- a/test_pool/pcie/p035.c
+++ b/test_pool/pcie/p035.c
@@ -24,8 +24,6 @@
 #define TEST_RULE  "PCI_SM_02"
 #define TEST_DESC  "Check Function level reset            "
 
-extern bool g_pcie_skip_dp_nic_ms;
-
 static
 uint32_t is_flr_failed(uint32_t bdf)
 {
@@ -94,7 +92,7 @@ payload(void)
        * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (g_pcie_skip_dp_nic_ms &&
+      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
           ((base_cc == UNCLAS_CC) || (base_cc == MAS_CC)
           || (base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC)))
       {

--- a/test_pool/pcie/p045.c
+++ b/test_pool/pcie/p045.c
@@ -19,8 +19,6 @@
 #include "acs_pcie.h"
 #include "acs_memory.h"
 
-extern bool g_pcie_skip_dp_nic_ms;
-
 /* Test runs on Linux and BM Env */
 static const
 test_config_t test_entries[] = {
@@ -144,7 +142,7 @@ next_bdf:
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (g_pcie_skip_dp_nic_ms &&
+          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
               val_print(DEBUG, "\n       Skipping BDF as  0x%x", bdf);

--- a/test_pool/pcie/p058.c
+++ b/test_pool/pcie/p058.c
@@ -20,8 +20,6 @@
 #include "val_interface.h"
 #include "acs_pcie.h"
 
-extern bool g_pcie_skip_dp_nic_ms;
-
 static const
 test_config_t test_entries[] = {
     { ACS_PCIE_TEST_NUM_BASE + 58, "Check MSE, CapPtr & BIST: RCiEP, RCEC ", "RE_REG_1"},
@@ -92,7 +90,7 @@ get_dsf_bdf(uint32_t rp_bdf, uint32_t *target_bdf)
           val_pcie_read_cfg(dev_bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Downstream class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (g_pcie_skip_dp_nic_ms &&
+          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
               val_print(DEBUG, "\n       Skipping downstream BDF 0x%x", dev_bdf);
@@ -200,7 +198,7 @@ payload(void *arg)
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (g_pcie_skip_dp_nic_ms &&
+          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
               val_print(DEBUG, "\n       Skipping for BDF 0x%x", bdf);

--- a/test_pool/pcie/p063.c
+++ b/test_pool/pcie/p063.c
@@ -25,8 +25,6 @@
 #define TEST_RULE  "RI_RST_1"
 #define TEST_DESC  "Check Function level reset: RCiEP/iEP "
 
-extern bool g_pcie_skip_dp_nic_ms;
-
 static
 uint32_t is_flr_failed(uint32_t bdf)
 {
@@ -95,7 +93,7 @@ payload(void)
        * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (g_pcie_skip_dp_nic_ms &&
+      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
           ((base_cc == UNCLAS_CC) || (base_cc == MAS_CC)
           || (base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC)))
       {

--- a/test_pool/pcie/p094.c
+++ b/test_pool/pcie/p094.c
@@ -19,8 +19,6 @@
 #include "acs_pcie.h"
 #include "acs_memory.h"
 
-extern bool g_pcie_skip_dp_nic_ms;
-
 /* Test runs on Linux and BM Env */
 static const
 test_config_t test_entries[] = {
@@ -145,7 +143,7 @@ next_bdf:
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (g_pcie_skip_dp_nic_ms &&
+          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
               val_print(DEBUG, "\n       Skipping BDF as  0x%x", bdf);

--- a/test_pool/pcie/p097.c
+++ b/test_pool/pcie/p097.c
@@ -22,7 +22,6 @@
 #define TEST_RULE  "PCI_MSI_2"
 #define TEST_DESC  "Check MSI(X) vectors uniqueness       "
 
-extern bool g_pcie_skip_dp_nic_ms;
 /**
     @brief   Returns MSI(X) status of the device
 
@@ -147,7 +146,7 @@ payload (void)
        * descriptors is causing an exception and for the devices
        * with base class codes greater than 13h as they
        * are reserved */
-      if ((g_pcie_skip_dp_nic_ms &&
+      if ((acs_policy_get_pcie_skip_dp_nic_ms() &&
           ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
           || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)))
           || (base_cc > RES_CC))
@@ -192,7 +191,7 @@ payload (void)
                 * descriptors is causing an exception and for the devices
                 * with base class codes greater than 13h as they
                 * are reserved */
-                if ((g_pcie_skip_dp_nic_ms &&
+                if ((acs_policy_get_pcie_skip_dp_nic_ms() &&
                     ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
                     || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)))
                     || (base_cc > RES_CC))

--- a/test_pool/pe/pe001.c
+++ b/test_pool/pe/pe001.c
@@ -105,7 +105,7 @@ return_reg_value(uint32_t reg, uint8_t dependency)
 
   /* Skip specific EL1 register reads if requested via -el1skiptrap */
   if (reg == PMSIDR_EL1) {
-      if (g_el1skiptrap_mask & EL1SKIPTRAP_PMSIDR) {
+      if (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_PMSIDR) {
           return 0;
       }
   }

--- a/test_pool/pe/pe006.c
+++ b/test_pool/pe/pe006.c
@@ -29,7 +29,7 @@ payload()
   uint64_t data = 0;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  if (!g_crypto_support) {
+  if (!acs_policy_get_crypto_support()) {
         val_print_primary_pe(DEBUG, "\n       Crypto extension not supported",
                                                                                       0, index);
         val_set_status(index, RESULT_SKIP(1));

--- a/test_pool/pe/pe034.c
+++ b/test_pool/pe/pe034.c
@@ -28,7 +28,7 @@ static void payload(void)
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
 
-    if (!g_crypto_support) {
+    if (!acs_policy_get_crypto_support()) {
         val_print_primary_pe(DEBUG, "\n       Crypto extension not supported",
                                                                                       0, index);
         val_set_status(index, RESULT_SKIP(1));

--- a/test_pool/peripherals/d003.c
+++ b/test_pool/peripherals/d003.c
@@ -437,7 +437,7 @@ payload_check_arm_generic_uart_interrupt()
               }
 
               uart_enable_txintr();
-              val_print_raw(l_uart_base, g_print_level,
+              val_print_raw(l_uart_base, acs_policy_get_print_level(),
                             "\n       Test Message                          ", 0);
 
               while ((--timeout > 0) && (IS_RESULT_PENDING(val_get_status(index)))) {

--- a/test_pool/power_wakeup/u001.c
+++ b/test_pool/power_wakeup/u001.c
@@ -25,8 +25,6 @@
 #define TEST_DESC "Wake from EL1 PHY Timer Int           "
 
 static uint32_t g_el1phy_int_received;
-extern uint32_t g_timeout_pass;
-
 static
 void
 isr1()
@@ -49,7 +47,8 @@ payload1()
   uint32_t intid;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t delay_loop = MAX_SPIN_LOOPS;
-  uint32_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_pass));
+  uint32_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_pass()));
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   if (val_gic_install_isr(intid, isr1)) {
@@ -96,7 +95,7 @@ u001_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
+  if (!(acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT)) {
       val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
       status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
 

--- a/test_pool/power_wakeup/u002.c
+++ b/test_pool/power_wakeup/u002.c
@@ -26,9 +26,6 @@
 
 static uint32_t g_el1vir_int_received;
 static uint32_t g_failsafe_int_rcvd;
-extern uint32_t g_timeout_pass;
-extern uint32_t g_timeout_fail;
-
 static
 void
 isr_failsafe()
@@ -57,7 +54,8 @@ void
 wakeup_set_failsafe()
 {
   uint32_t intid;
-  uint32_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_fail));
+  uint32_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_fail()));
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
   val_timer_set_phy_el1(timer_expire_val);
@@ -95,7 +93,8 @@ payload2()
   uint32_t intid;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t delay_loop = MAX_SPIN_LOOPS;
-  uint32_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_pass));
+  uint32_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_pass()));
 
   intid = val_timer_get_info(TIMER_INFO_VIR_EL1_INTID, 0);
   if (val_gic_install_isr(intid, isr2)) {
@@ -149,7 +148,7 @@ u002_entry(uint32_t num_pe)
 
   num_pe = 1;  //This Timer test is run on single processor
 
-  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
+  if (!(acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT)) {
       val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
       status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
 

--- a/test_pool/power_wakeup/u003.c
+++ b/test_pool/power_wakeup/u003.c
@@ -26,9 +26,6 @@
 
 static uint32_t g_el2phy_int_rcvd;
 static uint32_t g_failsafe_int_rcvd;
-extern uint32_t g_timeout_pass;
-extern uint32_t g_timeout_fail;
-
 static
 void
 isr_failsafe()
@@ -74,7 +71,8 @@ void
 wakeup_set_failsafe()
 {
   uint32_t intid;
-  uint32_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_fail));
+  uint32_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_fail()));
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
@@ -95,7 +93,8 @@ payload3()
   uint32_t intid;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t delay_loop = MAX_SPIN_LOOPS;
-  uint32_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_pass));
+  uint32_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_pass()));
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL2_INTID, 0);
   if (val_gic_install_isr(intid, isr3)) {

--- a/test_pool/power_wakeup/u004.c
+++ b/test_pool/power_wakeup/u004.c
@@ -27,9 +27,6 @@
 static uint64_t wd_num;
 static uint32_t g_wd_int_received;
 static uint32_t g_failsafe_int_received;
-extern uint32_t g_timeout_pass;
-extern uint32_t g_timeout_fail;
-
 static
 void
 isr_failsafe()
@@ -72,7 +69,8 @@ void
 wakeup_set_failsafe()
 {
   uint32_t intid;
-  uint64_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_fail));
+  uint64_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_fail()));
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
@@ -95,7 +93,7 @@ payload4()
   uint32_t intid;
   uint32_t delay_loop = MAX_SPIN_LOOPS;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
-  uint64_t timer_expire_val = val_get_timeout_to_ticks(g_timeout_pass);
+  uint64_t timer_expire_val = val_get_timeout_to_ticks(acs_policy_get_timeout_pass());
 
   wd_num = val_wd_get_info(0, WD_INFO_COUNT);
 

--- a/test_pool/power_wakeup/u005.c
+++ b/test_pool/power_wakeup/u005.c
@@ -27,9 +27,6 @@
 static uint64_t timer_num;
 static uint32_t g_failsafe_int_rcvd;
 static uint32_t g_timer_int_rcvd;
-extern uint32_t g_timeout_pass;
-extern uint32_t g_timeout_fail;
-
 static
 void
 isr_failsafe()
@@ -76,7 +73,8 @@ void
 wakeup_set_failsafe()
 {
   uint32_t intid;
-  uint64_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_fail));
+  uint64_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_fail()));
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
@@ -100,7 +98,8 @@ payload5()
   uint32_t intid;
   uint32_t delay_loop = MAX_SPIN_LOOPS;
   uint64_t cnt_base_n;
-  uint64_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_pass));
+  uint64_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_pass()));
 
   timer_num = val_timer_get_info(TIMER_INFO_NUM_PLATFORM_TIMERS, 0);
   if (!timer_num) {

--- a/test_pool/timer/t005.c
+++ b/test_pool/timer/t005.c
@@ -62,16 +62,16 @@ payload()
   uint64_t ticks;
   uint32_t pe_timeout_us;
   /* System timer */
-  if (g_timer_timeout_us == 0) {
+  if (acs_policy_get_timer_timeout_us() == 0) {
       val_print(ERROR, "\n       Timer timeout is zero; configure a valid timeout");
       val_set_status(index, RESULT_FAIL(3));
       return;
   }
-  ticks = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timer_timeout_us));
+  ticks = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timer_timeout_us()));
   sys_timer_ticks = (uint32_t)ticks;
 
   /* PE timer */
-  pe_timeout_us = g_timer_timeout_us * 2;
+  pe_timeout_us = acs_policy_get_timer_timeout_us() * 2;
 
   ticks = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(pe_timeout_us));
   pe_timer_ticks = (uint32_t)ticks;

--- a/test_pool/timer/t008.c
+++ b/test_pool/timer/t008.c
@@ -45,7 +45,7 @@ void payload(void)
         val_print_primary_pe(DEBUG, "\n       FEAT_ECV is Implemented, Reading CntPctSS",
                                                                                         0, index);
 
-        if (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)
+        if (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT)
             goto read_virt_ss_timer;
 
         while (iter) {
@@ -89,7 +89,7 @@ read_virt_ss_timer:
     }
     else {
 
-        if (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)
+        if (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT)
             goto read_virt_timer;
 
         val_print_primary_pe(DEBUG, "\n       FEAT_ECV isn't Implemented, Reading CntPct",

--- a/test_pool/watchdog/w002.c
+++ b/test_pool/watchdog/w002.c
@@ -34,9 +34,6 @@ static uint32_t int_id;
 static uint64_t wd_num;
 static volatile uint32_t g_failsafe_int_received;
 static volatile uint32_t g_wd_int_received;
-extern uint32_t g_timeout_pass;
-extern uint32_t g_timeout_fail;
-
 static
 void
 isr()
@@ -78,7 +75,8 @@ void
 wakeup_set_failsafe()
 {
   uint32_t intid;
-  uint32_t timer_expire_val = CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(g_timeout_fail));
+  uint32_t timer_expire_val =
+      CEIL_TO_MAX_SYS_TIMEOUT(val_get_timeout_to_ticks(acs_policy_get_timeout_fail()));
 
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid, isr_failsafe);
@@ -99,7 +97,7 @@ payload()
 
     uint32_t status, ns_wdg = 0;
     uint64_t timeout;
-    uint64_t timer_expire_ticks = val_get_timeout_to_ticks(g_timeout_pass);
+    uint64_t timer_expire_ticks = val_get_timeout_to_ticks(acs_policy_get_timeout_pass());
     uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
     wd_num = val_wd_get_info(0, WD_INFO_COUNT);
 
@@ -155,7 +153,7 @@ payload()
         }
         wakeup_set_failsafe();
 
-        timeout = val_get_timeout_to_ticks(g_timeout_fail);
+        timeout = val_get_timeout_to_ticks(acs_policy_get_timeout_fail());
         while (timeout && (g_wd_int_received == 0) && (g_failsafe_int_received == 0)) {
           val_data_cache_ops_by_va((addr_t)&g_wd_int_received, INVALIDATE);
           val_data_cache_ops_by_va((addr_t)&g_failsafe_int_received, INVALIDATE);

--- a/val/Makefile
+++ b/val/Makefile
@@ -57,6 +57,7 @@ bsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_test_infra.o  $(VAL_SRC)/acs_pcie.o  $(VAL_SRC)/acs_pe_infra.o \
     $(VAL_SRC)/acs_iovirt.o $(VAL_SRC)/bsa_execute_test.o\
     $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o $(VAL_SRC)/val_libc.o \
+    $(VAL_SRC)/acs_execution_policy.o \
     $(VAL_SRC)/acs_run_request.o \
     $(VAL_SRC)/../driver/smmu_v3/smmu_v3.o $(VAL_SRC)/../driver/pcie/pcie.o \
     $(VAL_SRC)/rule_based_execution_helpers.o \
@@ -73,6 +74,7 @@ sbsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_test_infra.o  $(VAL_SRC)/acs_pcie.o $(VAL_SRC)/acs_pe_infra.o \
     $(VAL_SRC)/acs_iovirt.o $(VAL_SRC)/../driver/smmu_v3/smmu_v3.o \
     $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o $(VAL_SRC)/val_libc.o \
+    $(VAL_SRC)/acs_execution_policy.o \
     $(VAL_SRC)/acs_run_request.o \
     $(VAL_SRC)/sbsa_execute_test.o $(VAL_SRC)/../driver/pcie/pcie.o \
     $(VAL_SRC)/rule_based_execution_helpers.o \
@@ -88,6 +90,7 @@ pcbsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_test_infra.o  $(VAL_SRC)/acs_pcie.o $(VAL_SRC)/acs_pe_infra.o \
     $(VAL_SRC)/acs_iovirt.o    $(VAL_SRC)/../driver/smmu_v3/smmu_v3.o \
     $(VAL_SRC)/val_status.o $(VAL_SRC)/val_logger.o $(VAL_SRC)/val_libc.o \
+    $(VAL_SRC)/acs_execution_policy.o \
     $(VAL_SRC)/pc_bsa_execute_test.o $(VAL_SRC)/../driver/pcie/pcie.o
 endif
 

--- a/val/SbsaValNistLib.inf
+++ b/val/SbsaValNistLib.inf
@@ -58,6 +58,7 @@
   src/acs_pcc.c
   src/acs_nist.c
   src/acs_cxl.c
+  src/acs_execution_policy.c
   src/acs_interface.c
   src/acs_msc_error.c
   driver/smmu_v3/smmu_v3.c

--- a/val/ValLib.inf
+++ b/val/ValLib.inf
@@ -60,6 +60,7 @@
   src/acs_pfdi.c
   src/acs_msc_error.c
   src/acs_tpm.c
+  src/acs_execution_policy.c
   src/acs_run_request.c
   src/val_libc.c
   driver/smmu_v3/smmu_v3.c

--- a/val/ValLibRB.inf
+++ b/val/ValLibRB.inf
@@ -63,6 +63,7 @@
   src/acs_msc_error.c
   src/acs_tpm.c
   src/acs_cxl.c
+  src/acs_execution_policy.c
   src/acs_run_request.c
   driver/smmu_v3/smmu_v3.c
   driver/gic/gic.c

--- a/val/driver/smmu_v3/smmu_v3.c
+++ b/val/driver/smmu_v3/smmu_v3.c
@@ -1024,7 +1024,7 @@ static int smmu_cdtab_write_ctx_desc(smmu_master_t *master,
 
     cdptr[0] = val;
 
-    if (g_print_level <= TRACE)
+    if (acs_policy_get_print_level() <= TRACE)
         dump_cdtab(cdptr);
 
     return 1;
@@ -1212,7 +1212,7 @@ uint64_t val_smmu_map(smmu_master_attributes_t master_attr, pgt_descriptor_t pgt
     ste = smmu_strtab_get_ste_for_sid(smmu, master->sid);
     smmu_strtab_write_ste(master, ste);
 
-    if (g_print_level <= TRACE)
+    if (acs_policy_get_print_level() <= TRACE)
         dump_strtab(ste);
 
     smmu_tlbi_cfgi(smmu);
@@ -1240,7 +1240,7 @@ uint32_t val_smmu_config_ste_dcp(smmu_master_attributes_t master_attr, uint32_t 
     else
         ste[1] = ste[1] & BITFIELD_SET(STRTAB_STE_1_DCP, value);
 
-    if (g_print_level <= TRACE)
+    if (acs_policy_get_print_level() <= TRACE)
     {
         val_print(TRACE, "\n       Dump STE values");
         dump_strtab(ste);

--- a/val/include/acs_cfg.h
+++ b/val/include/acs_cfg.h
@@ -18,7 +18,8 @@
 #ifndef __ACS_CFG_H__
 #define __ACS_CFG_H__
 
-extern uint32_t g_print_level;
+#include "acs_execution_policy.h"
+
 extern uint32_t g_execute_secure;
 extern uint32_t *g_skip_test_num;
 extern uint32_t g_num_skip;
@@ -41,12 +42,8 @@ extern uint32_t g_num_modules;
 extern uint32_t g_build_sbsa;
 extern uint32_t g_build_pcbsa;
 extern uint32_t g_curr_module;
-extern uint32_t g_sys_last_lvl_cache;
-extern uint32_t g_crypto_support;
 extern uint32_t g_drtm_acs_dlme[];
 extern uint64_t g_drtm_acs_dlme_size;
-extern uint32_t g_el1skiptrap_mask;
-extern uint32_t g_timer_timeout_us;
 
 
 #endif

--- a/val/include/acs_common.h
+++ b/val/include/acs_common.h
@@ -21,7 +21,7 @@
 /* This file is common to all the test-cases and VAL of the suite. */
 #include "val_logger.h"
 #include "val_status.h"
-
+#include "acs_execution_policy.h"
 #include "acs_run_request.h"
 
 #define G_SW_OS    0
@@ -167,9 +167,10 @@ void
 val_test_entry(void);
 
 void acs_load_run_request_defaults(acs_run_request_t *ctx);
-void acs_apply_el3_params(acs_run_request_t *ctx);
+void acs_load_execution_policy_defaults(acs_execution_policy_t *policy);
+void acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy);
 bool acs_list_contains(const uint32_t *list, uint32_t count, uint32_t value);
 bool acs_is_module_enabled(uint32_t module_base);
-void acs_apply_compile_params(acs_run_request_t *ctx);
+void acs_apply_compile_params(acs_run_request_t *ctx, acs_execution_policy_t *policy);
 
 #endif

--- a/val/include/acs_execution_policy.h
+++ b/val/include/acs_execution_policy.h
@@ -1,0 +1,73 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_EXECUTION_POLICY_H__
+#define __ACS_EXECUTION_POLICY_H__
+
+#include "acs_stdint.h"
+#include "acs_stdbool.h"
+
+/*
+ * acs_execution_policy_t captures shared runtime behavior knobs for one ACS
+ * invocation. It contains only "how to run" inputs gathered from platform
+ * defaults, build overrides, CLI parsing, or EL3-provided parameters:
+ * - print verbosity and MMIO-print enablement
+ * - PCIe/CXL behavior hints
+ * - wakeup/watchdog/timer timeout controls
+ * - crypto-extension and EL1 trap workarounds
+ * - system last-level cache hinting
+ */
+typedef struct acs_execution_policy {
+    uint32_t pcie_p2p;
+    uint32_t pcie_cache_present;
+    bool     pcie_skip_dp_nic_ms;
+    uint32_t print_level;
+    uint32_t print_mmio;
+    uint32_t timeout_pass;
+    uint32_t timeout_fail;
+    uint32_t timer_timeout_us;
+    uint32_t crypto_support;
+    /*
+     * System last-level cache hint used by MPAM and related tests:
+     *   0 - Unknown
+     *   1 - PPTT PE-side LLC
+     *   2 - HMAT mem-side LLC
+     */
+    uint32_t sys_last_lvl_cache;
+    /*
+     * Bitmask of EL1 register accesses to skip when a platform traps or does
+     * not safely expose them. Compose with EL1SKIPTRAP_* flags.
+     */
+    uint32_t el1skiptrap_mask;
+} acs_execution_policy_t;
+
+void acs_reset_execution_policy(void);
+acs_execution_policy_t *acs_get_execution_policy_mut(void);
+const acs_execution_policy_t *acs_get_execution_policy(void);
+uint32_t acs_policy_get_print_level(void);
+uint32_t acs_policy_get_print_mmio(void);
+uint32_t acs_policy_get_pcie_p2p(void);
+uint32_t acs_policy_get_pcie_cache_present(void);
+bool acs_policy_get_pcie_skip_dp_nic_ms(void);
+uint32_t acs_policy_get_timeout_pass(void);
+uint32_t acs_policy_get_timeout_fail(void);
+uint32_t acs_policy_get_timer_timeout_us(void);
+uint32_t acs_policy_get_crypto_support(void);
+uint32_t acs_policy_get_sys_last_lvl_cache(void);
+uint32_t acs_policy_get_el1skiptrap_mask(void);
+
+#endif /* __ACS_EXECUTION_POLICY_H__ */

--- a/val/include/acs_interface.h
+++ b/val/include/acs_interface.h
@@ -18,22 +18,18 @@
 #ifndef __ACS_INTERFACE_H__
 #define __ACS_INTERFACE_H__
 
-#ifdef TARGET_UEFI
-typedef UINT32 acs_uint32_t;
-#else
-typedef uint32_t acs_uint32_t;
-#endif
+#include "acs_stdint.h"
 
 /* Test status counters visible across ACS */
 typedef struct {
-    acs_uint32_t total_rules_run;     /* Total rules/tests that reported a status */
-    acs_uint32_t passed;              /* Count of TEST_PASS */
-    acs_uint32_t partial_coverage;    /* Count of TEST_PARTIAL_COV */
-    acs_uint32_t warnings;            /* Count of TEST_WARN */
-    acs_uint32_t skipped;             /* Count of TEST_SKIP */
-    acs_uint32_t failed;              /* Count of TEST_FAIL */
-    acs_uint32_t not_implemented;     /* Count of TEST_NO_IMP */
-    acs_uint32_t pal_not_supported;   /* Count of TEST_PAL_NS */
+    uint32_t total_rules_run;     /* Total rules/tests that reported a status */
+    uint32_t passed;              /* Count of TEST_PASS */
+    uint32_t partial_coverage;    /* Count of TEST_PARTIAL_COV */
+    uint32_t warnings;            /* Count of TEST_WARN */
+    uint32_t skipped;             /* Count of TEST_SKIP */
+    uint32_t failed;              /* Count of TEST_FAIL */
+    uint32_t not_implemented;     /* Count of TEST_NO_IMP */
+    uint32_t pal_not_supported;   /* Count of TEST_PAL_NS */
 } acs_test_status_counters_t;
 
 acs_test_status_counters_t *acs_get_test_status(void);

--- a/val/include/acs_stdbool.h
+++ b/val/include/acs_stdbool.h
@@ -1,0 +1,29 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_STDBOOL_H__
+#define __ACS_STDBOOL_H__
+
+#if defined(TARGET_UEFI)
+#include <stdbool.h>
+#elif defined(TARGET_LINUX) && defined(__KERNEL__)
+#include <linux/types.h>
+#else
+#include <stdbool.h>
+#endif
+
+#endif /* __ACS_STDBOOL_H__ */

--- a/val/include/acs_stdint.h
+++ b/val/include/acs_stdint.h
@@ -1,0 +1,55 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_STDINT_H__
+#define __ACS_STDINT_H__
+
+#if defined(TARGET_UEFI)
+#include <Base.h>
+
+typedef INT8    int8_t;
+typedef INT16   int16_t;
+typedef INT32   int32_t;
+typedef INT64   int64_t;
+typedef UINT8   uint8_t;
+typedef UINT16  uint16_t;
+typedef UINT32  uint32_t;
+typedef UINT64  uint64_t;
+typedef UINTN   uintptr_t;
+typedef INTN    intptr_t;
+typedef INT64   intmax_t;
+typedef UINT64  uintmax_t;
+#elif defined(TARGET_LINUX) && defined(__KERNEL__)
+#include <linux/types.h>
+
+typedef s8      int8_t;
+typedef s16     int16_t;
+typedef s32     int32_t;
+typedef s64     int64_t;
+typedef u8      uint8_t;
+typedef u16     uint16_t;
+typedef u32     uint32_t;
+typedef u64     uint64_t;
+typedef unsigned long uintptr_t;
+typedef long    intptr_t;
+typedef s64     intmax_t;
+typedef u64     uintmax_t;
+#else
+#include <stdint.h>
+#endif
+
+#endif /* __ACS_STDINT_H__ */

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -22,7 +22,7 @@
   #include <stdint.h>
   #include <stdarg.h>
   #include <stddef.h>
-  #include <stdbool.h>
+  #include "acs_stdbool.h"
   #include "platform_override_fvp.h"
   #include "acs_interface.h"
 
@@ -96,35 +96,16 @@
 
 #ifdef TARGET_UEFI
   #include <stdarg.h>
-  #include <stdbool.h>
   #include <stddef.h>
-  #include <Base.h>
+  #include "acs_stdbool.h"
+  #include "acs_stdint.h"
   #include "platform_override.h"
   #include "acs_interface.h"
 
-  typedef INT8    int8_t;
-  typedef INT16   int16_t;
-  typedef INT32   int32_t;
-  typedef INT64   int64_t;
-  typedef UINT8   uint8_t;
-  typedef UINT16  uint16_t;
-  typedef UINT32  uint32_t;
-  typedef UINT64  uint64_t;
   typedef UINT64  addr_t;
   typedef UINT64  dma_addr_t;
-  typedef UINTN  uintptr_t;
-  typedef INTN   intptr_t;
-  typedef INT64  intmax_t;
-  typedef UINT64 uintmax_t;
   typedef CHAR8   char8_t;
   typedef CHAR16  char16_t;
-
-  /* Avoid redefining bool when the language or headers already provide it. */
-  #if !defined(__cplusplus) && \
-      !(defined(__STDC_VERSION__) && __STDC_VERSION__ > 201710L) && \
-      !defined(__bool_true_false_are_defined)
-    typedef BOOLEAN bool;
-  #endif
 
   #define MAX_SID  32
   #define MMU_PGT_IAS    48

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -22,10 +22,9 @@
 #include "acs_drtm.h"
 #include "acs_pfdi.h"
 #include "acs_cxl.h"
+#include "acs_execution_policy.h"
 #include "val_status.h"
 #include "val_libc.h"
-
-extern uint32_t g_print_level;
 
 #define ACS_STATUS_ERR       0xEDCB1234  //some impropable value?
 #define ACS_STATUS_NIST_PASS 0x1
@@ -40,7 +39,7 @@ enable implementation specific prints in PAL*/
 #ifndef val_print
 #define val_print(level, ...)                     \
     do {                                          \
-        if ((level) >= g_print_level)             \
+        if ((level) >= acs_policy_get_print_level()) \
             val_printf((level), __VA_ARGS__);     \
     } while (0)
 #endif

--- a/val/src/acs_execution_policy.c
+++ b/val/src/acs_execution_policy.c
@@ -1,0 +1,99 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "acs_execution_policy.h"
+#include "val_interface.h"
+#include "val_logger.h"
+
+static acs_execution_policy_t g_execution_policy;
+
+void acs_reset_execution_policy(void)
+{
+    g_execution_policy = (acs_execution_policy_t) {
+        .print_level = INFO,
+        .timeout_pass = WAKEUP_WD_PASS_TIMEOUT_DEFAULT,
+        .timeout_fail = WAKEUP_WD_PASS_TIMEOUT_DEFAULT *
+                        WAKEUP_WD_FAILSAFE_TIMEOUT_MULTIPLIER,
+        .timer_timeout_us = TIMER_TIMEOUT_DEFAULT,
+        .crypto_support = 1u,
+    };
+}
+
+acs_execution_policy_t *acs_get_execution_policy_mut(void)
+{
+    return &g_execution_policy;
+}
+
+const acs_execution_policy_t *acs_get_execution_policy(void)
+{
+    return &g_execution_policy;
+}
+
+uint32_t acs_policy_get_print_level(void)
+{
+    return g_execution_policy.print_level;
+}
+
+uint32_t acs_policy_get_print_mmio(void)
+{
+    return g_execution_policy.print_mmio;
+}
+
+uint32_t acs_policy_get_pcie_p2p(void)
+{
+    return g_execution_policy.pcie_p2p;
+}
+
+uint32_t acs_policy_get_pcie_cache_present(void)
+{
+    return g_execution_policy.pcie_cache_present;
+}
+
+bool acs_policy_get_pcie_skip_dp_nic_ms(void)
+{
+    return g_execution_policy.pcie_skip_dp_nic_ms;
+}
+
+uint32_t acs_policy_get_timeout_pass(void)
+{
+    return g_execution_policy.timeout_pass;
+}
+
+uint32_t acs_policy_get_timeout_fail(void)
+{
+    return g_execution_policy.timeout_fail;
+}
+
+uint32_t acs_policy_get_timer_timeout_us(void)
+{
+    return g_execution_policy.timer_timeout_us;
+}
+
+uint32_t acs_policy_get_crypto_support(void)
+{
+    return g_execution_policy.crypto_support;
+}
+
+uint32_t acs_policy_get_sys_last_lvl_cache(void)
+{
+    return g_execution_policy.sys_last_lvl_cache;
+}
+
+uint32_t acs_policy_get_el1skiptrap_mask(void)
+{
+    return g_execution_policy.el1skiptrap_mask;
+}

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -300,7 +300,7 @@ val_peripheral_create_info_table(uint64_t *peripheral_info_table)
   val_print(INFO, " Peripheral: Num of UART controllers  :    %d\n",
     val_peripheral_get_info(NUM_UART, 0));
 
-  if (g_print_level <= TRACE)
+  if (acs_policy_get_print_level() <= TRACE)
     val_peripheral_dump_info();
 
 }

--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -179,14 +179,11 @@ val_print_acs_test_status_summary(void)
   @return        None
  **/
 void
-val_print_raw(uint64_t uart_address, uint32_t level, char8_t *string,
-                                                                uint64_t data)
+val_print_raw(uint64_t uart_address, uint32_t level, char8_t *string, uint64_t data)
 {
-
-  if (level >= g_print_level){
+  if (level >= acs_policy_get_print_level()) {
       pal_print_raw(uart_address, string, data);
   }
-
 }
 
 /**

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -247,7 +247,7 @@ val_timer_create_info_table(uint64_t *timer_info_table)
   /* UEFI or other EL1 software may have enabled the EL1 physical/virtual timer.
      Disable the timers to prevent interrupts at un-expected times */
 
-  if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT)) {
+  if (!(acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT)) {
      val_timer_set_phy_el1(0);
      val_timer_set_vir_el1(0);
   }

--- a/val/src/bsa_execute_test.c
+++ b/val/src/bsa_execute_test.c
@@ -240,7 +240,7 @@ val_bsa_gic_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
           }
 
           status |= g005_entry(num_pe);
-          if (!(g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT))
+          if (!(acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT))
               status |= g006_entry(num_pe);
 
           status |= g007_entry(num_pe);

--- a/val/src/test_wrappers.c
+++ b/val/src/test_wrappers.c
@@ -447,7 +447,7 @@ v_l1wk_02_05_entry(uint32_t num_pe)
     return TEST_SKIP;
 #endif
 
-    if (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT) {
+    if (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT) {
         val_print(INFO,
                     "\n       Skipping rule as EL1 physical timer access not supported", 0);
         return RESULT_SKIP(0);
@@ -478,7 +478,7 @@ v_l1pp_00_entry(uint32_t num_pe)
     TEST_ENTRY_ID_e default_list[] = {G006_ENTRY, G007_ENTRY, TEST_ENTRY_SENTINEL};
 
     TEST_ENTRY_ID_e *entry_list =
-        (g_el1skiptrap_mask & EL1SKIPTRAP_CNTPCT) ? skip_list : default_list;
+        (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT) ? skip_list : default_list;
 
     return run_test_entries(entry_list, num_pe);
 }


### PR DESCRIPTION
Move shared execution-policy knobs out of scattered globals into a dedicated acs_execution_policy_t with explicit reset and accessor APIs. This keeps execution policy separate from run-request selection state, routes defaults and overrides through one place, and removes direct global and header coupling across VAL, PAL, baremetal, and UEFI paths.

- add acs_execution_policy.[ch] as the canonical shared policy object for print, PCIe, timeout, crypto, SLC, and EL1 trap settings
- replace direct policy g_* globals across VAL, PAL, test pool, baremetal, and UEFI code with policy fields or acs_policy_get_*() accessors
- update baremetal and UEFI entry paths to reset, populate, and consume execution policy explicitly
- split generic policy reset defaults from baremetal target overrides, and expose target defaults through acs_get_platform_execution_policy_defaults()
- update compile-time and EL3 override helpers to write execution policy separately from run-request filtering state
- remove duplicated policy declarations from PAL and UEFI headers and keep the shared policy API in one canonical header
- wire acs_execution_policy.c into the relevant VAL build files for baremetal and UEFI flows
- keep headers self-contained with shared fixed-width types and drop local scalar typedef wrappers that no longer add value
- retain documentation for sys_last_lvl_cache values and el1skiptrap_mask usage in the canonical policy definition

Change-Id: I1e320c46aaab9a6479b189d433a0a3d8f7a62258