### PR TITLE
refactor(pal): unify PAL print helper macros

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -19,11 +19,12 @@
 #define __PAL_COMMON_SUPPORT_H_
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include <string.h>
 #include <stdlib.h>
 #include "pal_status.h"
 #include "pal_execution_policy.h"
+#include "pal_print.h"
 #include "platform_override_fvp.h"
 
 typedef uintptr_t addr_t;
@@ -31,12 +32,6 @@ typedef char     char8_t;
 
 extern uint32_t g_curr_module;
 extern uint32_t g_enable_module;
-
-#define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_WARN  4      /* Only warnings & errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
-#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
-#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
 #define MEM_ALIGN_4K       0x1000
 #define MEM_ALIGN_8K       0x2000
@@ -65,14 +60,10 @@ void *pal_aligned_alloc( uint32_t alignment, uint32_t size );
 #define PCIE_MAX_DEV    32
 #define PCIE_MAX_FUNC    8
 
-void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
 void pal_warn_not_implemented(const char *api_name);
 #define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            pal_uart_print((verbose), (string), ##__VA_ARGS__); \
-    } while (0)
+    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
 
 #define PCIE_CREATE_BDF(Seg, Bus, Dev, Func) ((Seg << 24) | (Bus << 16) | (Dev << 8) | Func)
 

--- a/pal/baremetal/base/include/pal_pcie_enum.h
+++ b/pal/baremetal/base/include/pal_pcie_enum.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 #define __PAL_PCIE_ENUM_H__
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 
 
 /* Header Offset and Type*/

--- a/pal/baremetal/base/include/pal_pl011_uart.h
+++ b/pal/baremetal/base/include/pal_pl011_uart.h
@@ -15,7 +15,7 @@
  * limitations under the License.
 **/
 
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "platform_override_fvp.h"
 
 #ifndef _PAL_UART_PL011_H_

--- a/pal/baremetal/base/include/pal_run_request.h
+++ b/pal/baremetal/base/include/pal_run_request.h
@@ -18,7 +18,7 @@
 #ifndef __PAL_RUN_REQUEST_H__
 #define __PAL_RUN_REQUEST_H__
 
-#include <stdint.h>
+#include "acs_stdint.h"
 
 #include "rule_based_execution_enum.h"
 

--- a/pal/baremetal/base/src/pal_misc.c
+++ b/pal/baremetal/base/src/pal_misc.c
@@ -15,7 +15,7 @@
  * limitations under the License.
 **/
 
-#include <stdint.h>
+#include "acs_stdint.h"
 #include <stdarg.h>
 #include "pal_pcie_enum.h"
 #include "pal_common_support.h"

--- a/pal/baremetal/target/RDN2/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDN2/include/pal_exerciser.h
@@ -17,15 +17,10 @@
 **/
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "acs_execution_policy.h"
+#include "pal_print.h"
 #include "platform_override_fvp.h"
-
-#define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_WARN  4      /* Only warnings & errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
-#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
-#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
 #define PCIE_SUCCESS            0x00000000  /* Operation completed successfully */
 #define PCIE_NO_MAPPING         0x10000001  /* A mapping to a Function does not exist */
@@ -33,22 +28,11 @@
 #define PCIE_UNKNOWN_RESPONSE   0xFFFFFFFF  /* Function not found or UR response from completer */
 
 #ifdef TARGET_BAREMETAL
-void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
-#define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            pal_uart_print((verbose), (string), ##__VA_ARGS__); \
-    } while (0)
-#else
-#include <Library/UefiLib.h>
+#endif
 
 #define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            Print(L##string, ##__VA_ARGS__); \
-    } while (0)
-#endif
+    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
 
 #define PCIE_CREATE_BDF(Seg, Bus, Dev, Func) ((Seg << 24) | (Bus << 16) | (Dev << 8) | Func)
 #define PCIE_EXTRACT_BDF_SEG(bdf)  ((bdf >> 24) & 0xFF)

--- a/pal/baremetal/target/RDN2/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_struct.h
@@ -16,7 +16,7 @@
 **/
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "platform_override_fvp.h"
 
 #define MAX_CS_COMP_LENGTH 256

--- a/pal/baremetal/target/RDV3/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3/include/pal_exerciser.h
@@ -17,15 +17,10 @@
 **/
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "acs_execution_policy.h"
+#include "pal_print.h"
 #include "platform_override_fvp.h"
-
-#define ACS_PRINT_ERR   5      /* Only Errors. Use this to trim output to key info */
-#define ACS_PRINT_WARN  4      /* Only warnings & errors. Use this to trim output to key info */
-#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
-#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
-#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
 #define PCIE_SUCCESS            0x00000000  /* Operation completed successfully */
 #define PCIE_NO_MAPPING         0x10000001  /* A mapping to a Function does not exist */
