### PR TITLE
ci: add mem_test UEFI workflow build

### DIFF
--- a/.github/workflows/sysarch_ci.yml
+++ b/.github/workflows/sysarch_ci.yml
@@ -107,6 +107,10 @@ jobs:
             arg: pfdi
             outfile: pfdi.efi
             artifact: Pfdi_dt_target.efi
+          - name: MEM-TEST ACPI
+            arg: mem_test
+            outfile: Bsa.efi
+            artifact: memtest_acpi_target.efi
     steps:
       - name: Install dependencies
         run: |
@@ -147,7 +151,6 @@ jobs:
             cd /opt/cross
             wget https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
             tar -xf arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
-            echo "GCC_AARCH64_PREFIX=/opt/cross/arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-" >> "$GITHUB_ENV"
 
           elif [[ "${{ matrix.toolchain }}" == "gcc" ]]; then
             echo "Checking for existing GCC source-built toolchain..."
@@ -193,11 +196,33 @@ jobs:
             fi
 
             echo "$INSTALL/bin" >> "$GITHUB_PATH"
-            echo "GCC_AARCH64_PREFIX=$INSTALL/bin/aarch64-none-linux-gnu-" >> "$GITHUB_ENV"
           else
             echo "::error ::Invalid toolchain selected: '${{ matrix.toolchain }}'"
             exit 1
           fi
+
+      - name: Export target build environment
+        run: |
+          if [[ "${{ matrix.toolchain }}" == "arm-toolchain" ]]; then
+            PREFIX=/opt/cross/arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+          else
+            PREFIX=$HOME/gcc-linux-gnu/install/bin/aarch64-none-linux-gnu-
+          fi
+
+          if [[ "${{ matrix.target.arg }}" == "mem_test" ]]; then
+            echo "BUILD_TAG=GCCNOLTO" >> "$GITHUB_ENV"
+            echo "GCCNOLTO_AARCH64_PREFIX=$PREFIX" >> "$GITHUB_ENV"
+          else
+            echo "BUILD_TAG=GCC" >> "$GITHUB_ENV"
+            echo "GCC_AARCH64_PREFIX=$PREFIX" >> "$GITHUB_ENV"
+          fi
+
+      - name: Download mem_test sources
+        if: ${{ matrix.target.arg == 'mem_test' }}
+        run: |
+          git clone --depth 1 --branch target-efi-bsa --single-branch \
+            https://github.com/relokin/kvm-unit-tests.git \
+            edk2/ShellPkg/Application/sysarch-acs/mem_test/kvm-unit-tests
 
       - name: Build ${{ matrix.target.name }}
         run: |
@@ -206,13 +231,13 @@ jobs:
           source edksetup.sh
           make -C BaseTools/Source/C
           source ShellPkg/Application/sysarch-acs/tools/scripts/acsbuild.sh ${{ matrix.target.arg }}
-          build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/Shell/Shell.inf
+          build -a AARCH64 -t "$BUILD_TAG" -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/Shell/Shell.inf
 
       - name: Move output to toolchain folder
         run: |
           mkdir -p "artifacts/${{ matrix.toolchain }}"
-          cp "edk2/Build/Shell/DEBUG_GCC/AARCH64/${{ matrix.target.outfile }}" "artifacts/${{ matrix.toolchain }}/${{ matrix.target.artifact }}"
-          cp "edk2/Build/Shell/DEBUG_GCC/AARCH64/ShellPkg/Application/Shell/Shell/OUTPUT/Shell.efi" "artifacts/${{ matrix.toolchain }}/"
+          cp "edk2/Build/Shell/DEBUG_${BUILD_TAG}/AARCH64/${{ matrix.target.outfile }}" "artifacts/${{ matrix.toolchain }}/${{ matrix.target.artifact }}"
+          cp "edk2/Build/Shell/DEBUG_${BUILD_TAG}/AARCH64/ShellPkg/Application/Shell/Shell/OUTPUT/Shell.efi" "artifacts/${{ matrix.toolchain }}/"
 
       - name: Upload ${{ matrix.target.artifact }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Extend the reusable UEFI workflow to build
mem_test with its extra source download and
target-specific toolchain environment.