### PR TITLE
refactor(baremetal): isolate runtime init and platform run defaults

### DIFF
--- a/apps/baremetal/acs.h
+++ b/apps/baremetal/acs.h
@@ -81,23 +81,13 @@
    gating C code when included by .S files */
 #ifndef __ASSEMBLER__
 #include "val/include/rule_based_execution.h"
+#include "acs_runtime_init.h"
 
 #define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
     ((filter_mode == LVL_FILTER_ONLY && level == fr_level) ? \
     "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
     ((filter_mode == LVL_FILTER_ONLY) ? \
     "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
-
-/* Extern declarations for globals from platform_cfg_fvp.c */
-extern RULE_ID_e g_rule_list_arr[];
-extern uint32_t  g_rule_count;
-extern RULE_ID_e g_skip_rule_list_arr[];
-extern uint32_t  g_skip_rule_count;
-extern uint32_t g_execute_modules_arr[];
-extern uint32_t g_num_modules;
-extern uint32_t g_skip_modules_arr[];
-extern uint32_t g_num_skip_modules;
-extern uint32_t g_level_filter_mode;
 
 /* Remaining baremetal execution globals from apps/baremetal/acs_globals.c */
 extern uint32_t  g_el1physkip;

--- a/apps/baremetal/acs_runtime_init.c
+++ b/apps/baremetal/acs_runtime_init.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "pal/baremetal/base/include/pal_execution_policy.h"
+#include "pal/baremetal/base/include/pal_run_request.h"
 #include "val/include/val_interface.h"
 #include "val/include/acs_el3_param.h"
 #include "val/include/rule_based_execution_enum.h"
@@ -33,21 +34,7 @@ const uint32_t acs_build_module_count =
     sizeof(acs_build_module_array) / sizeof(acs_build_module_array[0]);
 #endif
 
-bool
-acs_is_module_enabled(uint32_t module_base)
-{
-    const acs_run_request_t *ctx = acs_get_run_request();
-
-    /* Runtime / EL3 / CLI override has highest priority */
-    if (ctx->num_modules) {
-        return acs_list_contains(ctx->execute_modules, ctx->num_modules, module_base);
-    }
-    /* No overrides: enable everything */
-    (void)module_base;
-    return true;
-}
-
-bool
+static bool
 acs_list_contains(const uint32_t *list, uint32_t count, uint32_t value)
 {
   uint32_t i;
@@ -61,6 +48,20 @@ acs_list_contains(const uint32_t *list, uint32_t count, uint32_t value)
   }
 
   return false;
+}
+
+bool
+acs_is_module_enabled(uint32_t module_base)
+{
+    const acs_run_request_t *ctx = acs_get_run_request();
+
+    /* Runtime / EL3 / CLI override has highest priority */
+    if (ctx->num_modules) {
+        return acs_list_contains(ctx->execute_modules, ctx->num_modules, module_base);
+    }
+    /* No overrides: enable everything */
+    (void)module_base;
+    return true;
 }
 
 void
@@ -117,9 +118,15 @@ acs_load_execution_policy_defaults(acs_execution_policy_t *policy)
 void
 acs_load_run_request_defaults(acs_run_request_t *ctx)
 {
+  const acs_platform_run_request_defaults_t *platform_defaults;
+
   if (ctx == NULL)
       return;
 
+  /*
+   * Seed the detached/shared request directly to keep the baremetal path
+   * freestanding and avoid aggregate-copy codegen pulling in memcpy().
+   */
   ctx->rule_list = NULL;
   ctx->rule_count = 0;
   ctx->skip_rule_list = NULL;
@@ -129,7 +136,7 @@ acs_load_run_request_defaults(acs_run_request_t *ctx)
   ctx->skip_modules = NULL;
   ctx->num_skip_modules = 0;
   ctx->arch_selection = ARCH_NONE;
-  ctx->level_filter_mode = g_level_filter_mode;
+  ctx->level_filter_mode = LVL_FILTER_NONE;
   ctx->level_value = 0;
   ctx->bsa_sw_view_mask = 0;
   ctx->rule_list_owned = false;
@@ -137,21 +144,27 @@ acs_load_run_request_defaults(acs_run_request_t *ctx)
   ctx->execute_modules_owned = false;
   ctx->skip_modules_owned = false;
 
-  if (g_rule_count) {
-      ctx->rule_list = g_rule_list_arr;
-      ctx->rule_count = g_rule_count;
+  platform_defaults = acs_get_platform_run_request_defaults();
+  if (platform_defaults == NULL)
+      return;
+
+  ctx->level_filter_mode = platform_defaults->level_filter_mode;
+
+  if (platform_defaults->rule_count != 0u) {
+      ctx->rule_list = platform_defaults->rule_list;
+      ctx->rule_count = platform_defaults->rule_count;
   }
-  if (g_skip_rule_count) {
-      ctx->skip_rule_list = g_skip_rule_list_arr;
-      ctx->skip_rule_count = g_skip_rule_count;
+  if (platform_defaults->skip_rule_count != 0u) {
+      ctx->skip_rule_list = platform_defaults->skip_rule_list;
+      ctx->skip_rule_count = platform_defaults->skip_rule_count;
   }
-  if (g_num_modules) {
-      ctx->execute_modules = g_execute_modules_arr;
-      ctx->num_modules = g_num_modules;
+  if (platform_defaults->num_modules != 0u) {
+      ctx->execute_modules = platform_defaults->execute_modules;
+      ctx->num_modules = platform_defaults->num_modules;
   }
-  if (g_num_skip_modules) {
-      ctx->skip_modules = g_skip_modules_arr;
-      ctx->num_skip_modules = g_num_skip_modules;
+  if (platform_defaults->num_skip_modules != 0u) {
+      ctx->skip_modules = platform_defaults->skip_modules;
+      ctx->num_skip_modules = platform_defaults->num_skip_modules;
   }
 }
 

--- a/apps/baremetal/acs_runtime_init.h
+++ b/apps/baremetal/acs_runtime_init.h
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_RUNTIME_INIT_H__
+#define __ACS_RUNTIME_INIT_H__
+
+#include "acs_execution_policy.h"
+#include "acs_run_request.h"
+
+void acs_load_run_request_defaults(acs_run_request_t *ctx);
+void acs_load_execution_policy_defaults(acs_execution_policy_t *policy);
+void acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy);
+bool acs_is_module_enabled(uint32_t module_base);
+void acs_apply_compile_params(acs_run_request_t *ctx, acs_execution_policy_t *policy);
+
+#endif /* __ACS_RUNTIME_INIT_H__ */

--- a/pal/baremetal/base/include/pal_run_request.h
+++ b/pal/baremetal/base/include/pal_run_request.h
@@ -1,0 +1,44 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __PAL_RUN_REQUEST_H__
+#define __PAL_RUN_REQUEST_H__
+
+#include <stdint.h>
+
+#include "rule_based_execution_enum.h"
+
+/*
+ * Target-owned baremetal run-request defaults. These are borrowed/static
+ * inputs used to seed the mutable shared run request before compile-time or
+ * EL3 overrides are applied.
+ */
+typedef struct {
+    RULE_ID_e *rule_list;
+    uint32_t   rule_count;
+    RULE_ID_e *skip_rule_list;
+    uint32_t   skip_rule_count;
+    uint32_t  *execute_modules;
+    uint32_t   num_modules;
+    uint32_t  *skip_modules;
+    uint32_t   num_skip_modules;
+    uint32_t   level_filter_mode; /* LEVEL_FILTER_MODE_e */
+} acs_platform_run_request_defaults_t;
+
+const acs_platform_run_request_defaults_t *acs_get_platform_run_request_defaults(void);
+
+#endif /* __PAL_RUN_REQUEST_H__ */

--- a/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
@@ -16,6 +16,7 @@
 **/
 
 #include "pal_common_support.h"
+#include "pal_run_request.h"
 #include "platform_override_struct.h"
 #include "rule_based_execution_enum.h"
 
@@ -23,45 +24,54 @@
    as well as run compliance against subset of rules.
 
    Partner fill-in guide :
-   - g_rule_list_arr: Explicit list of rule IDs (RULE_ID_e) to execute. Leave empty for default
-     rule checklist.
+   - platform_rule_list_arr: Explicit list of rule IDs (RULE_ID_e) to execute. Leave empty for
+       the default rule checklist.
        Example entries: B_PE_01, S_L3PE_02, P_L1PE_01, B_GIC_03, ...
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_skip_rule_list_arr: Rules (RULE_ID_e) to skip.
-       These take precedence over selections via g_rule_list_arr or module filters.
+   - platform_skip_rule_list_arr: Rules (RULE_ID_e) to skip.
+       These take precedence over selections via platform_rule_list_arr or module filters.
        Example entries: B_PE_01, S_L3PE_02, P_L1PE_01, B_GIC_03, ...
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_execute_modules_arr: Modules to include (values from MODULE_NAME_e: PE, GIC, SMMU,
+   - platform_execute_modules_arr: Modules to include (values from MODULE_NAME_e: PE, GIC, SMMU,
        TIMER, PERIPHERAL, RAS, WATCHDOG, PCIE, MPAM, ETE, TPM, etc.). If non-empty, only
        rules belonging to these modules will run.
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_skip_modules_arr: Modules (MODULE_NAME_e) to exclude from execution.
+   - platform_skip_modules_arr: Modules (MODULE_NAME_e) to exclude from execution.
+
+   - g_platform_run_request_defaults.level_filter_mode: Default baremetal level filtering mode.
 
    Notes:
    - Counts are auto-derived via sizeof; no sentinel terminators are required.
    - If both include and skip specify the same module/rule, skip wins.
 */
-RULE_ID_e g_rule_list_arr[] = {} ;
-uint32_t  g_rule_count = sizeof(g_rule_list_arr)/sizeof(g_rule_list_arr[0]);
+static RULE_ID_e platform_rule_list_arr[] = {};
+static RULE_ID_e platform_skip_rule_list_arr[] = {};
+static uint32_t platform_execute_modules_arr[] = {};
+static uint32_t platform_skip_modules_arr[] = {};
 
-RULE_ID_e g_skip_rule_list_arr[] = {};
-uint32_t g_skip_rule_count = sizeof(g_skip_rule_list_arr)/sizeof(g_skip_rule_list_arr[0]);
+static const acs_platform_run_request_defaults_t g_platform_run_request_defaults = {
+    .rule_list = platform_rule_list_arr,
+    .rule_count = sizeof(platform_rule_list_arr) / sizeof(platform_rule_list_arr[0]),
+    .skip_rule_list = platform_skip_rule_list_arr,
+    .skip_rule_count = sizeof(platform_skip_rule_list_arr) /
+        sizeof(platform_skip_rule_list_arr[0]),
+    .execute_modules = platform_execute_modules_arr,
+    .num_modules = sizeof(platform_execute_modules_arr) /
+        sizeof(platform_execute_modules_arr[0]),
+    .skip_modules = platform_skip_modules_arr,
+    .num_skip_modules = sizeof(platform_skip_modules_arr) /
+        sizeof(platform_skip_modules_arr[0]),
+    .level_filter_mode = LVL_FILTER_MAX,
+};
 
-uint32_t  g_execute_modules_arr[] = {};
-uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules_arr[0]);
-
-uint32_t  g_skip_modules_arr[] = {};
-uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
-
-/* The Baremetal app supports three filtering modes
-    LVL_FILTER_MAX,    run rules with level <= selected level
-    LVL_FILTER_ONLY,   run rules with level == selected level
-    LVL_FILTER_FR      run rules with level <= *_LEVEL_FR
-*/
-uint32_t g_level_filter_mode = LVL_FILTER_MAX; /* Default set to LVL_FILTER_MAX */
+const acs_platform_run_request_defaults_t *
+acs_get_platform_run_request_defaults(void)
+{
+    return &g_platform_run_request_defaults;
+}
 
 /*
  * Platform execution-policy defaults overlaid on top of the generic runtime

--- a/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
@@ -16,6 +16,7 @@
 **/
 
 #include "pal_common_support.h"
+#include "pal_run_request.h"
 #include "platform_override_struct.h"
 #include "rule_based_execution_enum.h"
 
@@ -23,45 +24,54 @@
    as well as run compliance against subset of rules.
 
    Partner fill-in guide :
-   - g_rule_list_arr: Explicit list of rule IDs (RULE_ID_e) to execute. Leave empty for default
-     rule checklist.
+   - platform_rule_list_arr: Explicit list of rule IDs (RULE_ID_e) to execute. Leave empty for
+       the default rule checklist.
        Example entries: B_PE_01, S_L3PE_02, P_L1PE_01, B_GIC_03, ...
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_skip_rule_list_arr: Rules (RULE_ID_e) to skip.
-       These take precedence over selections via g_rule_list_arr or module filters.
+   - platform_skip_rule_list_arr: Rules (RULE_ID_e) to skip.
+       These take precedence over selections via platform_rule_list_arr or module filters.
        Example entries: B_PE_01, S_L3PE_02, P_L1PE_01, B_GIC_03, ...
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_execute_modules_arr: Modules to include (values from MODULE_NAME_e: PE, GIC, SMMU,
+   - platform_execute_modules_arr: Modules to include (values from MODULE_NAME_e: PE, GIC, SMMU,
        TIMER, PERIPHERAL, RAS, WATCHDOG, PCIE, MPAM, ETE, TPM, etc.). If non-empty, only
        rules belonging to these modules will run.
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_skip_modules_arr: Modules (MODULE_NAME_e) to exclude from execution.
+   - platform_skip_modules_arr: Modules (MODULE_NAME_e) to exclude from execution.
+
+   - g_platform_run_request_defaults.level_filter_mode: Default baremetal level filtering mode.
 
    Notes:
    - Counts are auto-derived via sizeof; no sentinel terminators are required.
    - If both include and skip specify the same module/rule, skip wins.
 */
-RULE_ID_e g_rule_list_arr[] = {} ;
-uint32_t  g_rule_count = sizeof(g_rule_list_arr)/sizeof(g_rule_list_arr[0]);
+static RULE_ID_e platform_rule_list_arr[] = {};
+static RULE_ID_e platform_skip_rule_list_arr[] = {};
+static uint32_t platform_execute_modules_arr[] = {};
+static uint32_t platform_skip_modules_arr[] = {};
 
-RULE_ID_e g_skip_rule_list_arr[] = {};
-uint32_t g_skip_rule_count = sizeof(g_skip_rule_list_arr)/sizeof(g_skip_rule_list_arr[0]);
+static const acs_platform_run_request_defaults_t g_platform_run_request_defaults = {
+    .rule_list = platform_rule_list_arr,
+    .rule_count = sizeof(platform_rule_list_arr) / sizeof(platform_rule_list_arr[0]),
+    .skip_rule_list = platform_skip_rule_list_arr,
+    .skip_rule_count = sizeof(platform_skip_rule_list_arr) /
+        sizeof(platform_skip_rule_list_arr[0]),
+    .execute_modules = platform_execute_modules_arr,
+    .num_modules = sizeof(platform_execute_modules_arr) /
+        sizeof(platform_execute_modules_arr[0]),
+    .skip_modules = platform_skip_modules_arr,
+    .num_skip_modules = sizeof(platform_skip_modules_arr) /
+        sizeof(platform_skip_modules_arr[0]),
+    .level_filter_mode = LVL_FILTER_MAX,
+};
 
-uint32_t  g_execute_modules_arr[] = {};
-uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules_arr[0]);
-
-uint32_t  g_skip_modules_arr[] = {};
-uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
-
-/* The Baremetal app supports three filtering modes
-    LVL_FILTER_MAX,    run rules with level <= selected level
-    LVL_FILTER_ONLY,   run rules with level == selected level
-    LVL_FILTER_FR      run rules with level <= *_LEVEL_FR
-*/
-uint32_t g_level_filter_mode = LVL_FILTER_MAX; /* Default set to LVL_FILTER_MAX */
+const acs_platform_run_request_defaults_t *
+acs_get_platform_run_request_defaults(void)
+{
+    return &g_platform_run_request_defaults;
+}
 
 /*
  * Platform execution-policy defaults overlaid on top of the generic runtime

--- a/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
@@ -16,6 +16,7 @@
 **/
 
 #include "pal_common_support.h"
+#include "pal_run_request.h"
 #include "platform_override_struct.h"
 #include "rule_based_execution_enum.h"
 
@@ -23,45 +24,54 @@
    as well as run compliance against subset of rules.
 
    Partner fill-in guide :
-   - g_rule_list_arr: Explicit list of rule IDs (RULE_ID_e) to execute. Leave empty for default
-     rule checklist.
+   - platform_rule_list_arr: Explicit list of rule IDs (RULE_ID_e) to execute. Leave empty for
+       the default rule checklist.
        Example entries: B_PE_01, S_L3PE_02, P_L1PE_01, B_GIC_03, ...
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_skip_rule_list_arr: Rules (RULE_ID_e) to skip.
-       These take precedence over selections via g_rule_list_arr or module filters.
+   - platform_skip_rule_list_arr: Rules (RULE_ID_e) to skip.
+       These take precedence over selections via platform_rule_list_arr or module filters.
        Example entries: B_PE_01, S_L3PE_02, P_L1PE_01, B_GIC_03, ...
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_execute_modules_arr: Modules to include (values from MODULE_NAME_e: PE, GIC, SMMU,
+   - platform_execute_modules_arr: Modules to include (values from MODULE_NAME_e: PE, GIC, SMMU,
        TIMER, PERIPHERAL, RAS, WATCHDOG, PCIE, MPAM, ETE, TPM, etc.). If non-empty, only
        rules belonging to these modules will run.
        Refer sysarch-acs/val/include/rule_based_execution_enum.h for valid enums.
 
-   - g_skip_modules_arr: Modules (MODULE_NAME_e) to exclude from execution.
+   - platform_skip_modules_arr: Modules (MODULE_NAME_e) to exclude from execution.
+
+   - g_platform_run_request_defaults.level_filter_mode: Default baremetal level filtering mode.
 
    Notes:
    - Counts are auto-derived via sizeof; no sentinel terminators are required.
    - If both include and skip specify the same module/rule, skip wins.
 */
-RULE_ID_e g_rule_list_arr[] = {} ;
-uint32_t  g_rule_count = sizeof(g_rule_list_arr)/sizeof(g_rule_list_arr[0]);
+static RULE_ID_e platform_rule_list_arr[] = {};
+static RULE_ID_e platform_skip_rule_list_arr[] = {};
+static uint32_t platform_execute_modules_arr[] = {};
+static uint32_t platform_skip_modules_arr[] = {};
 
-RULE_ID_e g_skip_rule_list_arr[] = {};
-uint32_t g_skip_rule_count = sizeof(g_skip_rule_list_arr)/sizeof(g_skip_rule_list_arr[0]);
+static const acs_platform_run_request_defaults_t g_platform_run_request_defaults = {
+    .rule_list = platform_rule_list_arr,
+    .rule_count = sizeof(platform_rule_list_arr) / sizeof(platform_rule_list_arr[0]),
+    .skip_rule_list = platform_skip_rule_list_arr,
+    .skip_rule_count = sizeof(platform_skip_rule_list_arr) /
+        sizeof(platform_skip_rule_list_arr[0]),
+    .execute_modules = platform_execute_modules_arr,
+    .num_modules = sizeof(platform_execute_modules_arr) /
+        sizeof(platform_execute_modules_arr[0]),
+    .skip_modules = platform_skip_modules_arr,
+    .num_skip_modules = sizeof(platform_skip_modules_arr) /
+        sizeof(platform_skip_modules_arr[0]),
+    .level_filter_mode = LVL_FILTER_MAX,
+};
 
-uint32_t  g_execute_modules_arr[] = {};
-uint32_t  g_num_modules = sizeof(g_execute_modules_arr)/sizeof(g_execute_modules_arr[0]);
-
-uint32_t  g_skip_modules_arr[] = {};
-uint32_t  g_num_skip_modules = sizeof(g_skip_modules_arr)/sizeof(g_skip_modules_arr[0]);
-
-/* The Baremetal app supports three filtering modes
-    LVL_FILTER_MAX,    run rules with level <= selected level
-    LVL_FILTER_ONLY,   run rules with level == selected level
-    LVL_FILTER_FR      run rules with level <= *_LEVEL_FR
-*/
-uint32_t g_level_filter_mode = LVL_FILTER_MAX; /* Default set to LVL_FILTER_MAX */
+const acs_platform_run_request_defaults_t *
+acs_get_platform_run_request_defaults(void)
+{
+    return &g_platform_run_request_defaults;
+}
 
 /*
  * Platform execution-policy defaults overlaid on top of the generic runtime

--- a/val/include/acs_common.h
+++ b/val/include/acs_common.h
@@ -166,11 +166,4 @@ val_data_cache_ops_by_va(addr_t addr, uint32_t type);
 void
 val_test_entry(void);
 
-void acs_load_run_request_defaults(acs_run_request_t *ctx);
-void acs_load_execution_policy_defaults(acs_execution_policy_t *policy);
-void acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy);
-bool acs_list_contains(const uint32_t *list, uint32_t count, uint32_t value);
-bool acs_is_module_enabled(uint32_t module_base);
-void acs_apply_compile_params(acs_run_request_t *ctx, acs_execution_policy_t *policy);
-
 #endif


### PR DESCRIPTION
Move baremetal runtime-init helpers out of shared VAL headers and hide platform run-request defaults behind a baremetal accessor. This keeps VAL-facing headers focused on shared runtime APIs, removes baremetal default externs from common headers, and aligns run-request default ownership more closely with the execution-policy model without changing runtime behavior.

- add acs_runtime_init.h and rename acs_common.c to acs_runtime_init.c
- move baremetal-only init helper declarations out of val/include/acs_common.h
- remove baremetal run-request default externs from apps/baremetal/acs.h
- add pal_run_request.h for baremetal platform default access
- make each target own static run-request default arrays in platform_cfg_fvp.c
- expose target defaults through acs_get_platform_run_request_defaults()
- update baremetal runtime init to seed run-request state from platform defaults
- keep helper-only list checks local to the baremetal runtime-init unit

Change-Id: I7aa53bdf394d6d17159bdfd41112d55baa707b20