@@ -33,22 +28,11 @@
 #define PCIE_UNKNOWN_RESPONSE   0xFFFFFFFF  /* Function not found or UR response from completer */
 
 #ifdef TARGET_BAREMETAL
-void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
-#define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            pal_uart_print((verbose), (string), ##__VA_ARGS__); \
-    } while (0)
-#else
-#include <Library/UefiLib.h>
+#endif
 
 #define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            Print(L##string, ##__VA_ARGS__); \
-    } while (0)
-#endif
+    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
 
 /* Exerciser PAL API declarations */
 uint64_t pal_exerciser_get_ecam(uint32_t Bdf);

--- a/pal/baremetal/target/RDV3/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDV3/include/platform_override_struct.h
@@ -16,7 +16,7 @@
 **/
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "platform_override_fvp.h"
 
 #define MAX_CS_COMP_LENGTH 256

--- a/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
@@ -17,15 +17,10 @@
 **/
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "acs_execution_policy.h"
+#include "pal_print.h"
 #include "platform_override_fvp.h"
-
-#define ACS_PRINT_ERR   5      /* Only Errors. Use this to trim output to key info */
-#define ACS_PRINT_WARN  4      /* Only warnings & errors. Use this to trim output to key info */
-#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
-#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
-#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
 #define PCIE_SUCCESS            0x00000000  /* Operation completed successfully */
 #define PCIE_NO_MAPPING         0x10000001  /* A mapping to a Function does not exist */
@@ -33,22 +28,11 @@
 #define PCIE_UNKNOWN_RESPONSE   0xFFFFFFFF  /* Function not found or UR response from completer */
 
 #ifdef TARGET_BAREMETAL
-void pal_uart_print(int log, const char *fmt, ...);
 void *mem_alloc(size_t alignment, size_t size);
-#define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            pal_uart_print((verbose), (string), ##__VA_ARGS__); \
-    } while (0)
-#else
-#include <Library/UefiLib.h>
+#endif
 
 #define print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            Print(L##string, ##__VA_ARGS__); \
-    } while (0)
-#endif
+    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
 
 /* Exerciser PAL API declarations */
 uint64_t pal_exerciser_get_ecam(uint32_t Bdf);

--- a/pal/baremetal/target/RDV3CFG1/include/platform_override_struct.h
+++ b/pal/baremetal/target/RDV3CFG1/include/platform_override_struct.h
@@ -16,7 +16,7 @@
 **/
 
 #include <stdio.h>
-#include <stdint.h>
+#include "acs_stdint.h"
 #include "platform_override_fvp.h"
 
 #define MAX_CS_COMP_LENGTH 256

