### PR TITLE
cleanup(linux-app): localize CLI state in BSA and SBSA apps

### DIFF
--- a/apps/linux/bsa-acs-app/bsa_app_main.c
+++ b/apps/linux/bsa-acs-app/bsa_app_main.c
@@ -37,20 +37,13 @@
 /* Global extern for rule ID string map (defined in val/src/rule_enum_string_map.c) */
 extern char *rule_id_string[RULE_ID_SENTINEL];
 
-/* Global variables for app */
-int  g_print_level = 3;
-bool g_pcie_skip_dp_nic_ms = 0;
-uint32_t g_level_filter_mode = LVL_FILTER_MAX;  /* default: filter by max level */
-uint32_t g_level_value = BSA_LEVEL_1; /* Default BSA_LEVEL_1*/
-
 /* Legacy numeric skip support kept inert for compatibility with other files */
 unsigned int  *g_skip_test_num;
-unsigned int  g_num_skip = 3;
 unsigned int  g_sw_view[3] = {1, 1, 1}; //Operating System, Hypervisor, Platform Security
 
 /* New rule-based skip list parsed from -skip */
 static RULE_ID_e g_skip_rule_buf[BSA_RULE_ID_LIST_MAX];
-unsigned int g_skip_rule_count = 0;
+static unsigned int g_skip_rule_count;
 
 /*  Helpers for rule parsing  */
 static int sizeof_char_ptr(const char *tok)
@@ -98,9 +91,9 @@ static void skip_list_append(RULE_ID_e rid)
 
 
 int
-initialize_test_environment(unsigned int print_level)
+initialize_test_environment(unsigned int print_level, bool pcie_skip_dp_nic_ms)
 {
-    return call_drv_init_test_env(print_level);
+    return call_drv_init_test_env(print_level, pcie_skip_dp_nic_ms);
 }
 
 void
