### PR TITLE
feat(sbsa): Add alias mappings for L5/L6 rules

### DIFF
--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -451,14 +451,23 @@ The checklist provides information about:
       <td></td>
     </tr>
     <tr>
-      <td>L5</td>
-      <td>S_L5SM_04</td>
-      <td>S_L5SM_04</td>
-      <td>Not Covered</td>
+      <td rowspan="2">L5</td>
+      <td rowspan="2">S_L5SM_04</td>
+      <td>B_SMMU_09</td>
+      <td>310</td>
+      <td>Check S-EL2 &amp; SMMU Stage1 support</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+    </tr>
+    <tr>
+      <td>B_SMMU_20</td>
+      <td>311</td>
+      <td>Check S-EL2 &amp; SMMU Stage2 Support</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
     </tr>
     <tr>
@@ -589,11 +598,11 @@ The checklist provides information about:
       <td>L6</td>
       <td>S_L6PE_08</td>
       <td>S_L6PE_08</td>
-      <td>Not covered</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+      <td>37</td>
+      <td>Check SPE if implemented</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
     </tr>
     <tr>
@@ -608,14 +617,59 @@ The checklist provides information about:
       <td></td>
     </tr>
     <tr>
-      <td>L6</td>
-      <td>S_L6SM_04</td>
-      <td>S_L6SM_04</td>
-      <td>Not covered</td>
+      <td rowspan="6">L6</td>
+      <td rowspan="6">S_L6SM_04</td>
+      <td>B_SMMU_03</td>
+      <td>316</td>
+      <td>Check SMMU Large VA Support</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
+    </tr>
+    </tr>
+     <td>B_SMMU_04</td>
+      <td>317</td>
+      <td>Check TLB Range Invalidation</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
+    </tr>
+    <tr>
+      <td>B_SMMU_05</td>
+      <td>330</td>
+      <td>Check DVM capabilities</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
+    </tr>
+    <tr>
+      <td>B_SMMU_13</td>
+      <td>318</td>
+      <td>Check SMMU 16 Bit ASID Support</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
+    </tr>
+    <tr>
+      <td>B_SMMU_14</td>
+      <td>319</td>
+      <td>Check SMMU Endianess Support</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>B_SMMU_23</td>
+      <td>315</td>
+      <td>Check SMMU 16 Bit VMID Support</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
     </tr>
     <tr>
@@ -3621,6 +3675,9 @@ The checklist provides information about:
 </table>
 
 ## Latest Checklist Changes
+- Updated S_L5SM_04, S_L6PE_08, S_L6SM_04
+
+### v26.03_SBSA_8.0.1
 - **FR Added:** LVQBC, KBRZG
 - **RI_ Added:** RI_PWR_1
 - B_PCIe_10 and B_PCIe_11 mapped to S_PCIe_10

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -465,6 +465,14 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_PE_TEST_NUM_BASE  +  48,
         },
+        [S_L6PE_08] = {
+            .test_entry_id    = PE037_ENTRY,
+            .module_id        = PE,
+            .rule_desc        = "Check SPE if implemented",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = BASE_RULE,
+            .test_num         = ACS_PE_TEST_NUM_BASE  +  37,
+        },
         [S_L7PE_02] = {
             .test_entry_id    = PE049_ENTRY,
             .module_id        = PE,
@@ -1317,6 +1325,13 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_SMMU_TEST_NUM_BASE + 12,
         },
+        [S_L5SM_04] = {
+            .test_entry_id    = NULL_ENTRY,
+            .module_id        = SMMU,
+            .rule_desc        = "S-EL2 & SMMU Stage1 and Stage2 support",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = ALIAS_RULE,
+        },
         [S_L6SM_02] = {
             .test_entry_id    = I013_ENTRY,
             .module_id        = SMMU,
@@ -1332,6 +1347,13 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
             .flag             = BASE_RULE,
             .test_num         = ACS_SMMU_TEST_NUM_BASE + 14,
+        },
+        [S_L6SM_04] = {
+            .test_entry_id    = NULL_ENTRY,
+            .module_id        = SMMU,
+            .rule_desc        = "Check SMMU large VA/TLB/DVM ASID VMID",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = ALIAS_RULE,
         },
         [S_L7SM_01] = {
             .test_entry_id    = I022_ENTRY,
@@ -3007,9 +3029,6 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
         [S_L6PE_07] = {
             .module_id        = PE,
         },
-        [S_L6PE_08] = {
-            .module_id        = PE,
-        },
         [S_L8PE_08] = {
             .module_id        = PE,
         },
@@ -3107,12 +3126,6 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .module_id        = SMMU,
         },
         [S_L3SM_01] = {
-            .module_id        = SMMU,
-        },
-        [S_L5SM_04] = {
-            .module_id        = SMMU,
-        },
-        [S_L6SM_04] = {
             .module_id        = SMMU,
         },
         [P_L1SM_01] = {
@@ -4845,6 +4858,13 @@ RULE_ID_e s_l8cxl_rule_list[] = {
     RULE_ID_SENTINEL
 };
 
+/* S_L5SM_04 */
+RULE_ID_e s_l5sm_04_rule_list[]   = {B_SMMU_09, B_SMMU_20, RULE_ID_SENTINEL};
+
+/* S_L6SM_04 */
+RULE_ID_e s_l6sm_04_rule_list[]   = {B_SMMU_03, B_SMMU_04, B_SMMU_05, B_SMMU_13,
+                                     B_SMMU_14, B_SMMU_23, RULE_ID_SENTINEL};
+
 /* PCBSA alias lists */
 /* P_L2WD_01 */
 RULE_ID_e p_l2wd_01_rule_list[]   = {B_WD_01, B_WD_02, B_WD_03, B_WD_04, B_WD_05,
@@ -4939,6 +4959,8 @@ const alias_rule_map_t alias_rule_map[] = {
     {LVQBC,     lvqbc_rule_list},
     {S_L8CXL_1, s_l8cxl_rule_list},
     {XDGKZ,     xdgkz_rule_list},
+    {S_L5SM_04, s_l5sm_04_rule_list},
+    {S_L6SM_04, s_l6sm_04_rule_list},
 
     /* PCBSA alias rules */
     {P_L1_01,   bsa_l1_rule_list},


### PR DESCRIPTION
- Introduce alias rules for S_L5SM_04, S_L6SM_04, and S_L6PE_08
- Update rule metadata with descriptions and platform support
- Remove redundant base-only entries for newly aliased rules
- Extend documentation checklist with detailed test coverage entries

Fixes #342
Fixes #343 
Fixes #258 

Signed-off-by: Shanmuga Priya L <[shanmuga.priyal@arm.com](mailto:shanmuga.priyal@arm.com)>
Change-Id: I9a6073f617b06be3f3957956cc272f1909ea43bb