--- a/pal/include/pal_print.h
+++ b/pal/include/pal_print.h
@@ -1,0 +1,56 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __PAL_PRINT_H__
+#define __PAL_PRINT_H__
+
+#include "acs_execution_policy.h"
+
+#define ACS_PRINT_ERR   5      /* Only Errors. Use this to trim output to key info */
+#define ACS_PRINT_WARN  4      /* Only warnings & errors. Use this to trim output to key info */
+#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
+#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
+#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
+
+#define PAL_PRINT_IF(verbose, call_expr) \
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) { \
+            call_expr; \
+        } \
+    } while (0)
+
+#if defined(TARGET_BAREMETAL)
+void pal_uart_print(int log, const char *fmt, ...);
+
+#define PAL_PRINT_FORMAT(verbose, string, ...) \
+    PAL_PRINT_IF((verbose), pal_uart_print((verbose), (string), ##__VA_ARGS__))
+
+#define PAL_PRINT_LITERAL(verbose, string, ...) \
+    PAL_PRINT_FORMAT((verbose), (string), ##__VA_ARGS__)
+#elif defined(TARGET_UEFI)
+#include <Library/UefiLib.h>
+
+#define PAL_PRINT_FORMAT(verbose, string, ...) \
+    PAL_PRINT_IF((verbose), Print((string), ##__VA_ARGS__))
+
+#define PAL_PRINT_LITERAL(verbose, string, ...) \
+    PAL_PRINT_IF((verbose), Print(L##string, ##__VA_ARGS__))
+#else
+#error "pal_print.h requires TARGET_BAREMETAL or TARGET_UEFI"
+#endif
+
+#endif

--- a/pal/include/pal_status.h
+++ b/pal/include/pal_status.h
@@ -19,7 +19,7 @@
 #ifndef PAL_STATUS_H_
 #define PAL_STATUS_H_
 
-#include <stdint.h>
+#include "acs_stdint.h"
 
 typedef enum pal_status {
   PAL_STATUS_SUCCESS                = 0x00000000u,

--- a/pal/uefi_acpi/PalLib.inf
+++ b/pal/uefi_acpi/PalLib.inf
@@ -84,4 +84,4 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a -D__ASSEMBLY__ -D__ASSEMBLER__
-  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_UEFI_ACPI_INCLUDE_FLAGS)
+  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_UEFI_ACPI_INCLUDE_FLAGS) -DTARGET_UEFI

--- a/pal/uefi_acpi/SbsaPalNistLib.inf
+++ b/pal/uefi_acpi/SbsaPalNistLib.inf
@@ -85,4 +85,4 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a
-  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_NIST_INCLUDE_FLAGS)
+  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_NIST_INCLUDE_FLAGS) -DTARGET_UEFI

--- a/pal/uefi_acpi/include/pal_uefi.h
+++ b/pal/uefi_acpi/include/pal_uefi.h
@@ -19,7 +19,7 @@
 #define __PAL_UEFI_H__
 
 #include "pal_status.h"
-#include "acs_execution_policy.h"
+#include "pal_print.h"
 
 /* include ACPI specification headers */
 #include "Include/Guid/Acpi.h"
@@ -36,12 +36,6 @@ extern VOID* g_acs_log_file_handle;
 extern UINT32 g_curr_module;
 extern UINT32 g_enable_module;
 VOID pal_warn_not_implemented(const CHAR8 *api_name);
-
-#define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_WARN  4      /* Only warnings & errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
-#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
-#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
 #define PCIE_SUCCESS            0x00000000  /* Operation completed successfully */
 #define PCIE_NO_MAPPING         0x10000001  /* A mapping to a Function does not exist */
@@ -91,10 +85,7 @@ typedef struct {
 } ARM_SMC_ARGS;
 
 #define acs_print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            Print((string), ##__VA_ARGS__); \
-    } while (0)
+    PAL_PRINT_FORMAT((verbose), (string), ##__VA_ARGS__)
 
 /**
   Conduits for service calls (SMC vs HVC).

--- a/pal/uefi_dt/PalLib.inf
+++ b/pal/uefi_dt/PalLib.inf
@@ -83,4 +83,4 @@
 
 [BuildOptions]
   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.2-a -D__ASSEMBLY__ -D__ASSEMBLER__
-  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_UEFI_DT_INCLUDE_FLAGS) $(BASE_FDT_LIB_INCLUDE_FLAGS)
+  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+profile+lse $(PAL_UEFI_DT_INCLUDE_FLAGS) $(BASE_FDT_LIB_INCLUDE_FLAGS) -DTARGET_UEFI

--- a/pal/uefi_dt/include/pal_uefi.h
+++ b/pal/uefi_dt/include/pal_uefi.h
@@ -19,18 +19,12 @@
 #define __PAL_UEFI_H__
 
 #include "pal_status.h"
-#include "acs_execution_policy.h"
+#include "pal_print.h"
 
 extern VOID* g_acs_log_file_handle;
 extern UINT32 g_curr_module;
 extern UINT32 g_enable_module;
 VOID pal_warn_not_implemented(const CHAR8 *api_name);
-
-#define ACS_PRINT_ERR   5      /* Only Errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_WARN  4      /* Only warnings & errors. use this to de-clutter the terminal and focus only on specifics */
-#define ACS_PRINT_TEST  3      /* Test description and result descriptions. THIS is DEFAULT */
-#define ACS_PRINT_DEBUG 2      /* For Debug statements. contains register dumps etc */
-#define ACS_PRINT_INFO  1      /* Print all statements. Do not use unless really needed */
 
 #define PCIE_SUCCESS            0x00000000  /* Operation completed successfully */
 #define PCIE_NO_MAPPING         0x10000001  /* A mapping to a Function does not exist */
@@ -80,10 +74,7 @@ typedef struct {
 } ARM_SMC_ARGS;
 
 #define acs_print(verbose, string, ...) \
-    do { \
-        if ((verbose) >= acs_policy_get_print_level()) \
-            Print((string), ##__VA_ARGS__); \
-    } while (0)
+    PAL_PRINT_FORMAT((verbose), (string), ##__VA_ARGS__)
 
 /**
   Conduits for service calls (SMC vs HVC).


### PR DESCRIPTION
Introduce a shared PAL print helper and route the existing PAL print front ends through it. This removes repeated print gating and level definitions from baremetal common, exerciser, and UEFI PAL headers while keeping current call sites and backend behavior intact.

- add pal/include/pal_print.h for shared PAL print levels and gating
- centralize backend selection between pal_uart_print and UEFI Print
- keep separate literal and format helpers for ASCII literals and pre-wide UEFI format strings
- convert pal_common_support.h, target pal_exerciser.h, and UEFI pal_uefi.h to thin wrapper macros over the shared helper
- make supported targets explicit in pal_print.h for baremetal and UEFI builds

Change-Id: I0fc28009df537a76791986bb899d1513a37601cf