@@ -129,10 +122,14 @@ void print_help(){
 int
 main (int argc, char **argv)
 {
-
     int   c = 0;
     char *endptr;
     int   status;
+    unsigned int print_level = 3;
+    bool pcie_skip_dp_nic_ms = false;
+    uint32_t level_filter_mode = LVL_FILTER_MAX;  /* default: filter by max level */
+    uint32_t level_value = BSA_LEVEL_1; /* Default BSA_LEVEL_1*/
+    const unsigned int num_skip = 3;
     struct option long_opt[] =
     {
       {"skip", required_argument, NULL, 'n'},
@@ -145,7 +142,7 @@ main (int argc, char **argv)
     };
 
     /* Keep LEGACY array allocated and zeroed to avoid NULL deref in call_update_skip_list */
-    g_skip_test_num = (unsigned int *) calloc(g_num_skip, sizeof(unsigned int));
+    g_skip_test_num = (unsigned int *) calloc(num_skip, sizeof(unsigned int));
 
     /* Process Command Line arguments */
     while ((c = getopt_long(argc, argv, "hfr:v:l:oc", long_opt, NULL)) != -1)
@@ -153,18 +150,18 @@ main (int argc, char **argv)
        switch (c)
        {
        case 'v':
-         g_print_level = strtol(optarg, &endptr, 10);
+         print_level = strtol(optarg, &endptr, 10);
          break;
        case 'l':
-         g_level_value =  strtol(optarg, &endptr, 10);
-         g_level_filter_mode = LVL_FILTER_MAX;
+         level_value =  strtol(optarg, &endptr, 10);
+         level_filter_mode = LVL_FILTER_MAX;
          break;
        case 'o':
-         g_level_filter_mode = LVL_FILTER_ONLY;
+         level_filter_mode = LVL_FILTER_ONLY;
          break;
        case 'f':
-         g_level_filter_mode = LVL_FILTER_FR;
-         g_level_value = 0;
+         level_filter_mode = LVL_FILTER_FR;
+         level_value = 0;
          break;
        case 'r':
        {
@@ -203,7 +200,7 @@ main (int argc, char **argv)
          return 1;
          break;
        case 'c':
-         g_pcie_skip_dp_nic_ms = 1;
+         pcie_skip_dp_nic_ms = true;
          break;
        case 'n': /* --skip: parse comma-separated RULE IDs */
        {
@@ -248,19 +245,19 @@ main (int argc, char **argv)
     printf("                        Version %d.%d.%d\n",
             BSA_APP_VERSION_MAJOR, BSA_APP_VERSION_MINOR, BSA_APP_VERSION_SUBMINOR);
 
-    printf(LEVEL_PRINT_FORMAT(g_level_value, g_level_filter_mode, BSA_LEVEL_FR), g_level_value);
+    printf(LEVEL_PRINT_FORMAT(level_value, level_filter_mode, BSA_LEVEL_FR), level_value);
 
-    printf("(Print level is %2d)\n\n", g_print_level);
+    printf("(Print level is %2d)\n\n", print_level);
 
     printf(" Gathering system information....\n");
-    status = initialize_test_environment(g_print_level);
+    status = initialize_test_environment(print_level, pcie_skip_dp_nic_ms);
     if (status) {
         printf("Cannot initialize test environment. Exiting....\n");
         return 0;
     }
 
     /* Trigger rule-based run */
-    call_drv_execute_test(RUN_TESTS, 0, g_print_level, 0);
+    call_drv_execute_test(RUN_TESTS, 0, print_level, 0, level_filter_mode, level_value);
     (void)call_drv_wait_for_completion();
 
     printf("\n                    *** BSA tests complete ***\n\n");

--- a/apps/linux/bsa-acs-app/bsa_app_memory.c
+++ b/apps/linux/bsa-acs-app/bsa_app_memory.c
@@ -40,7 +40,7 @@ execute_tests_memory(int num_pe, unsigned int print_level)
     int status;
     call_update_sw_view(BSA_UPDATE_SW_VIEW, g_sw_view);
     call_update_skip_list(BSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(BSA_MEM_EXECUTE_TEST, num_pe, print_level, 0);
+    call_drv_execute_test(BSA_MEM_EXECUTE_TEST, num_pe, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
     return status;
 }

--- a/apps/linux/bsa-acs-app/bsa_app_pcie.c
+++ b/apps/linux/bsa-acs-app/bsa_app_pcie.c
@@ -39,7 +39,7 @@ execute_tests_pcie(int num_pe, unsigned int print_level)
     int status;
     call_update_sw_view(BSA_UPDATE_SW_VIEW, g_sw_view);
     call_update_skip_list(BSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(BSA_PCIE_EXECUTE_TEST, num_pe, print_level, 0);
+    call_drv_execute_test(BSA_PCIE_EXECUTE_TEST, num_pe, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
     return status;
 }
@@ -51,7 +51,7 @@ execute_tests_exerciser(int num_pe, unsigned int print_level)
     int status;
     call_update_sw_view(BSA_UPDATE_SW_VIEW, g_sw_view);
     call_update_skip_list(BSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(BSA_EXERCISER_EXECUTE_TEST, num_pe, print_level, 0);
+    call_drv_execute_test(BSA_EXERCISER_EXECUTE_TEST, num_pe, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
     return status;
 }

--- a/apps/linux/bsa-acs-app/bsa_app_peripheral.c
+++ b/apps/linux/bsa-acs-app/bsa_app_peripheral.c
@@ -40,7 +40,7 @@ execute_tests_peripheral(int num_pe, unsigned int print_level)
     int status;
     call_update_sw_view(BSA_UPDATE_SW_VIEW, g_sw_view);
     call_update_skip_list(BSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(BSA_PER_EXECUTE_TEST, num_pe, print_level, 0);
+    call_drv_execute_test(BSA_PER_EXECUTE_TEST, num_pe, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
     return status;
 }

--- a/apps/linux/bsa-acs-app/bsa_drv_intf.c
+++ b/apps/linux/bsa-acs-app/bsa_drv_intf.c
@@ -25,10 +25,6 @@
 #include <unistd.h>
 #include "bsa_drv_intf.h"
 
-extern bool g_pcie_skip_dp_nic_ms;
-extern uint32_t g_level_filter_mode;
-extern uint32_t g_level_value;
-
 typedef
 struct __BSA_DRV_PARMS__
 {
@@ -86,7 +82,7 @@ call_drv_wait_for_completion()
 
 
 int
-call_drv_init_test_env(unsigned int print_level)
+call_drv_init_test_env(unsigned int print_level, bool pcie_skip_dp_nic_ms)
 {
     FILE             *fd = NULL;
     bsa_drv_parms_t test_params;
@@ -101,7 +97,7 @@ call_drv_init_test_env(unsigned int print_level)
 
     test_params.api_num  = BSA_CREATE_INFO_TABLES;
     test_params.arg1     = print_level;
-    test_params.arg2     = g_pcie_skip_dp_nic_ms;
+    test_params.arg2     = pcie_skip_dp_nic_ms;
 
     fwrite(&test_params,1,sizeof(test_params),fd);
 
@@ -140,7 +136,8 @@ call_drv_clean_test_env()
 
 int
 call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
-  unsigned int print_level, unsigned long int test_input)
+  unsigned int print_level, unsigned long int test_input,
+  uint32_t level_filter_mode, uint32_t level_value)
 {
     FILE             *fd = NULL;
     bsa_drv_parms_t test_params;
@@ -161,8 +158,8 @@ call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
 
     if (api_num == RUN_TESTS) {
         /* Pass desired level and filter mode to driver */
-        test_params.level    = g_level_value;
-        test_params.arg0     = g_level_filter_mode;
+        test_params.level    = level_value;
+        test_params.arg0     = level_filter_mode;
         test_params.arg1     = print_level;
     }
 

--- a/apps/linux/bsa-acs-app/include/bsa_drv_intf.h
+++ b/apps/linux/bsa-acs-app/include/bsa_drv_intf.h
@@ -17,6 +17,7 @@
 
 #ifndef __BSA_DRV_INTF_H__
 #define __BSA_DRV_INTF_H__
+#include <stdbool.h>
 #include <stdint.h>
 
 /* API NUMBERS to COMMUNICATE with DRIVER */
@@ -53,14 +54,15 @@ typedef struct bsa_array_update_u {
 /* Function Prototypes */
 
 int
-call_drv_init_test_env(unsigned int print_level);
+call_drv_init_test_env(unsigned int print_level, bool pcie_skip_dp_nic_ms);
 
 int
 call_drv_clean_test_env(void);
 
 int
 call_drv_execute_test(unsigned int test_num, unsigned int num_pe,
-  unsigned int print_level, unsigned long int test_input);
+  unsigned int print_level, unsigned long int test_input,
+  uint32_t level_filter_mode, uint32_t level_value);
 
 int
 call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num);

--- a/apps/linux/pcbsa-acs-app/pcbsa_app_main.c
+++ b/apps/linux/pcbsa-acs-app/pcbsa_app_main.c
@@ -24,16 +24,7 @@
 #include "pcbsa_app.h"
 #include <getopt.h>
 
-int  g_pcbsa_level = 1;
-int  g_pcbsa_only_level = 0;
-int  g_print_level = 3;
-unsigned int g_num_skip = 3;
 unsigned int *g_skip_test_num;
-unsigned long int  g_exception_ret_addr;
-unsigned int g_print_mmio;
-unsigned int g_curr_module;
-unsigned int g_enable_module;
-
 #define PC_BSA_LEVEL_PRINT_FORMAT(level, only) ((level > PCBSA_MAX_LEVEL_SUPPORTED) ? \
     ((only) != 0 ? "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
     ((only) != 0 ? "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
@@ -74,6 +65,10 @@ int main(int argc, char **argv)
     int   c = 0, i = 0;
     char *endptr, *pt;
     int   status;
+    int pcbsa_level = 1;
+    int pcbsa_only_level = 0;
+    unsigned int print_level = 3;
+    const unsigned int num_skip = 3;
 
     struct option long_opt[] = {
       {"skip", required_argument, NULL, 'n'},
@@ -83,7 +78,7 @@ int main(int argc, char **argv)
       {NULL, 0, NULL, 0}
     };
 
-    g_skip_test_num = (unsigned int *) malloc(g_num_skip * sizeof(unsigned int));
+    g_skip_test_num = (unsigned int *) malloc(num_skip * sizeof(unsigned int));
 
     /* Process Command Line arguments */
     while ((c = getopt_long(argc, argv, "hrv:l:oe:", long_opt, NULL)) != -1)
@@ -91,16 +86,16 @@ int main(int argc, char **argv)
        switch (c)
        {
        case 'v':
-         g_print_level = strtol(optarg, &endptr, 10);
+         print_level = strtol(optarg, &endptr, 10);
          break;
        case 'l':
-         g_pcbsa_level = strtol(optarg, &endptr, 10);
+         pcbsa_level = strtol(optarg, &endptr, 10);
          break;
        case 'o':
-         g_pcbsa_only_level = 1;
+         pcbsa_only_level = 1;
          break;
        case 'r':
-         g_pcbsa_level = 8;
+         pcbsa_level = 8;
          break;
        case 'h':
          print_help();
@@ -108,7 +103,7 @@ int main(int argc, char **argv)
          break;
        case 'n':/*SKIP tests */
          pt = strtok(optarg, ",");
-         while ((pt != NULL) && (i < g_num_skip)) {
+         while ((pt != NULL) && (i < num_skip)) {
            int a = atoi(pt);
 
            g_skip_test_num[i++] = a;
@@ -134,22 +129,22 @@ int main(int argc, char **argv)
             PC_BSA_APP_VERSION_MINOR, PC_BSA_APP_VERSION_SUBMINOR);
 
 
-    printf(PC_BSA_LEVEL_PRINT_FORMAT(g_pcbsa_level, g_pcbsa_only_level),
-                                   (g_pcbsa_level > PCBSA_MAX_LEVEL_SUPPORTED) ? 0 : g_pcbsa_level);
+    printf(PC_BSA_LEVEL_PRINT_FORMAT(pcbsa_level, pcbsa_only_level),
+                                   (pcbsa_level > PCBSA_MAX_LEVEL_SUPPORTED) ? 0 : pcbsa_level);
 
-    printf("(Print level is %2d)\n\n", g_print_level);
+    printf("(Print level is %2d)\n\n", print_level);
 
-    if (g_pcbsa_only_level)
-        g_pcbsa_only_level = g_pcbsa_level;
+    if (pcbsa_only_level)
+        pcbsa_only_level = pcbsa_level;
 
     printf(" Gathering system information....\n");
-    status = initialize_test_environment(g_print_level);
+    status = initialize_test_environment(print_level);
     if (status) {
         printf("Cannot initialize test environment. Exiting....\n");
         return 0;
     }
 
-    execute_tests_pcie(1, g_pcbsa_level, g_print_level);
+    execute_tests_pcie(1, pcbsa_level, print_level);
 
     printf("\n  ** For complete PCBSA test coverage, it is necessary to run the BSA test **\n");
     printf("\n                    *** PC BSA tests complete ***\n\n");

--- a/apps/linux/sbsa-acs-app/include/sbsa_drv_intf.h
+++ b/apps/linux/sbsa-acs-app/include/sbsa_drv_intf.h
@@ -17,6 +17,7 @@
 
 #ifndef __SBSA_DRV_INTF_H__
 #define __SBSA_DRV_INTF_H__
+#include <stdbool.h>
 #include <stdint.h>
 
 /* API NUMBERS to COMMUNICATE with DRIVER */
@@ -52,14 +53,15 @@ typedef struct sbsa_array_update_u {
 /* Function Prototypes */
 
 int
-call_drv_init_test_env(unsigned int print_level);
+call_drv_init_test_env(unsigned int print_level, bool pcie_skip_dp_nic_ms);
 
 int
 call_drv_clean_test_env(void);
 
 int
 call_drv_execute_test(unsigned int test_num, unsigned int num_pe,
-  unsigned int level, unsigned int print_level, unsigned long int test_input);
+  unsigned int level, unsigned int print_level, unsigned long int test_input,
+  uint32_t level_filter_mode, uint32_t level_value);
 
 int
 call_update_skip_list(unsigned int api_num, uint32_t *p_skip_test_num);

--- a/apps/linux/sbsa-acs-app/sbsa_app_main.c
+++ b/apps/linux/sbsa-acs-app/sbsa_app_main.c
@@ -37,20 +37,13 @@
 /* Global extern for rule ID string map (defined in val/src/rule_enum_string_map.c) */
 extern char *rule_id_string[RULE_ID_SENTINEL];
 
-/* Global variables for app */
-int  g_print_level = 3;
-bool g_pcie_skip_dp_nic_ms = 0;
-uint32_t g_level_filter_mode = LVL_FILTER_MAX;  /* LEVEL_FILTER_MODE_e */
-uint32_t g_level_value = SBSA_LEVEL_3;          /* Default SBSA level */
-
 /* Legacy numeric skip support kept inert for compatibility with other files */
 unsigned int  *g_skip_test_num;
-unsigned int  g_num_skip = 3;
 unsigned int  g_sw_view[3] = {1, 1, 1}; //Operating System, Hypervisor, Platform Security
 
 /* New rule-based skip list parsed from -skip */
 static RULE_ID_e g_skip_rule_buf[RULE_ID_LIST_MAX];
-unsigned int g_skip_rule_count = 0;
+static unsigned int g_skip_rule_count;
 
 /*  Helpers for rule parsing  */
 static int sizeof_char_ptr(const char *tok)
@@ -98,9 +91,9 @@ static void skip_list_append(RULE_ID_e rid)
 
 
 int
-initialize_test_environment(unsigned int print_level)
+initialize_test_environment(unsigned int print_level, bool pcie_skip_dp_nic_ms)
 {
-    return call_drv_init_test_env(print_level);
+    return call_drv_init_test_env(print_level, pcie_skip_dp_nic_ms);
 }
 
 void
@@ -128,10 +121,14 @@ void print_help(){
 int
 main (int argc, char **argv)
 {
-
     int   c = 0;
     char *endptr;
     int   status;
+    unsigned int print_level = 3;
+    bool pcie_skip_dp_nic_ms = false;
+    uint32_t level_filter_mode = LVL_FILTER_MAX;  /* LEVEL_FILTER_MODE_e */
+    uint32_t level_value = SBSA_LEVEL_3;          /* Default SBSA level */
+    const unsigned int num_skip = 3;
     struct option long_opt[] =
     {
       {"skip", required_argument, NULL, 'n'},
@@ -144,7 +141,7 @@ main (int argc, char **argv)
     };
 
     /* Keep legacy array allocated and zeroed to avoid NULL deref in call_update_skip_list */
-    g_skip_test_num = (unsigned int *) calloc(g_num_skip, sizeof(unsigned int));
+    g_skip_test_num = (unsigned int *) calloc(num_skip, sizeof(unsigned int));
 
     /* Process Command Line arguments */
     while ((c = getopt_long(argc, argv, "hfr:v:l:oc", long_opt, NULL)) != -1)
@@ -152,19 +149,19 @@ main (int argc, char **argv)
        switch (c)
        {
        case 'v':
-         g_print_level = strtol(optarg, &endptr, 10);
+         print_level = strtol(optarg, &endptr, 10);
          break;
        case 'l':
-         g_level_value =  strtol(optarg, &endptr, 10);
-         g_level_filter_mode = LVL_FILTER_MAX;
+         level_value =  strtol(optarg, &endptr, 10);
+         level_filter_mode = LVL_FILTER_MAX;
          break;
        case 'o':
-         g_level_value =  strtol(optarg, &endptr, 10);
-         g_level_filter_mode = LVL_FILTER_ONLY;
+         level_value =  strtol(optarg, &endptr, 10);
+         level_filter_mode = LVL_FILTER_ONLY;
          break;
        case 'f':
-         g_level_filter_mode = LVL_FILTER_FR;
-         g_level_value = 0;
+         level_filter_mode = LVL_FILTER_FR;
+         level_value = 0;
          break;
        case 'r':
        {
@@ -203,7 +200,7 @@ main (int argc, char **argv)
          return 1;
          break;
        case 'c':
-         g_pcie_skip_dp_nic_ms = 1;
+         pcie_skip_dp_nic_ms = true;
          break;
        case 'n': /* --skip: parse comma-separated RULE IDs */
        {
@@ -248,19 +245,19 @@ main (int argc, char **argv)
     printf("                        Version %d.%d.%d\n", SBSA_APP_VERSION_MAJOR,
             SBSA_APP_VERSION_MINOR, SBSA_APP_VERSION_SUBMINOR);
 
-    printf(LEVEL_PRINT_FORMAT(g_level_value, g_level_filter_mode, SBSA_LEVEL_FR), g_level_value);
+    printf(LEVEL_PRINT_FORMAT(level_value, level_filter_mode, SBSA_LEVEL_FR), level_value);
 
-    printf("(Print level is %2d)\n\n", g_print_level);
+    printf("(Print level is %2d)\n\n", print_level);
 
     printf(" Gathering system information....\n");
-    status = initialize_test_environment(g_print_level);
+    status = initialize_test_environment(print_level, pcie_skip_dp_nic_ms);
     if (status) {
         printf("Cannot initialize test environment. Exiting....\n");
         return 0;
     }
 
     /* Trigger rule-based run */
-    call_drv_execute_test(RUN_TESTS, 0, 0, g_print_level, 0);
+    call_drv_execute_test(RUN_TESTS, 0, 0, print_level, 0, level_filter_mode, level_value);
     (void)call_drv_wait_for_completion();
 
     printf("\n                    *** SBSA tests complete ***\n\n");

--- a/apps/linux/sbsa-acs-app/sbsa_app_pcie.c
+++ b/apps/linux/sbsa-acs-app/sbsa_app_pcie.c
@@ -38,7 +38,7 @@ execute_tests_pcie(int num_pe, int level, unsigned int print_level)
 
     int status;
     call_update_skip_list(SBSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(SBSA_PCIE_EXECUTE_TEST, num_pe, level, print_level, 0);
+    call_drv_execute_test(SBSA_PCIE_EXECUTE_TEST, num_pe, level, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
     return status;
 }
@@ -49,7 +49,7 @@ execute_tests_exerciser(int num_pe, int level, unsigned int print_level)
 
     int status;
     call_update_skip_list(SBSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(SBSA_EXERCISER_EXECUTE_TEST, num_pe, level, print_level, 0);
+    call_drv_execute_test(SBSA_EXERCISER_EXECUTE_TEST, num_pe, level, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
     return status;
 }

--- a/apps/linux/sbsa-acs-app/sbsa_app_smmu.c
+++ b/apps/linux/sbsa-acs-app/sbsa_app_smmu.c
@@ -39,9 +39,8 @@ execute_tests_smmu(int num_pe, int level, unsigned int print_level)
     int status;
 
     call_update_skip_list(SBSA_UPDATE_SKIP_LIST, g_skip_test_num);
-    call_drv_execute_test(SBSA_SMMU_EXECUTE_TEST, num_pe, level, print_level, 0);
+    call_drv_execute_test(SBSA_SMMU_EXECUTE_TEST, num_pe, level, print_level, 0, 0, 0);
     status  = call_drv_wait_for_completion();
 
     return status;
 }
-

--- a/apps/linux/sbsa-acs-app/sbsa_drv_intf.c
+++ b/apps/linux/sbsa-acs-app/sbsa_drv_intf.c
@@ -25,10 +25,6 @@
 #include <unistd.h>
 #include "sbsa_drv_intf.h"
 
-extern bool g_pcie_skip_dp_nic_ms;
-extern uint32_t g_level_value;
-extern uint32_t g_level_filter_mode;
-
 typedef
 struct __SBSA_DRV_PARMS__
 {
@@ -86,7 +82,7 @@ call_drv_wait_for_completion(void)
 
 
 int
-call_drv_init_test_env(unsigned int print_level)
+call_drv_init_test_env(unsigned int print_level, bool pcie_skip_dp_nic_ms)
 {
     FILE             *fd = NULL;
     sbsa_drv_parms_t test_params;
@@ -102,7 +98,7 @@ call_drv_init_test_env(unsigned int print_level)
 
     test_params.api_num  = SBSA_CREATE_INFO_TABLES;
     test_params.arg1     = print_level;
-    test_params.arg2     = g_pcie_skip_dp_nic_ms;
+    test_params.arg2     = pcie_skip_dp_nic_ms;
 
     fwrite(&test_params,1,sizeof(test_params),fd);
 
@@ -140,7 +136,8 @@ call_drv_clean_test_env(void)
 
 int
 call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
-  unsigned int level, unsigned int print_level, unsigned long int test_input)
+  unsigned int level, unsigned int print_level, unsigned long int test_input,
+  uint32_t level_filter_mode, uint32_t level_value)
 {
     FILE             *fd = NULL;
     sbsa_drv_parms_t test_params;
@@ -162,8 +159,8 @@ call_drv_execute_test(unsigned int api_num, unsigned int num_pe,
 
     if (api_num == RUN_TESTS) {
         /* Pass desired level and filter mode to driver */
-        test_params.level = g_level_value;
-        test_params.arg0  = g_level_filter_mode;
+        test_params.level = level_value;
+        test_params.arg0  = level_filter_mode;
         test_params.arg1 = print_level;
     }
 


### PR DESCRIPTION
Remove Linux app CLI state leakage from the BSA and SBSA driver-interface layers by passing print and rule-selection inputs explicitly instead of reading them through app globals. This keeps the userspace CLI state local to the app entry files, reduces cross-file coupling, and tightens the PCBSA app main state where it was clearly local, without changing driver behavior.

- pass BSA and SBSA print, skip-DP-NIC-MS, and rule-selection inputs explicitly into the driver-interface helpers
- remove BSA and SBSA driver-interface dependence on app-level extern globals
- localize BSA and SBSA CLI state in the app main files
- keep legacy cross-file skip-list and software-view globals unchanged where other Linux app objects still rely on them
- tighten obvious file-local state in pcbsa_app_main.c without changing the PCBSA driver interface

Change-Id: Icc39be47a775015e8e5d16f461875ee42b9cd269