### PR TITLE
refactor(pal): rename PAL print wrappers

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -62,8 +62,6 @@ void *pal_aligned_alloc( uint32_t alignment, uint32_t size );
 
 void *mem_alloc(size_t alignment, size_t size);
 void pal_warn_not_implemented(const char *api_name);
-#define print(verbose, string, ...) \
-    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
 
 #define PCIE_CREATE_BDF(Seg, Bus, Dev, Func) ((Seg << 24) | (Bus << 16) | (Dev << 8) | Func)
 

--- a/pal/baremetal/base/src/pal_cxl.c
+++ b/pal/baremetal/base/src/pal_cxl.c
@@ -30,14 +30,16 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
   uint32_t max_windows;
 
   if (CxlTable == NULL) {
-    print(ACS_PRINT_ERR, "Input CXL Table Pointer is NULL. Cannot create CXL INFO Table\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "Input CXL Table Pointer is NULL. Cannot create CXL INFO Table\n");
     return;
   }
 
   CxlTable->num_entries = 0;
 
   if (platform_cxl_cfg.num_entries == 0) {
-    print(ACS_PRINT_ERR, "Number of HB is 0. Cannot create CXL INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "Number of HB is 0. Cannot create CXL INFO\n");
     return;
   }
 
@@ -55,7 +57,8 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
     window_count = platform_cxl_cfg.device[i].cfmws_count;
     if (window_count > max_windows) {
       window_count = max_windows;
-      print(ACS_PRINT_WARN, "CFMWS count exceeds per-host capacity. Truncating\n");
+      pal_print_msg(ACS_PRINT_WARN,
+                    "CFMWS count exceeds per-host capacity. Truncating\n");
     }
     CxlTable->device[i].cfmws_count = window_count;
 
@@ -84,6 +87,8 @@ pal_cxl_get_host_bridge_uid(uint32_t bdf, uint32_t *uid)
   if (uid != NULL)
     *uid = 0;
   else
-    print(ACS_PRINT_ERR, " pal_cxl_get_host_bridge_uid UID pointer NULL ");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " %s UID pointer NULL ",
+                  __func__);
   return 1;
 }

--- a/pal/baremetal/base/src/pal_hmat.c
+++ b/pal/baremetal/base/src/pal_hmat.c
@@ -38,11 +38,18 @@ void pal_hmat_dump_info_table(HMAT_INFO_TABLE *HmatTable)
       return;
 
   curr_entry = HmatTable->bw_info;
-  print(ACS_PRINT_INFO, "\n*** HMAT info table entries ***\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n*** HMAT info table entries ***\n");
   for (i = 0 ; i < HmatTable->num_of_mem_prox_domain ; i++) {
-      print(ACS_PRINT_INFO, "\nMemory Proximity domain  :   0x%llx", curr_entry->mem_prox_domain);
-      print(ACS_PRINT_INFO, "\n  Write bandwidth        :   0x%llx", curr_entry->write_bw);
-      print(ACS_PRINT_INFO, "\n  Read  bandwidth        :   0x%llx\n", curr_entry->read_bw);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMemory Proximity domain  :   0x%llx",
+                    curr_entry->mem_prox_domain);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  Write bandwidth        :   0x%llx",
+                    curr_entry->write_bw);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  Read  bandwidth        :   0x%llx\n",
+                    curr_entry->read_bw);
       curr_entry++;
   }
 }
@@ -64,7 +71,8 @@ void pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
   HMAT_BW_ENTRY *curr_info_entry;
 
   if (HmatTable == NULL) {
-      print(ACS_PRINT_ERR, " Unable to create HMAT info table, input pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Unable to create HMAT info table, input pointer is NULL\n");
       return;
   }
 

--- a/pal/baremetal/base/src/pal_iovirt.c
+++ b/pal/baremetal/base/src/pal_iovirt.c
@@ -63,8 +63,9 @@ pal_iovirt_get_rc_smmu_base (
   }
 
   if (!mapping_found) {
-      print(ACS_PRINT_ERR,
-               "\n       RID to Stream ID/Dev ID map not found ", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n       RID to Stream ID/Dev ID map not found ",
+                    0);
       return 0xFFFFFFFF;
 
 }
@@ -79,8 +80,9 @@ pal_iovirt_get_rc_smmu_base (
           if(sid >= (*map).map.input_base && sid <= ((*map).map.input_base +
                                                     (*map).map.id_count))
           {
-              print(ACS_PRINT_DEBUG,
-                         "\n       find RC block->data.smmu.base : %llx", block->data.smmu.base);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "\n       find RC block->data.smmu.base : %llx",
+                            block->data.smmu.base);
               return block->data.smmu.base;
           }
       }
@@ -89,8 +91,9 @@ pal_iovirt_get_rc_smmu_base (
   /* The Root Complex represented by rc_seg_num
    * is not behind any SMMU. Return NULL pointer
    */
-  print(ACS_PRINT_DEBUG,
-             " No SMMU found behind the RootComplex with segment :%x", RcSegmentNum);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " No SMMU found behind the RootComplex with segment :%x",
+                RcSegmentNum);
   return 0;
 }
 
@@ -124,39 +127,55 @@ dump_block(IOVIRT_BLOCK *block) {
   NODE_DATA_MAP *map = &(block->data_map[0]);
   switch(block->type) {
       case IOVIRT_NODE_ITS_GROUP:
-      print(ACS_PRINT_INFO, "\n ITS Group: Num ITS:%d\n", (*map).id[0]);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n ITS Group: Num ITS:%d\n",
+                    (*map).id[0]);
       for(i = 0; i < block->data.its_count; i++)
-          print(ACS_PRINT_INFO, "  ITS ID : %d\n", (*map).id[i]);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  ITS ID : %d\n",
+                        (*map).id[i]);
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
-      print(ACS_PRINT_INFO,
-                 " Named Component:\n Device Name:%s", block->data.named_comp.name);
-      print(ACS_PRINT_INFO, "\n CCA Attribute: 0x%lx\n", block->data.named_comp.cca);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " Named Component:\n Device Name:%s",
+                    block->data.named_comp.name);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n CCA Attribute: 0x%lx\n",
+                    block->data.named_comp.cca);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
-      print(ACS_PRINT_INFO,
-                 " Root Complex: PCI segment number:%d\n", block->data.rc.segment);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " Root Complex: PCI segment number:%d\n",
+                    block->data.rc.segment);
       break;
       case IOVIRT_NODE_SMMU:
       case IOVIRT_NODE_SMMU_V3:
-      print(ACS_PRINT_INFO, " SMMU: Major Rev:%d Base Address:0x%llx\n",
-                 block->data.smmu.arch_major_rev, block->data.smmu.base);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " SMMU: Major Rev:%d Base Address:0x%llx\n",
+                    block->data.smmu.arch_major_rev,
+                    block->data.smmu.base);
       break;
       case IOVIRT_NODE_PMCG:
-      print(ACS_PRINT_INFO,
-                 " PMCG: Base:0x%x\n Overflow GSIV:0x%x Node Reference:0x%x\n",
-                 block->data.pmcg.base, block->data.pmcg.overflow_gsiv, block->data.pmcg.node_ref);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " PMCG: Base:0x%x\n Overflow GSIV:0x%x Node Reference:0x%x\n",
+                    block->data.pmcg.base,
+                    block->data.pmcg.overflow_gsiv,
+                    block->data.pmcg.node_ref);
       break;
   }
-  print(ACS_PRINT_INFO,
-             " Number of ID Mappings:%d\n", block->num_data_map);
+  pal_print_msg(ACS_PRINT_INFO,
+                " Number of ID Mappings:%d\n",
+                block->num_data_map);
   for(i = 0; i < block->num_data_map; i++, map++) {
-      print(ACS_PRINT_INFO,
-                 "  input_base:0x%x id_count:0x%x\n  output_base:0x%x output ref:0x%x\n",
-            (*map).map.input_base, (*map).map.id_count,
-            (*map).map.output_base, (*map).map.output_ref);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  input_base:0x%x id_count:0x%x\n  output_base:0x%x output ref:0x%x\n",
+                    (*map).map.input_base,
+                    (*map).map.id_count,
+                    (*map).map.output_base,
+                    (*map).map.output_ref);
   }
-  print(ACS_PRINT_INFO, "\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n");
 }
 
 void
@@ -248,7 +267,8 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
              p++;
              break;
           default:
-             print(ACS_PRINT_ERR, "Invalid IORT node type\n");
+             pal_print_msg(ACS_PRINT_ERR,
+                           "Invalid IORT node type\n");
              return;
      }
      node[i] = (uint8_t*)(block) - (uint8_t*)IoVirtTable;
@@ -288,7 +308,9 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   }
 
   block = &(IoVirtTable->blocks[0]);
-  print(ACS_PRINT_DEBUG, " Number of IOVIRT blocks = %d\n", IoVirtTable->num_blocks);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " Number of IOVIRT blocks = %d\n",
+                IoVirtTable->num_blocks);
 
   if (acs_policy_get_print_level() <= ACS_PRINT_INFO) {
       for (i = 0; i < IoVirtTable->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))

--- a/pal/baremetal/base/src/pal_misc.c
+++ b/pal/baremetal/base/src/pal_misc.c
@@ -49,7 +49,11 @@ pal_mmio_read8(uint64_t addr)
 
   data = (*(volatile uint8_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_read8 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -69,7 +73,11 @@ pal_mmio_read16(uint64_t addr)
 
   data = (*(volatile uint16_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_read16 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -89,7 +97,11 @@ pal_mmio_read64(uint64_t addr)
 
   data = (*(volatile uint64_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_read64 Address = %llx  Data = %llx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %llx  Data = %llx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -110,7 +122,11 @@ pal_mmio_read(uint64_t addr)
 
   data = (*(volatile uint32_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_read Address = %8x  Data = %x\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %8x  Data = %x\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 
@@ -129,7 +145,11 @@ void
 pal_mmio_write8(uint64_t addr, uint8_t data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile uint8_t *)addr = data;
 }
@@ -147,7 +167,11 @@ void
 pal_mmio_write16(uint64_t addr, uint16_t data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile uint16_t *)addr = data;
 }
@@ -165,7 +189,11 @@ void
 pal_mmio_write64(uint64_t addr, uint64_t data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %llx  Data = %llx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile uint64_t *)addr = data;
 }
@@ -184,7 +212,11 @@ pal_mmio_write(uint64_t addr, uint32_t data)
 {
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      print(ACS_PRINT_INFO, " pal_mmio_write Address = %8x  Data = %x\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %s Address = %8x  Data = %x\n",
+                    __func__,
+                    addr,
+                    data);
 
     *(volatile uint32_t *)addr = data;
 }
@@ -242,11 +274,13 @@ pal_warn_not_implemented(const char *api_name)
     if (api_name == NULL)
         return;
 
-    print(ACS_PRINT_WARN,
-          "\n       %s is not implemented."
-          "\n       Please implement the PAL function in test suite or"
-          "\n       conduct an offline review for this rule.",
-          api_name);
+    pal_print_msg(ACS_PRINT_WARN,
+                  "\n       %s is not implemented.",
+                  api_name);
+    pal_print_msg(ACS_PRINT_WARN,
+                  "\n       Please implement the PAL function in test suite or");
+    pal_print_msg(ACS_PRINT_WARN,
+                  "\n       conduct an offline review for this rule.");
 }
 
 /**
@@ -644,7 +678,9 @@ void pal_uart_print(int log, const char *fmt, ...)
 void
 pal_dump_dtb()
 {
-  print(ACS_PRINT_ERR, " DTB dump not available for platform initialized with ACPI table\n", 0);
+  pal_print_msg(ACS_PRINT_ERR,
+                " DTB dump not available for platform initialized with ACPI table\n",
+                0);
 }
 
 /**

--- a/pal/baremetal/base/src/pal_mpam.c
+++ b/pal/baremetal/base/src/pal_mpam.c
@@ -44,22 +44,32 @@ pal_mpam_dump_table(MPAM_INFO_TABLE *MpamTable)
   curr_entry = &(MpamTable->msc_node[0]);
 
   for (i = 0; i < MpamTable->msc_count; i++) {
-      print(ACS_PRINT_INFO, "\nMSC node Index      :%d ", i);
-      print(ACS_PRINT_INFO, "\nMSC base addr       :%llx ",
-                                        curr_entry->msc_base_addr);
-      print(ACS_PRINT_INFO, "\nMSC resource count  :%lx ",
-                                        curr_entry->rsrc_count);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC node Index      :%d ",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC base addr       :%llx ",
+                    curr_entry->msc_base_addr);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC resource count  :%lx ",
+                    curr_entry->rsrc_count);
 
       for (j = 0; j < curr_entry->rsrc_count; j++) {
-          print(ACS_PRINT_INFO, "\nRESOURCE index  :%d ", j);
-          print(ACS_PRINT_INFO, "\nRIS index       :%d ",
-                               curr_entry->rsrc_node[j].ris_index);
-          print(ACS_PRINT_INFO, "\nlocator type    :%08X ",
-                            curr_entry->rsrc_node[j].locator_type);
-          print(ACS_PRINT_INFO, "\ndescriptor1     :%llx ",
-                             curr_entry->rsrc_node[j].descriptor1);
-          print(ACS_PRINT_INFO, "\ndescriptor2     :%llx ",
-                             curr_entry->rsrc_node[j].descriptor2);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nRESOURCE index  :%d ",
+                        j);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nRIS index       :%d ",
+                        curr_entry->rsrc_node[j].ris_index);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nlocator type    :%08X ",
+                        curr_entry->rsrc_node[j].locator_type);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\ndescriptor1     :%llx ",
+                        curr_entry->rsrc_node[j].descriptor1);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\ndescriptor2     :%llx ",
+                        curr_entry->rsrc_node[j].descriptor2);
       }
       curr_entry = MPAM_NEXT_MSC(curr_entry);
   }
@@ -85,18 +95,23 @@ pal_srat_dump_table(SRAT_INFO_TABLE *SratTable)
   for (i = 0; i < SratTable->num_of_srat_entries; i++) {
       curr_entry = &(SratTable->srat_info[i]);
       if (curr_entry->node_type == SRAT_NODE_MEM_AFF) {
-          print(ACS_PRINT_INFO, "\n       SRAT mem prox domain :%x ",
-                                              curr_entry->node_data.mem_aff.prox_domain);
-          print(ACS_PRINT_INFO, "\n       SRAT mem addr_base :%llx ",
-                                                curr_entry->node_data.mem_aff.addr_base);
-          print(ACS_PRINT_INFO, "\n       SRAT mem addr_len :%llx ",
-                                                      curr_entry->node_data.mem_aff.addr_len);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT mem prox domain :%x ",
+                        curr_entry->node_data.mem_aff.prox_domain);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT mem addr_base :%llx ",
+                        curr_entry->node_data.mem_aff.addr_base);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT mem addr_len :%llx ",
+                        curr_entry->node_data.mem_aff.addr_len);
       }
       else if (curr_entry->node_type == SRAT_NODE_GICC_AFF) {
-          print(ACS_PRINT_INFO, "\n       SRAT Gicc prox domain :%x ",
-                                              curr_entry->node_data.gicc_aff.prox_domain);
-          print(ACS_PRINT_INFO, "\n       SRAT Gicc processor uid :%x ",
-                                                   curr_entry->node_data.gicc_aff.proc_uid);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT Gicc prox domain :%x ",
+                        curr_entry->node_data.gicc_aff.prox_domain);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT Gicc processor uid :%x ",
+                        curr_entry->node_data.gicc_aff.proc_uid);
       }
   }
 }
@@ -118,7 +133,8 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
   MPAM_MSC_NODE *curr_entry;
 
   if (MpamTable == NULL) {
-      print(ACS_PRINT_ERR, " Input MPAM Table Pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Input MPAM Table Pointer is NULL\n");
       return;
   }
 
@@ -179,7 +195,8 @@ uint32_t
 pal_mpam_parse_dsdt_info(MPAM_INFO_TABLE *MpamTable)
 {
   if (MpamTable == NULL) {
-      print(ACS_PRINT_ERR, " Input MPAM Table Pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Input MPAM Table Pointer is NULL\n");
       return 0;
   }
   return 0;
@@ -199,7 +216,8 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
   uint32_t Index, mem_index = 0, gicc_index = 0;
 
   if (SratTable == NULL) {
-      print(ACS_PRINT_ERR, " Input SRAT Table Pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Input SRAT Table Pointer is NULL\n");
       return;
   }
 

--- a/pal/baremetal/base/src/pal_pcc.c
+++ b/pal/baremetal/base/src/pal_pcc.c
@@ -35,43 +35,59 @@ pal_pcc_dump_info_table(PCC_INFO_TABLE *PccInfoTable)
   uint32_t i;
 
   if (PccInfoTable == NULL) {
-      print(ACS_PRINT_ERR, "\nUnable to dump PCC info table, input pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\nUnable to dump PCC info table, input pointer is NULL\n");
       return;
   }
 
-  print(ACS_PRINT_INFO, "\n*** PCC Information ***");
-  print(ACS_PRINT_INFO, "\nNumber of PCC subspace entries : %d", PccInfoTable->subspace_cnt);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n*** PCC Information ***");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nNumber of PCC subspace entries : %d",
+                PccInfoTable->subspace_cnt);
 
   curr_entry = PccInfoTable->pcc_info;
 
   for (i = 0; i < PccInfoTable->subspace_cnt; i++) {
-      print(ACS_PRINT_INFO, "\n PCC subspace index                : 0x%x",
-                  curr_entry->subspace_idx);
-      print(ACS_PRINT_INFO, "\n PCC subspace type                 : 0x%x",
-                  curr_entry->subspace_type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n PCC subspace index                : 0x%x",
+                    curr_entry->subspace_idx);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n PCC subspace type                 : 0x%x",
+                    curr_entry->subspace_type);
 
       if (curr_entry->subspace_type == PCCT_SUBSPACE_TYPE_3_EXTENDED_PCC) {
           ptr_pcc_ss_type_3 = &(curr_entry->type_spec_info.pcc_ss_type_3);
-          print(ACS_PRINT_INFO, "\n Base address                      : 0x%lx",
-                      ptr_pcc_ss_type_3->base_addr);
-          print(ACS_PRINT_INFO, "\n Doorbell Register addr            : 0x%lx",
-                      ptr_pcc_ss_type_3->doorbell_reg.addr);
-          print(ACS_PRINT_INFO, "\n Doorbell preserve Mask            : 0x%lx",
-                      ptr_pcc_ss_type_3->doorbell_preserve);
-          print(ACS_PRINT_INFO, "\n Doorbell write Mask               : 0x%lx",
-                      ptr_pcc_ss_type_3->doorbell_write);
-          print(ACS_PRINT_INFO, "\n Min req turnaround time (us)      : 0x%x",
-                      ptr_pcc_ss_type_3->min_req_turnaround_usec);
-          print(ACS_PRINT_INFO, "\n Command complete check reg addr   : 0x%lx",
-                      ptr_pcc_ss_type_3->cmd_complete_chk_reg.addr);
-          print(ACS_PRINT_INFO, "\n Command complete check mask       : 0x%lx",
-                      ptr_pcc_ss_type_3->cmd_complete_chk_mask);
-          print(ACS_PRINT_INFO, "\n Command complete update reg addr  : 0x%lx",
-                      ptr_pcc_ss_type_3->cmd_complete_update_reg.addr);
-          print(ACS_PRINT_INFO, "\n Command complete update preserve  : 0x%lx",
-                      ptr_pcc_ss_type_3->cmd_complete_update_preserve);
-          print(ACS_PRINT_INFO, "\n Command complete update set mask  : 0x%lx",
-                      ptr_pcc_ss_type_3->cmd_complete_update_set);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Base address                      : 0x%lx",
+                        ptr_pcc_ss_type_3->base_addr);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Doorbell Register addr            : 0x%lx",
+                        ptr_pcc_ss_type_3->doorbell_reg.addr);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Doorbell preserve Mask            : 0x%lx",
+                        ptr_pcc_ss_type_3->doorbell_preserve);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Doorbell write Mask               : 0x%lx",
+                        ptr_pcc_ss_type_3->doorbell_write);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Min req turnaround time (us)      : 0x%x",
+                        ptr_pcc_ss_type_3->min_req_turnaround_usec);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Command complete check reg addr   : 0x%lx",
+                        ptr_pcc_ss_type_3->cmd_complete_chk_reg.addr);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Command complete check mask       : 0x%lx",
+                        ptr_pcc_ss_type_3->cmd_complete_chk_mask);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Command complete update reg addr  : 0x%lx",
+                        ptr_pcc_ss_type_3->cmd_complete_update_reg.addr);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Command complete update preserve  : 0x%lx",
+                        ptr_pcc_ss_type_3->cmd_complete_update_preserve);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n Command complete update set mask  : 0x%lx",
+                        ptr_pcc_ss_type_3->cmd_complete_update_set);
       }
   }
 }
@@ -89,7 +105,8 @@ pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
   uint32_t i;
 
   if (PccInfoTable == NULL) {
-    print(ACS_PRINT_ERR, " Unable to create PCC info table, input pointer is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Unable to create PCC info table, input pointer is NULL\n");
     return;
   }
 

--- a/pal/baremetal/base/src/pal_pcie.c
+++ b/pal/baremetal/base/src/pal_pcie.c
@@ -41,14 +41,16 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   uint32_t i = 0;
 
   if (PcieTable == NULL) {
-    print(ACS_PRINT_ERR, "Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
     return;
   }
 
   PcieTable->num_entries = 0;
 
   if(platform_pcie_cfg.num_entries == 0) {
-    print(ACS_PRINT_ERR, "Number of ECAM is 0. Cannot create PCIe INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "Number of ECAM is 0. Cannot create PCIe INFO\n");
     return;
   }
 
@@ -166,7 +168,8 @@ pal_pcie_io_read_cfg(uint32_t Bdf, uint32_t offset, uint32_t *data)
          }
   }
 
-  print(ACS_PRINT_ERR, "No PCI devices found in the system\n");
+  pal_print_msg(ACS_PRINT_ERR,
+                "No PCI devices found in the system\n");
   return PCIE_NO_MAPPING;
 }
 
@@ -500,7 +503,8 @@ pal_pcie_get_legacy_irq_map(uint32_t Seg, uint32_t Bus, uint32_t Dev, uint32_t F
         }
   }
 
-  print(ACS_PRINT_ERR, "No PCI devices found in the system\n");
+  pal_print_msg(ACS_PRINT_ERR,
+                "No PCI devices found in the system\n");
   return PCIE_NO_MAPPING;
 }
 
@@ -596,8 +600,11 @@ uint32_t pal_pcie_check_device_list(void)
     bdf_tbl_ptr = g_pcie_bdf_table;
 
     if (platform_pcie_device_hierarchy.num_entries != bdf_tbl_ptr->num_entries) {
-      print(ACS_PRINT_ERR, "  Number of PCIe devices entries in \
-              info table not equal to platform hierarchy\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Number of PCIe devices entries in ");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "info table not equal to platform hierarchy\n",
+                    0);
       return 1;
     }
 
@@ -626,18 +633,24 @@ uint32_t pal_pcie_check_device_list(void)
              pal_pcie_read_cfg(Seg, Bus, Dev, Func, TYPE0_HEADER, &data);
              vendor_id = data & 0xFFFF;
              if (vendor_id != pltf_vendor_id) {
-                print(ACS_PRINT_ERR, " VendorID mismatch for PCIe device with bdf = 0x%x\n", bdf);
+                pal_print_msg(ACS_PRINT_ERR,
+                              " VendorID mismatch for PCIe device with bdf = 0x%x\n",
+                              bdf);
                 return 1;
              }
              device_id = data >> DEVICE_ID_OFFSET;
              if (device_id != pltf_device_id) {
-                print(ACS_PRINT_ERR, " DeviceID mismatch for PCIe device with bdf = 0x%x\n", bdf);
+                pal_print_msg(ACS_PRINT_ERR,
+                              " DeviceID mismatch for PCIe device with bdf = 0x%x\n",
+                              bdf);
                 return 1;
              }
              pal_pcie_read_cfg(Seg, Bus, Dev, Func, TYPE01_RIDR, &class_code);
              class_code = class_code >> CC_SHIFT;
              if (class_code != pltf_class_code) {
-                print(ACS_PRINT_ERR, "ClassCode mismatch for PCIe device with bdf = 0x%x\n", bdf);
+                pal_print_msg(ACS_PRINT_ERR,
+                              "ClassCode mismatch for PCIe device with bdf = 0x%x\n",
+                              bdf);
                 return 1;
              }
 
@@ -649,7 +662,9 @@ uint32_t pal_pcie_check_device_list(void)
 
       /* If any bdf match not found in platform device hierarchy and info table, return false */
       if (i == bdf_tbl_ptr->num_entries) {
-          print(ACS_PRINT_ERR, " Bdf not found in info table = 0x%x\n", pltf_pcie_device_bdf);
+          pal_print_msg(ACS_PRINT_ERR,
+                        " Bdf not found in info table = 0x%x\n",
+                        pltf_pcie_device_bdf);
           return 1;
       }
     }

--- a/pal/baremetal/base/src/pal_pcie_enumeration.c
+++ b/pal/baremetal/base/src/pal_pcie_enumeration.c
@@ -179,7 +179,9 @@ pal_pcie_rp_program_bar(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t func)
       pal_pci_cfg_read(seg, bus, dev, func, offset, &bar_reg_value);
       if (BAR_REG(bar_reg_value) == BAR_64_BIT)
       {
-          print(ACS_PRINT_INFO, "The RP BAR supports P_MEM 64-bit addr decoding capability\n", 0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "The RP BAR supports P_MEM 64-bit addr decoding capability\n",
+                        0);
 
           /** BAR supports 64-bit address therefore, write all 1's
             *  to BARn and BARn+1 and identify the size requested
@@ -209,7 +211,9 @@ pal_pcie_rp_program_bar(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t func)
 
       else
       {
-          print(ACS_PRINT_INFO, "The RP BAR supports P_MEM 32-bit addr decoding capability\n", 0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "The RP BAR supports P_MEM 32-bit addr decoding capability\n",
+                        0);
 
           /**BAR supports 32-bit address. Write all 1's
            * to BARn and identify the size requested
@@ -226,7 +230,9 @@ pal_pcie_rp_program_bar(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t func)
               continue;
           }
           pal_pci_cfg_write(seg, bus, dev, func, offset, g_rp_bar32_value);
-          print(ACS_PRINT_INFO, "Value written to BAR register is %x\n", g_rp_bar32_value);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "Value written to BAR register is %x\n",
+                        g_rp_bar32_value);
           g_rp_bar32_value = g_rp_bar32_value + bar_size;
           offset = offset + 4;
       }
@@ -258,7 +264,9 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
     {
         if (BAR_REG(bar_reg_value) == BAR_64_BIT)
         {
-            print(ACS_PRINT_INFO, "The BAR supports P_MEM 64-bit addr decoding capability\n", 0);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "The BAR supports P_MEM 64-bit addr decoding capability\n",
+                          0);
 
             /** BAR supports 64-bit address therefore, write all 1's
               *  to BARn and BARn+1 and identify the size requested
@@ -302,7 +310,9 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
             pal_pci_cfg_write(seg, bus, dev, func, offset, g_bar64_p_start);
             pal_pci_cfg_write(seg, bus, dev, func, offset + 4, g_bar64_p_start >> 32);
 
-            print(ACS_PRINT_INFO, "Value written to BAR register is %llx\n", g_bar64_p_start);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "Value written to BAR register is %llx\n",
+                          g_bar64_p_start);
             p_bar64_size = bar_size;
             g_bar64_size = bar_size;
             g_64_bus = bus;
@@ -312,7 +322,9 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
 
         else
         {
-            print(ACS_PRINT_INFO, "The BAR supports P_MEM 32-bit addr decoding capability\n", 0);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "The BAR supports P_MEM 32-bit addr decoding capability\n",
+                          0);
 
             /**BAR supports 32-bit address. Write all 1's
              * to BARn and identify the size requested
@@ -349,7 +361,9 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
                 g_bar32_p_start = g_bar32_p_start + p_bar_size;
 
             pal_pci_cfg_write(seg, bus, dev, func, offset, g_bar32_p_start);
-            print(ACS_PRINT_INFO, "Value written to BAR register is %x\n", g_bar32_p_start);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "Value written to BAR register is %x\n",
+                          g_bar32_p_start);
             p_bar_size = bar_size;
             g_p_bar_size = bar_size;
             g_p_bus = bus;
@@ -360,7 +374,9 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
 
     else
     {
-         print(ACS_PRINT_INFO, "The BAR supports NP_MEM 32-bit addr decoding capability\n", 0);
+         pal_print_msg(ACS_PRINT_INFO,
+                       "The BAR supports NP_MEM 32-bit addr decoding capability\n",
+                       0);
 
          /**BAR supports 32-bit address. Write all 1's
           * to BARn and identify the size requested
@@ -399,7 +415,9 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
              g_bar32_np_start = g_bar32_np_start + np_bar_size;
 
          pal_pci_cfg_write(seg, bus, dev, func, offset, g_bar32_np_start);
-         print(ACS_PRINT_INFO, "Value written to BAR register is %x\n", g_bar32_np_start);
+         pal_print_msg(ACS_PRINT_INFO,
+                       "Value written to BAR register is %x\n",
+                       g_bar32_np_start);
          np_bar_size = bar_size;
          g_np_bar_size = bar_size;
          g_np_bus = bus;
@@ -461,12 +479,20 @@ uint32_t pal_pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
              (((class_code >> CC_SUB_SHIFT) & CC_SUB_MASK)) == HB_SUB_CLASS)
                 continue;
 
-        print(ACS_PRINT_INFO, "The Vendor id read is %x\n", vendor_id);
-        print(ACS_PRINT_INFO, "Valid PCIe device found at %x %x %x\n ", bus, dev, func);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "The Vendor id read is %x\n",
+                      vendor_id);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "Valid PCIe device found at %x %x %x\n ",
+                      bus,
+                      dev,
+                      func);
         pal_pci_cfg_read(seg, bus, dev, func, HEADER_OFFSET, &header_value);
         if (PCIE_HEADER_TYPE(header_value) == TYPE1_HEADER)
         {
-            print(ACS_PRINT_INFO, "TYPE1 HEADER found\n", 0);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "TYPE1 HEADER found\n",
+                          0);
 
             /* Enable memory access, Bus master enable and I/O access*/
             pal_pci_cfg_read(seg, bus, dev, func, COMMAND_REG_OFFSET, &com_reg_value);
@@ -507,7 +533,9 @@ uint32_t pal_pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
 
         if (PCIE_HEADER_TYPE(header_value) == TYPE0_HEADER)
         {
-            print(ACS_PRINT_INFO, "END POINT found\n", 0);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "END POINT found\n",
+                          0);
             pal_pcie_program_bar_reg(seg, bus, dev, func);
             sub_bus = sec_bus - 1;
         }
@@ -577,11 +605,15 @@ void pal_pcie_enumerate(void)
 
     if (g_pcie_info_table->num_entries == 0)
     {
-         print(ACS_PRINT_TEST, "\nSkipping Enumeration", 0);
+         pal_print_msg(ACS_PRINT_TEST,
+                       "\nSkipping Enumeration",
+                       0);
          return;
     }
 
-    print(ACS_PRINT_INFO, "\nStarting Enumeration\n", 0);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nStarting Enumeration\n",
+                  0);
     while (pcie_index < g_pcie_info_table->num_entries)
     {
        hb_count = platform_root_pcie_cfg.block[pcie_index].hb_entries;
@@ -710,7 +742,9 @@ pal_pcie_get_base(uint32_t bdf, uint32_t bar_index)
      bar_value = bar_value | (bar_upper_bits << 32 );
   }
 
-  print(ACS_PRINT_INFO, "value read from BAR 0x%llx\n", bar_value);
+  pal_print_msg(ACS_PRINT_INFO,
+                "value read from BAR 0x%llx\n",
+                bar_value);
 
   return bar_value;
 

--- a/pal/baremetal/base/src/pal_pe.c
+++ b/pal/baremetal/base/src/pal_pe.c
@@ -99,7 +99,9 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
   SmbiosTable->slot_count = platform_smbios_cfg.slot_count;
   if (SmbiosTable->slot_count == 0) {
-    print(ACS_PRINT_ERR, "SMBIOS Table Not Found\n", 0);
+    pal_print_msg(ACS_PRINT_ERR,
+                  "SMBIOS Table Not Found\n",
+                  0);
     return;
   }
 
@@ -137,7 +139,9 @@ PalAllocateSecondaryStack(uint64_t mpidr)
   {
       gSecondaryPeStack = pal_aligned_alloc(MEM_ALIGN_4K, NumPe * SIZE_STACK_SECONDARY_PE);
       if (gSecondaryPeStack == NULL){
-          print(ACS_PRINT_ERR, "FATAL - Allocation for Secondary stack failed\n", 0);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "FATAL - Allocation for Secondary stack failed\n",
+                        0);
       }
       pal_pe_data_cache_ops_by_va((uint64_t)&gSecondaryPeStack, CLEAN_AND_INVALIDATE);
   }
@@ -177,12 +181,24 @@ PalCaptureMmuConfig(void)
     gMmuConfig.sctlr = read_sctlr_el1();
   }
 
-  print(ACS_PRINT_INFO,  "  MMU Config captured at EL%d\n", gMmuConfig.current_el);
-  print(ACS_PRINT_DEBUG, "    TTBR0: 0x%lx\n", gMmuConfig.ttbr0);
-  print(ACS_PRINT_DEBUG, "    TTBR1: 0x%lx\n", gMmuConfig.ttbr1);
-  print(ACS_PRINT_DEBUG, "    TCR:   0x%lx\n", gMmuConfig.tcr);
-  print(ACS_PRINT_DEBUG, "    MAIR:  0x%lx\n", gMmuConfig.mair);
-  print(ACS_PRINT_DEBUG, "    SCTLR: 0x%lx\n", gMmuConfig.sctlr);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  MMU Config captured at EL%d\n",
+                gMmuConfig.current_el);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TTBR0: 0x%lx\n",
+                gMmuConfig.ttbr0);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TTBR1: 0x%lx\n",
+                gMmuConfig.ttbr1);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TCR:   0x%lx\n",
+                gMmuConfig.tcr);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    MAIR:  0x%lx\n",
+                gMmuConfig.mair);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    SCTLR: 0x%lx\n",
+                gMmuConfig.sctlr);
 
   /* Clean cache to ensure secondary PEs see the config */
   pal_pe_data_cache_ops_by_va((uint64_t)&gMmuConfig, CLEAN_AND_INVALIDATE);

--- a/pal/baremetal/base/src/pal_peripherals.c
+++ b/pal/baremetal/base/src/pal_peripherals.c
@@ -55,7 +55,8 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   PERIPHERAL_INFO_BLOCK *per_info = NULL;
 
   if (peripheralInfoTable == NULL) {
-    print(ACS_PRINT_ERR, "Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
     return;
   }
 
@@ -74,7 +75,8 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   /* check for any USB Controllers */
   do {
 
-       print(ACS_PRINT_INFO, "Entered USB loop\n");
+       pal_print_msg(ACS_PRINT_INFO,
+                     "Entered USB loop\n");
        DeviceBdf = pal_pcie_get_bdf(USB_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_USB;
@@ -87,7 +89,9 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->bdf   = DeviceBdf;
           per_info->platform_type = 0;
 
-          print(ACS_PRINT_INFO, "Found a USB controller %4x\n", per_info->base0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "Found a USB controller %4x\n",
+                        per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -101,7 +105,8 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   /* check for any SATA Controllers */
   do {
 
-       print(ACS_PRINT_INFO, "Entered SATA loop\n");
+       pal_print_msg(ACS_PRINT_INFO,
+                     "Entered SATA loop\n");
        DeviceBdf = pal_pcie_get_bdf(SATA_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_SATA;
@@ -115,7 +120,9 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->platform_type = 0;
           per_info->bdf   = DeviceBdf;
 
-          print(ACS_PRINT_INFO, "Found a SATA controller %4x\n", per_info->base0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "Found a SATA controller %4x\n",
+                        per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -183,7 +190,9 @@ uint32_t pal_peripheral_is_pcie(uint32_t seg, uint32_t bus, uint32_t dev, uint32
      pal_pcie_read_cfg(seg, bus, dev, fn, next_cap_offset, &reg_value);
      if ((reg_value & PCIE_CIDR_MASK) == CID_PCIECS)
      {
-         print(ACS_PRINT_INFO, "PCIe Capable", 0);
+         pal_print_msg(ACS_PRINT_INFO,
+                       "PCIe Capable",
+                       0);
          return 1;
      }
      next_cap_offset = ((reg_value >> PCIE_NCPR_SHIFT) & PCIE_NCPR_MASK);
@@ -206,7 +215,9 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
     uint32_t index = 0;
 
     if (memoryInfoTable == NULL) {
-        print(ACS_PRINT_ERR, "\nInput Memory Table Pointer is NULL", 0);
+        pal_print_msg(ACS_PRINT_ERR,
+                      "\nInput Memory Table Pointer is NULL",
+                      0);
         return;
     }
 
@@ -246,7 +257,9 @@ pal_memory_get_unpopulated_addr(uint64_t *addr, uint32_t instance)
           if (memory_instance == instance)
           {
               *addr =  platform_mem_cfg.info[index].virt_addr;
-              print(ACS_PRINT_INFO, "Unpopulated region with base address 0x%lX found\n", *addr);
+              pal_print_msg(ACS_PRINT_INFO,
+                            "Unpopulated region with base address 0x%lX found\n",
+                            *addr);
               return MEM_MAP_SUCCESS;
           }
 

--- a/pal/baremetal/base/src/pal_pmu.c
+++ b/pal/baremetal/base/src/pal_pmu.c
@@ -38,17 +38,28 @@ pal_pmu_dump_info_table(PMU_INFO_TABLE *PmuTable)
   }
 
   for (i = 0; i < PmuTable->pmu_count; i++) {
-      print(ACS_PRINT_INFO, "\nPMU info Index      :%d ", i);
-      print(ACS_PRINT_INFO, "\nPMU node type       :%02X ", PmuTable->info[i].type);
-      print(ACS_PRINT_INFO, "\nDual page extension :%d ",
-                 PmuTable->info[i].dual_page_extension);
-      print(ACS_PRINT_INFO, "\nBase Address 0      :%llX ", PmuTable->info[i].base0);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nPMU info Index      :%d ",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nPMU node type       :%02X ",
+                    PmuTable->info[i].type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nDual page extension :%d ",
+                    PmuTable->info[i].dual_page_extension);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nBase Address 0      :%llX ",
+                    PmuTable->info[i].base0);
       if(PmuTable->info[i].dual_page_extension)
-          print(ACS_PRINT_INFO, "\nBase Address 1      :%llX ", PmuTable->info[i].base1);
-      print(ACS_PRINT_INFO, "\nPrimary Instance    :%llX ",
-                 PmuTable->info[i].primary_instance);
-      print(ACS_PRINT_INFO, "\nSecondary Instance  :%08X ",
-                 PmuTable->info[i].secondary_instance);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nBase Address 1      :%llX ",
+                        PmuTable->info[i].base1);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nPrimary Instance    :%llX ",
+                    PmuTable->info[i].primary_instance);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nSecondary Instance  :%08X ",
+                    PmuTable->info[i].secondary_instance);
 
   }
 }
@@ -69,7 +80,8 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
 
   /* Check if memory for PMU info table allocated */
   if (PmuTable == NULL) {
-      print(ACS_PRINT_ERR, "\n Input PMU Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input PMU Table Pointer is NULL");
       return;
   }
 
@@ -87,8 +99,9 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
 
       PmuTable->pmu_count++;
       if (PmuTable->pmu_count >= MAX_NUM_OF_PMU_SUPPORTED) {
-          print(ACS_PRINT_WARN, "\n Number of PMUs greater than %d",
-                MAX_NUM_OF_PMU_SUPPORTED);
+          pal_print_msg(ACS_PRINT_WARN,
+                        "\n Number of PMUs greater than %d",
+                        MAX_NUM_OF_PMU_SUPPORTED);
           break;
       }
 

--- a/pal/baremetal/base/src/pal_pptt.c
+++ b/pal/baremetal/base/src/pal_pptt.c
@@ -38,26 +38,47 @@ pal_cache_dump_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable)
 
   /*Iterate cache info table and print cache info entries*/
   for (i = 0 ; i < CacheTable->num_of_cache ; i++) {
-    print(ACS_PRINT_INFO, "\nCache info * Index %d *", i);
-    print(ACS_PRINT_INFO, "\n  Offset:                  0x%llx", curr_entry->my_offset);
-    print(ACS_PRINT_INFO, "\n  Type:                    0x%llx", curr_entry->cache_type);
-    print(ACS_PRINT_INFO, "\n  Cache ID:                0x%llx", curr_entry->cache_id);
-    print(ACS_PRINT_INFO, "\n  Size:                    0x%llx", curr_entry->size);
-    print(ACS_PRINT_INFO, "\n  Next level index:        %d", curr_entry->next_level_index);
-    print(ACS_PRINT_INFO, "\n  Private flag:            0x%llx\n", curr_entry->is_private);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nCache info * Index %d *",
+                  i);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Offset:                  0x%llx",
+                  curr_entry->my_offset);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Type:                    0x%llx",
+                  curr_entry->cache_type);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Cache ID:                0x%llx",
+                  curr_entry->cache_id);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Size:                    0x%llx",
+                  curr_entry->size);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Next level index:        %d",
+                  curr_entry->next_level_index);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Private flag:            0x%llx\n",
+                  curr_entry->is_private);
     curr_entry++;
   }
 
-  print(ACS_PRINT_INFO, "\nPE level one cache index info");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nPE level one cache index info");
   /*Iterate PE info table and print level one cache index info*/
   for (i = 0 ; i < PeTable->header.num_of_pe; i++) {
-    print(ACS_PRINT_INFO, "\nPE Index * %d *", i);
-    print(ACS_PRINT_INFO, "\n  Level 1 Cache index(s) :");
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nPE Index * %d *",
+                  i);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Level 1 Cache index(s) :");
 
     for (j = 0; j < MAX_L1_CACHE_RES && pe_entry->level_1_res[j] != DEFAULT_CACHE_IDX; j++) {
-      print(ACS_PRINT_INFO, " %d,", pe_entry->level_1_res[j]);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %d,",
+                    pe_entry->level_1_res[j]);
     }
-    print(ACS_PRINT_INFO, "\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n");
     pe_entry++;
   }
 }
@@ -110,7 +131,8 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
   uint32_t i;
 
   if (CacheTable == NULL) {
-    print(ACS_PRINT_ERR, " Unable to create cache info table, input pointer is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Unable to create cache info table, input pointer is NULL\n");
     return;
   }
 

--- a/pal/baremetal/base/src/pal_ras.c
+++ b/pal/baremetal/base/src/pal_ras.c
@@ -59,48 +59,78 @@ pal_ras_dump_info_table(RAS_INFO_TABLE *RasInfoTable)
       return;
   }
 
-  print(ACS_PRINT_INFO, "\nRAS Info :");
-  print(ACS_PRINT_INFO, "\nRAS Num Nodes : %d ", RasInfoTable->num_nodes);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nRAS Info :");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nRAS Num Nodes : %d ",
+                RasInfoTable->num_nodes);
 
   curr = &(RasInfoTable->node[0]);
 
   for (i = 0; i < RasInfoTable->num_nodes; i++) {
-      print(ACS_PRINT_INFO, "\n Index    : %d ", i);
-      print(ACS_PRINT_INFO, "\n Type     : 0x%x ", curr->type);
-      print(ACS_PRINT_INFO, "\n Num Intr : 0x%x ", curr->num_intr_entries);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Index    : %d ",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Type     : 0x%x ",
+                    curr->type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Num Intr : 0x%x ",
+                    curr->num_intr_entries);
 
       switch (curr->type) {
        case NODE_TYPE_PE:
            /* Print Processor Node Details */
-           print(ACS_PRINT_INFO, "\n ProcessorID : 0x%x ", curr->node_data.pe.processor_id);
-           print(ACS_PRINT_INFO, "\n resource_type : 0x%x ",
-                                      curr->node_data.pe.resource_type);
-           print(ACS_PRINT_INFO, "\n flags : 0x%x ", curr->node_data.pe.flags);
-           print(ACS_PRINT_INFO, "\n affinity : 0x%x ", curr->node_data.pe.affinity);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n ProcessorID : 0x%x ",
+                         curr->node_data.pe.processor_id);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n resource_type : 0x%x ",
+                         curr->node_data.pe.resource_type);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n flags : 0x%x ",
+                         curr->node_data.pe.flags);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n affinity : 0x%x ",
+                         curr->node_data.pe.affinity);
            break;
        case NODE_TYPE_MC:
            /* Print Memory Controller Node Details */
-           print(ACS_PRINT_INFO, "\n proximity_domain : 0x%x ",
-                                      curr->node_data.mc.proximity_domain);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n proximity_domain : 0x%x ",
+                         curr->node_data.mc.proximity_domain);
            break;
        default:
            break;
       }
 
-      print(ACS_PRINT_INFO, "\n Interface Info :");
-      print(ACS_PRINT_INFO, "\n  type    : 0x%x ", curr->intf_info.intf_type);
-      print(ACS_PRINT_INFO, "\n  base    : 0x%x ", curr->intf_info.base_addr);
-      print(ACS_PRINT_INFO, "\n  num_err : 0x%x ", curr->intf_info.num_err_rec);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Interface Info :");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  type    : 0x%x ",
+                    curr->intf_info.intf_type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  base    : 0x%x ",
+                    curr->intf_info.base_addr);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  num_err : 0x%x ",
+                    curr->intf_info.num_err_rec);
 
-      print(ACS_PRINT_INFO, "\n Interrupt Info :");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Interrupt Info :");
       for (j = 0; j < curr->num_intr_entries; j++) {
-        print(ACS_PRINT_INFO, "\n  type    : 0x%x ", curr->intr_info[j].type);
-        print(ACS_PRINT_INFO, "\n  gsiv    : 0x%x ", curr->intr_info[j].gsiv);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  type    : 0x%x ",
+                      curr->intr_info[j].type);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  gsiv    : 0x%x ",
+                      curr->intr_info[j].gsiv);
       }
 
       curr++;
   }
-  print(ACS_PRINT_INFO, "\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n");
 }
 
 void fill_node_specific_data (
@@ -195,7 +225,8 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
   uint32_t i;
 
   if (RasInfoTable == NULL) {
-      print(ACS_PRINT_ERR, "\n Input RAS Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -227,8 +258,9 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
       RasInfoTable->num_nodes++;
 
       if (RasInfoTable->num_nodes >= RAS_MAX_NUM_NODES) {
-          print(ACS_PRINT_WARN, "\n Number of RAS nodes greater than %d",
-                     RAS_MAX_NUM_NODES);
+          pal_print_msg(ACS_PRINT_WARN,
+                        "\n Number of RAS nodes greater than %d",
+                        RAS_MAX_NUM_NODES);
           break;
       }
 
@@ -253,37 +285,44 @@ pal_ras2_dump_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   RAS2_BLOCK *curr_block;
 
   if (RasFeatInfoTable == NULL) {
-      print(ACS_PRINT_ERR, "\n Input RAS Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input RAS Table Pointer is NULL");
       return;
   }
 
   curr_block = RasFeatInfoTable->blocks;
   uint32_t i;
 
-  print(ACS_PRINT_INFO, "\n RAS2 Feature Info :");
-  print(ACS_PRINT_INFO,
-             "\n Total number of RAS2 feature info blocks  : %d",
-             RasFeatInfoTable->num_all_block);
-  print(ACS_PRINT_INFO,
-             "\n Number of RAS2 memory feature info blocks : %d\n",
-             RasFeatInfoTable->num_of_mem_block);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n RAS2 Feature Info :");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n Total number of RAS2 feature info blocks  : %d",
+                RasFeatInfoTable->num_all_block);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n Number of RAS2 memory feature info blocks : %d\n",
+                RasFeatInfoTable->num_of_mem_block);
 
   /*Iterate RAS2 feature info table and print info fields */
   for (i = 0 ; i < RasFeatInfoTable->num_all_block ; i++) {
-    print(ACS_PRINT_INFO, "\n RAS2 feature info * Index %d *", i);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n RAS2 feature info * Index %d *",
+                  i);
     switch(curr_block->type) {
     case RAS2_TYPE_MEMORY:
-        print(ACS_PRINT_INFO, "\n  Type                            : 0x%x",
-                   curr_block->type);
-        print(ACS_PRINT_INFO, "\n  Proximity Domain                : 0x%llx",
-                   curr_block->block_info.mem_feat_info.proximity_domain);
-        print(ACS_PRINT_INFO, "\n  Patrol scrub support            : 0x%lx\n",
-                   curr_block->block_info.mem_feat_info.patrol_scrub_support);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Type                            : 0x%x",
+                      curr_block->type);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Proximity Domain                : 0x%llx",
+                      curr_block->block_info.mem_feat_info.proximity_domain);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Patrol scrub support            : 0x%lx\n",
+                      curr_block->block_info.mem_feat_info.patrol_scrub_support);
         break;
     default:
-        print(ACS_PRINT_INFO,
-             "\n  Invalid RAS feature type : 0x%x",
-                   curr_block->type);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Invalid RAS feature type : 0x%x",
+                      curr_block->type);
     }
     curr_block++;
   }
@@ -303,7 +342,8 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   uint32_t i;
 
   if (RasFeatInfoTable == NULL) {
-      print(ACS_PRINT_ERR, "\n Input RAS Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input RAS Table Pointer is NULL");
       return;
   }
 

--- a/pal/baremetal/base/src/pal_tpm2.c
+++ b/pal/baremetal/base/src/pal_tpm2.c
@@ -31,7 +31,8 @@ void
 pal_tpm2_create_info_table(TPM2_INFO_TABLE *Tpm2InfoTable)
 {
     if (Tpm2InfoTable == NULL) {
-        print(ACS_PRINT_ERR, "\nTPM2: Info table pointer is NULL");
+        pal_print_msg(ACS_PRINT_ERR,
+                      "\nTPM2: Info table pointer is NULL");
         return;
     }
 
@@ -40,7 +41,8 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE *Tpm2InfoTable)
     Tpm2InfoTable->base          = 0;
 
     if (platform_tpm2_cfg.tpm_present == 0) {
-        print(ACS_PRINT_INFO, "\nTPM2: Platform reports no TPM");
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\nTPM2: Platform reports no TPM");
         return;
     }
 
@@ -48,9 +50,14 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE *Tpm2InfoTable)
     Tpm2InfoTable->tpm_interface = platform_tpm2_cfg.tpm_interface_type;
     Tpm2InfoTable->base          = platform_tpm2_cfg.tpm_base;
 
-    print(ACS_PRINT_INFO, "\nTPM2: Present");
-    print(ACS_PRINT_INFO, "\nTPM2: Interface 0x%llx", Tpm2InfoTable->tpm_interface);
-    print(ACS_PRINT_INFO, "\nTPM2: Base 0x%llx", Tpm2InfoTable->base);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nTPM2: Present");
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nTPM2: Interface 0x%llx",
+                  Tpm2InfoTable->tpm_interface);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nTPM2: Base 0x%llx",
+                  Tpm2InfoTable->base);
 }
 
 /**

--- a/pal/baremetal/target/RDN2/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDN2/include/pal_exerciser.h
@@ -31,9 +31,6 @@
 void *mem_alloc(size_t alignment, size_t size);
 #endif
 
-#define print(verbose, string, ...) \
-    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
-
 #define PCIE_CREATE_BDF(Seg, Bus, Dev, Func) ((Seg << 24) | (Bus << 16) | (Dev << 8) | Func)
 #define PCIE_EXTRACT_BDF_SEG(bdf)  ((bdf >> 24) & 0xFF)
 #define PCIE_EXTRACT_BDF_BUS(bdf)  ((bdf >> 16) & 0xFF)

--- a/pal/baremetal/target/RDN2/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDN2/src/pal_exerciser.c
@@ -73,7 +73,9 @@ pal_exerciser_get_ecam(uint32_t bdf)
     }
     i++;
   }
-  print(ACS_PRINT_ERR, "\n No ECAM base ",0);
+  pal_print_msg(ACS_PRINT_ERR,
+                "\n No ECAM base ",
+                0);
   return 0;
 }
 
@@ -127,7 +129,9 @@ pal_exerciser_get_base(uint32_t bdf, uint32_t bar_index)
      bar_value = bar_value | (bar_upper_bits << 32 );
   }
 
-  print(ACS_PRINT_INFO, "value read from BAR 0x%llx\n", bar_value);
+  pal_print_msg(ACS_PRINT_INFO,
+                "value read from BAR 0x%llx\n",
+                bar_value);
 
   return bar_value;
 
@@ -184,7 +188,9 @@ uint32_t pal_exerciser_find_pcie_capability (uint32_t ID, uint32_t Bdf, uint32_t
     NxtPtr = (Data >> PtrOffset) & PtrMask;
   }
 
-  print(ACS_PRINT_ERR, "\n No capabilities found",0);
+  pal_print_msg(ACS_PRINT_ERR,
+                "\n No capabilities found",
+                0);
   return 1;
 }
 /**

--- a/pal/baremetal/target/RDV3/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3/include/pal_exerciser.h
@@ -31,9 +31,6 @@
 void *mem_alloc(size_t alignment, size_t size);
 #endif
 
-#define print(verbose, string, ...) \
-    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
-
 /* Exerciser PAL API declarations */
 uint64_t pal_exerciser_get_ecam(uint32_t Bdf);
 uint64_t pal_exerciser_get_ecsr_base(uint32_t Bdf, uint32_t BarIndex);

--- a/pal/baremetal/target/RDV3/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3/src/pal_exerciser.c
@@ -58,7 +58,9 @@ pal_exerciser_get_ecam(uint32_t bdf)
     }
     i++;
   }
-  print(ACS_PRINT_ERR, "\n No ECAM base ", 0);
+  pal_print_msg(ACS_PRINT_ERR,
+                "\n No ECAM base ",
+                0);
   return 0;
 }
 
@@ -114,7 +116,9 @@ pal_exerciser_get_base(uint32_t bdf, uint32_t bar_index)
      bar_value = bar_value | (bar_upper_bits << 32);
   }
 
-  print(ACS_PRINT_INFO, "value read from BAR 0x%llx\n", bar_value);
+  pal_print_msg(ACS_PRINT_INFO,
+                "value read from BAR 0x%llx\n",
+                bar_value);
 
   return bar_value;
 
@@ -172,7 +176,9 @@ uint32_t pal_exerciser_find_pcie_capability(uint32_t ID, uint32_t Bdf, uint32_t 
     NxtPtr = (Data >> PtrOffset) & PtrMask;
   }
 
-  print(ACS_PRINT_ERR, "\n No capabilities found", 0);
+  pal_print_msg(ACS_PRINT_ERR,
+                "\n No capabilities found",
+                0);
   return 1;
 }
 /**

--- a/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
@@ -31,9 +31,6 @@
 void *mem_alloc(size_t alignment, size_t size);
 #endif
 
-#define print(verbose, string, ...) \
-    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
-
 /* Exerciser PAL API declarations */
 uint64_t pal_exerciser_get_ecam(uint32_t Bdf);
 uint64_t pal_exerciser_get_ecsr_base(uint32_t Bdf, uint32_t BarIndex);

--- a/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
@@ -58,7 +58,9 @@ pal_exerciser_get_ecam(uint32_t bdf)
     }
     i++;
   }
-  print(ACS_PRINT_ERR, "\n No ECAM base ", 0);
+  pal_print_msg(ACS_PRINT_ERR,
+                "\n No ECAM base ",
+                0);
   return 0;
 }
 
@@ -114,7 +116,9 @@ pal_exerciser_get_base(uint32_t bdf, uint32_t bar_index)
      bar_value = bar_value | (bar_upper_bits << 32);
   }
 
-  print(ACS_PRINT_INFO, "value read from BAR 0x%llx\n", bar_value);
+  pal_print_msg(ACS_PRINT_INFO,
+                "value read from BAR 0x%llx\n",
+                bar_value);
 
   return bar_value;
 
@@ -172,7 +176,9 @@ uint32_t pal_exerciser_find_pcie_capability(uint32_t ID, uint32_t Bdf, uint32_t 
     NxtPtr = (Data >> PtrOffset) & PtrMask;
   }
 
-  print(ACS_PRINT_ERR, "\n No capabilities found", 0);
+  pal_print_msg(ACS_PRINT_ERR,
+                "\n No capabilities found",
+                0);
   return 1;
 }
 /**

--- a/pal/include/pal_print.h
+++ b/pal/include/pal_print.h
@@ -33,6 +33,11 @@
         } \
     } while (0)
 
+/*
+ * PAL_PRINT_FORMAT and PAL_PRINT_LITERAL are backend-specific building blocks.
+ * Keep normal PAL call sites on pal_print_msg() with plain source literals.
+ * UEFI widens those literals here; baremetal forwards them unchanged.
+ */
 #if defined(TARGET_BAREMETAL)
 void pal_uart_print(int log, const char *fmt, ...);
 
@@ -48,9 +53,22 @@ void pal_uart_print(int log, const char *fmt, ...);
     PAL_PRINT_IF((verbose), Print((string), ##__VA_ARGS__))
 
 #define PAL_PRINT_LITERAL(verbose, string, ...) \
-    PAL_PRINT_IF((verbose), Print(L##string, ##__VA_ARGS__))
+    PAL_PRINT_IF((verbose), Print(L"" string, ##__VA_ARGS__))
 #else
 #error "pal_print.h requires TARGET_BAREMETAL or TARGET_UEFI"
 #endif
+
+/*
+ * pal_print_msg() is the standard PAL wrapper used by current call sites.
+ * Pass a plain C string literal, not L"...".
+ *
+ * pal_print_native() is only for rare cases where the caller already has a
+ * target-native format string, such as a UEFI CHAR16/L"..." format.
+ */
+#define pal_print_native(verbose, string, ...) \
+    PAL_PRINT_FORMAT((verbose), (string), ##__VA_ARGS__)
+
+#define pal_print_msg(verbose, string, ...) \
+    PAL_PRINT_LITERAL((verbose), string, ##__VA_ARGS__)
 
 #endif

--- a/pal/uefi_acpi/include/pal_uefi.h
+++ b/pal/uefi_acpi/include/pal_uefi.h
@@ -84,9 +84,6 @@ typedef struct {
   UINT64   Arg7;
 } ARM_SMC_ARGS;
 
-#define acs_print(verbose, string, ...) \
-    PAL_PRINT_FORMAT((verbose), (string), ##__VA_ARGS__)
-
 /**
   Conduits for service calls (SMC vs HVC).
 **/

--- a/pal/uefi_acpi/src/pal_acpi.c
+++ b/pal/uefi_acpi/src/pal_acpi.c
@@ -54,8 +54,8 @@ pal_target_is_bm()
 VOID
 pal_dump_dtb()
 {
-  acs_print(ACS_PRINT_ERR, L" DTB dump not available for platform initialized"
-                                " with ACPI table\n");
+  pal_print_msg(ACS_PRINT_ERR,
+                " DTB dump not available for platform initialized with ACPI table\n");
 }
 
 /**
@@ -121,7 +121,8 @@ pal_get_madt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -155,7 +156,8 @@ pal_get_gtdt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -188,7 +190,8 @@ pal_get_mcfg_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -221,7 +224,8 @@ pal_get_spcr_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -254,7 +258,8 @@ pal_get_iort_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -292,7 +297,8 @@ pal_get_fadt_ptr (
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -325,7 +331,8 @@ pal_get_acpi_table_ptr(UINT32 table_signature)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -357,7 +364,8 @@ pal_get_aest_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -389,7 +397,8 @@ pal_get_apmt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -422,7 +431,8 @@ pal_get_hmat_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -455,7 +465,8 @@ pal_get_mpam_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -489,7 +500,8 @@ pal_get_pptt_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -523,7 +535,8 @@ pal_get_srat_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -556,7 +569,8 @@ pal_get_tpm2_ptr(void)
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -1040,7 +1054,8 @@ pal_acpi_parse_root_bridges(VOID)
     dsdt = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)fadt_table->Dsdt;
   else
   {
-    acs_print(ACS_PRINT_WARN, L" DSDT not found; root bridge AML unavailable ");
+    pal_print_msg(ACS_PRINT_WARN,
+                  " DSDT not found; root bridge AML unavailable ");
     dsdt = NULL;
   }
 
@@ -1088,7 +1103,8 @@ UINT32
 pal_acpi_get_root_bridge_uid(UINT16 segment, UINT8 bbn, UINT32 *uid)
 {
   if (uid == NULL) {
-    acs_print(ACS_PRINT_ERR, L" pal_acpi_get_root_bridge_uid UID pointer NULL ");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " pal_acpi_get_root_bridge_uid UID pointer NULL ");
     return 1;
   }
 

--- a/pal/uefi_acpi/src/pal_cxl.c
+++ b/pal/uefi_acpi/src/pal_cxl.c
@@ -91,14 +91,16 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
   UINT64 cedt_address;
 
   if (CxlTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input CXL Table Pointer is NULL. Cannot create CXL INFO ");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input CXL Table Pointer is NULL. Cannot create CXL INFO ");
     return;
   }
   CxlTable->num_entries = 0;
 
   cedt_address = pal_get_acpi_table_ptr(EFI_ACPI_6_4_CXL_EARLY_DISCOVERY_TABLE_SIGNATURE);
   if (cedt_address == 0) {
-    acs_print(ACS_PRINT_ERR, L" ACPI - CEDT Table not found.\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " ACPI - CEDT Table not found.\n");
     return;
   }
 
@@ -111,12 +113,14 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
       (EFI_ACPI_6_4_CEDT_CXL_HOST_BRIDGE_STRUCTURE *)ptr;
 
     if (Host->RecordLength == 0) {
-      acs_print(ACS_PRINT_WARN, L" CEDT record length is zero. Aborting parse. ");
+      pal_print_msg(ACS_PRINT_WARN,
+                    " CEDT record length is zero. Aborting parse. ");
       return;
     }
 
     if ((ptr + Host->RecordLength) > end) {
-      acs_print(ACS_PRINT_WARN, L" CEDT record overruns table length. Stopping parse. ");
+      pal_print_msg(ACS_PRINT_WARN,
+                    " CEDT record overruns table length. Stopping parse. ");
       break;
     }
 
@@ -145,12 +149,14 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
     UINT16 len  = *(UINT16 *)(ptr + 2);
 
     if (len == 0) {
-      acs_print(ACS_PRINT_WARN, L" CEDT record length is zero. Aborting parse. ");
+      pal_print_msg(ACS_PRINT_WARN,
+                    " CEDT record length is zero. Aborting parse. ");
       return;
     }
 
     if ((ptr + len) > end) {
-      acs_print(ACS_PRINT_WARN, L" CEDT record overruns table length. Stopping parse. ");
+      pal_print_msg(ACS_PRINT_WARN,
+                    " CEDT record overruns table length. Stopping parse. ");
       break;
     }
 
@@ -180,7 +186,9 @@ pal_cxl_get_host_bridge_uid(UINT32 bdf, UINT32 *uid)
 
   /* Map root port BDF to the root bridge UID for CEDT lookup. */
   if (uid == NULL) {
-    acs_print(ACS_PRINT_ERR, L" pal_cxl_get_host_bridge_uid UID pointer NULL ");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " %a UID pointer NULL ",
+                  __func__);
     return 1;
   }
 

--- a/pal/uefi_acpi/src/pal_dsdt.c
+++ b/pal/uefi_acpi/src/pal_dsdt.c
@@ -455,8 +455,10 @@ pal_acpi_parse_aml_for_device(CONST UINT8 *aml,
         SetMem(dev_name, sizeof(dev_name), 0);
         pal_acpi_copy_name_seg(dev_name, sizeof(dev_name), stack[depth].name_seg);
         if (record_fn != NULL) {
-          acs_print(ACS_PRINT_INFO, L" DSDT MSC: UID=0x%x Device=%a\n",
-                    stack[depth].uid, dev_name);
+          pal_print_msg(ACS_PRINT_INFO,
+                        " DSDT MSC: UID=0x%x Device=%a\n",
+                        stack[depth].uid,
+                        dev_name);
           record_fn(record_ctx, stack[depth].uid, dev_name);
         }
         msc_count++;
@@ -616,8 +618,10 @@ pal_acpi_parse_aml_for_device(CONST UINT8 *aml,
       SetMem(dev_name, sizeof(dev_name), 0);
       pal_acpi_copy_name_seg(dev_name, sizeof(dev_name), stack[depth].name_seg);
       if (record_fn != NULL) {
-        acs_print(ACS_PRINT_INFO, L" DSDT MSC: UID=0x%x Device=%a\n",
-                  stack[depth].uid, dev_name);
+        pal_print_msg(ACS_PRINT_INFO,
+                      " DSDT MSC: UID=0x%x Device=%a\n",
+                      stack[depth].uid,
+                      dev_name);
         record_fn(record_ctx, stack[depth].uid, dev_name);
       }
       msc_count++;

--- a/pal/uefi_acpi/src/pal_gic.c
+++ b/pal/uefi_acpi/src/pal_gic.c
@@ -56,7 +56,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   UINT32                         is_gicr_present = 0;
 
   if (GicTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
     return;
   }
 
@@ -73,9 +74,13 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
 
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
-    acs_print(ACS_PRINT_INFO, L"  MADT is at %x and length is %x\n", gMadtHdr, TableLength);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "  MADT is at %x and length is %x\n",
+                  gMadtHdr,
+                  TableLength);
   } else {
-    acs_print(ACS_PRINT_ERR, L" MADT not found\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " MADT not found\n");
     return;
   }
 
@@ -109,7 +114,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
       if (Entry->PhysicalBaseAddress != 0) {
         GicEntry->type = ENTRY_TYPE_CPUIF;
         GicEntry->base = Entry->PhysicalBaseAddress;
-        acs_print(ACS_PRINT_INFO, L"  GIC CPUIF base %lx\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC CPUIF base %lx\n",
+                      GicEntry->base);
         GicEntry++;
       }
 
@@ -119,12 +126,15 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
           GicEntry->type = ENTRY_TYPE_GICC_GICRD;
           GicEntry->base = Entry->GICRBaseAddress;
           GicEntry->length = 0;
-          acs_print(ACS_PRINT_INFO, L"  GICC RD base %lx\n", GicEntry->base);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  GICC RD base %lx\n",
+                        GicEntry->base);
           GicTable->header.num_gicc_rd++;
           GicEntry++;
         } else {
-          acs_print(ACS_PRINT_INFO,
-                    L"  Warning : GICR Structure Present, GICC RD Base Non-Zero\n", 0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Warning : GICR Structure Present, GICC RD Base Non-Zero\n",
+                        0);
         }
       }
 
@@ -132,7 +142,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICH;
         GicEntry->base = Entry->GICH;
         GicEntry->length = 0;
-        acs_print(ACS_PRINT_INFO, L"  GICH base %lx\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GICH base %lx\n",
+                      GicEntry->base);
         GicEntry++;
       }
     }
@@ -141,7 +153,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICD;
         GicEntry->base = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicTable->header.gic_version = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->GicVersion;
-        acs_print(ACS_PRINT_INFO, L"  GIC DIS base %lx\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC DIS base %lx\n",
+                      GicEntry->base);
         GicTable->header.num_gicd++;
         GicEntry++;
     }
@@ -150,8 +164,12 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICR_GICRD;
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
-        acs_print(ACS_PRINT_INFO, L"  GICR RD base %lx\n", GicEntry->base);
-        acs_print(ACS_PRINT_INFO, L"  GICR RD Length %lx\n", GicEntry->length);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GICR RD base %lx\n",
+                      GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GICR RD Length %lx\n",
+                      GicEntry->length);
         GicTable->header.num_gicr_rd++;
         GicEntry++;
     }
@@ -160,8 +178,12 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICITS;
         GicEntry->base = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicEntry->entry_id = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->GicItsId;
-        acs_print(ACS_PRINT_INFO, L"  GIC ITS base %lx\n", GicEntry->base);
-        acs_print(ACS_PRINT_INFO, L"  GIC ITS ID%x\n", GicEntry->entry_id);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC ITS base %lx\n",
+                      GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC ITS ID%x\n",
+                      GicEntry->entry_id);
         GicTable->header.num_its++;
         GicEntry++;
     }
@@ -173,9 +195,15 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->flags = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->Flags;
         GicEntry->spi_count = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPICount;
         GicEntry->spi_base = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPIBase;
-        acs_print(ACS_PRINT_INFO, L"  GIC MSI Frame base %lx\n", GicEntry->base);
-        acs_print(ACS_PRINT_INFO, L"  GIC MSI SPI base %x\n", GicEntry->spi_base);
-        acs_print(ACS_PRINT_INFO, L"  GIC MSI SPI Count %x\n", GicEntry->spi_count);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC MSI Frame base %lx\n",
+                      GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC MSI SPI base %x\n",
+                      GicEntry->spi_base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC MSI SPI Count %x\n",
+                      GicEntry->spi_count);
         GicTable->header.num_msi_frame++;
         GicEntry++;
     }

--- a/pal/uefi_acpi/src/pal_hmat.c
+++ b/pal/uefi_acpi/src/pal_hmat.c
@@ -125,9 +125,11 @@ EFI_ACPI_6_4_HMAT_STRUCTURE_SYSTEM_LOCALITY_LATENCY_AND_BANDWIDTH_INFO *curr_bw_
   entry_base_unit = curr_bw_struct->EntryBaseUnit;
 
   if (entry_base_unit > HMAT_BASE_UNIT_48BIT) {
-      acs_print(ACS_PRINT_ERR, L"\nEntry Base unit exceeds 0x%llx Mbytes/s ",
-                                HMAT_BASE_UNIT_48BIT);
-      acs_print(ACS_PRINT_ERR, L"\n  BW info entries might overflow 64 bit boundary");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\nEntry Base unit exceeds 0x%llx Mbytes/s ",
+                    HMAT_BASE_UNIT_48BIT);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n  BW info entries might overflow 64 bit boundary");
   }
 
   /* pointer to list of target proximity domains */
@@ -141,10 +143,18 @@ EFI_ACPI_6_4_HMAT_STRUCTURE_SYSTEM_LOCALITY_LATENCY_AND_BANDWIDTH_INFO *curr_bw_
       curr_max_bw_entry = pal_hmat_get_max_bw_entry(i, curr_bw_struct);
       curr_max_bw = entry_base_unit * curr_max_bw_entry;
 
-      acs_print(ACS_PRINT_INFO, L"\nMemory Proximity Domain  : 0x%llx", *curr_tgt_prox_domain);
-      acs_print(ACS_PRINT_INFO, L"\nEntry Base Unit          : 0x%llx", entry_base_unit);
-      acs_print(ACS_PRINT_INFO, L"\nMax Bandwidth entry      : 0x%llx", curr_max_bw_entry);
-      acs_print(ACS_PRINT_INFO, L"\nMax Bandwidth            : 0x%llx", curr_max_bw);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMemory Proximity Domain  : 0x%llx",
+                    *curr_tgt_prox_domain);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nEntry Base Unit          : 0x%llx",
+                    entry_base_unit);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMax Bandwidth entry      : 0x%llx",
+                    curr_max_bw_entry);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMax Bandwidth            : 0x%llx",
+                    curr_max_bw);
       /* get index to HMAT info table entry for curr_tgt_prox_domain */
       bw_info_index = pal_hmat_get_entry_index(HmatTable, *curr_tgt_prox_domain);
       /* pointer to HMAT info table entry curr_tgt_prox_domain */
@@ -185,12 +195,18 @@ VOID pal_hmat_dump_info_table(HMAT_INFO_TABLE *HmatTable)
       return;
 
   curr_entry = HmatTable->bw_info;
-  acs_print(ACS_PRINT_INFO, L"\n*** HMAT info table entries ***\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n*** HMAT info table entries ***\n");
   for (i = 0 ; i < HmatTable->num_of_mem_prox_domain ; i++) {
-      acs_print(ACS_PRINT_INFO, L"\nMemory Proximity domain  :   0x%llx",
-                                curr_entry->mem_prox_domain);
-      acs_print(ACS_PRINT_INFO, L"\n  Write bandwidth        :   0x%llx", curr_entry->write_bw);
-      acs_print(ACS_PRINT_INFO, L"\n  Read  bandwidth        :   0x%llx\n", curr_entry->read_bw);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMemory Proximity domain  :   0x%llx",
+                    curr_entry->mem_prox_domain);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  Write bandwidth        :   0x%llx",
+                    curr_entry->write_bw);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  Read  bandwidth        :   0x%llx\n",
+                    curr_entry->read_bw);
       curr_entry++;
   }
 }
@@ -211,7 +227,8 @@ VOID pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
   UINT32 TableLength = 0;
 
   if (HmatTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L" Unable to create HMAT info table, input pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Unable to create HMAT info table, input pointer is NULL\n");
       return;
   }
 
@@ -220,13 +237,16 @@ VOID pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
 
   HmatHdr = (EFI_ACPI_6_4_HETEROGENEOUS_MEMORY_ATTRIBUTE_TABLE_HEADER *) pal_get_hmat_ptr();
   if (HmatHdr == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" HMAT ACPI table not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " HMAT ACPI table not found\n");
       return;
   }
   else {
       TableLength = HmatHdr->Header.Length;
-      acs_print(ACS_PRINT_INFO, L"HMAT ACPI table found at 0x%llx with length 0x%x\n",
-                 HmatHdr, TableLength);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "HMAT ACPI table found at 0x%llx with length 0x%x\n",
+                    HmatHdr,
+                    TableLength);
   }
 
   /* pointer to first HMAT structure in ACPI table */

--- a/pal/uefi_acpi/src/pal_iovirt.c
+++ b/pal/uefi_acpi/src/pal_iovirt.c
@@ -64,39 +64,55 @@ dump_block(IOVIRT_BLOCK *block) {
   NODE_DATA_MAP *map = &block->data_map[0];
   switch(block->type) {
       case IOVIRT_NODE_ITS_GROUP:
-      acs_print(ACS_PRINT_INFO, L"  ITS Group Num ITS: %d\n",
-                                                        block->data.its_count);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  ITS Group Num ITS: %d\n",
+                    block->data.its_count);
       for(i = 0; i < block->data.its_count; i++)
-          acs_print(ACS_PRINT_INFO, L"  ITS ID: %d\n", (*map).id[i]);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  ITS ID: %d\n",
+                        (*map).id[i]);
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
-      acs_print(ACS_PRINT_INFO,
-                 L" Named Component:\n Device Name:%a", block->data.named_comp.name);
-      acs_print(ACS_PRINT_INFO, L"\n CCA Attribute: 0x%lx\n", block->data.named_comp.cca);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " Named Component:\n Device Name:%a",
+                    block->data.named_comp.name);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n CCA Attribute: 0x%lx\n",
+                    block->data.named_comp.cca);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
-      acs_print(ACS_PRINT_INFO, L"  Root Complex  Segment Num:%d\n",
-                                                      block->data.rc.segment);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Root Complex  Segment Num:%d\n",
+                    block->data.rc.segment);
       break;
       case IOVIRT_NODE_SMMU:
       case IOVIRT_NODE_SMMU_V3:
-      acs_print(ACS_PRINT_INFO, L"  SMMU: Major Rev:%d Base Address:0x%llx\n",
-                 block->data.smmu.arch_major_rev, block->data.smmu.base);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  SMMU: Major Rev:%d Base Address:0x%llx\n",
+                    block->data.smmu.arch_major_rev,
+                    block->data.smmu.base);
       break;
       case IOVIRT_NODE_PMCG:
-      acs_print(ACS_PRINT_INFO, L"  PMCG: Base:0x%x Overflow GSIV:0x%x"
-                               " Node Reference:0x%x\n", block->data.pmcg.base,
-                block->data.pmcg.overflow_gsiv, block->data.pmcg.node_ref);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  PMCG: Base:0x%x Overflow GSIV:0x%x Node Reference:0x%x\n",
+                    block->data.pmcg.base,
+                    block->data.pmcg.overflow_gsiv,
+                    block->data.pmcg.node_ref);
       break;
   }
-  acs_print(ACS_PRINT_INFO, L"  Number of ID Mappings:%d\n", block->num_data_map);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  Number of ID Mappings:%d\n",
+                block->num_data_map);
   for(i = 0; i < block->num_data_map; i++, map++) {
-      acs_print(ACS_PRINT_INFO, L"  input_base:0x%x id_count:0x%x\n"
-                                "  output_base:0x%x output ref:0x%x\n",
-            (*map).map.input_base, (*map).map.id_count,
-            (*map).map.output_base, (*map).map.output_ref);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  input_base:0x%x id_count:0x%x output_base:0x%x output ref:0x%x\n",
+                    (*map).map.input_base,
+                    (*map).map.id_count,
+                    (*map).map.output_base,
+                    (*map).map.output_ref);
   }
-  acs_print(ACS_PRINT_INFO, L"\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n");
 }
 
 /**
@@ -131,7 +147,9 @@ dump_iort_table(IOVIRT_INFO_TABLE *iovirt)
 {
   UINT32 i;
   IOVIRT_BLOCK *block = &iovirt->blocks[0];
-  acs_print(ACS_PRINT_INFO, L"  Number of IOVIRT blocks = %d\n", iovirt->num_blocks);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  Number of IOVIRT blocks = %d\n",
+                iovirt->num_blocks);
   for(i = 0; i < iovirt->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
     dump_block(block);
 }
@@ -190,14 +208,22 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
             if(tmp->type == IOVIRT_NODE_ITS_GROUP) {
                key_block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
-               acs_print(ACS_PRINT_INFO, L"\n Overlapping device ids %x-%x and %x-%x\n",
-                          key_start, key_end, start, end);
+               pal_print_msg(ACS_PRINT_INFO,
+                             "\n Overlapping device ids %x-%x and %x-%x\n",
+                             key_start,
+                             key_end,
+                             start,
+                             end);
             }
             else {
                key_block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
-               acs_print(ACS_PRINT_INFO, L"\n Overlapping stream ids %x-%x and %x-%x\n",
-                          key_start, key_end, start, end);
+               pal_print_msg(ACS_PRINT_INFO,
+                             "\n Overlapping stream ids %x-%x and %x-%x\n",
+                             key_start,
+                             key_end,
+                             start,
+                             end);
             }
           }
         }
@@ -261,7 +287,10 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
   NODE_DATA *data = &((*block)->data);
   VOID *node_data = &(iort_node->node_data[0]);
 
-  acs_print(ACS_PRINT_INFO, L"  IORT node offset:%x, type: %d\n", (UINT8*)iort_node - (UINT8*)iort, iort_node->type);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  IORT node offset:%x, type: %d\n",
+                (UINT8 *)iort_node - (UINT8 *)iort,
+                iort_node->type);
 
   SetMem(data, sizeof(NODE_DATA), 0);
 
@@ -324,7 +353,8 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
       count = &IoVirtTable->num_pmcgs;
       break;
     default:
-       acs_print(ACS_PRINT_ERR, L" Invalid IORT node type\n");
+       pal_print_msg(ACS_PRINT_ERR,
+                     " Invalid IORT node type\n");
        return (UINT32) -1;
   }
 
@@ -451,7 +481,8 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   /* Create iovirt block for each IORT node*/
   for (i = 0; i < iort->node_count; i++) {
     if (iort_node >= iort_end) {
-      acs_print(ACS_PRINT_ERR, L" Bad IORT table\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Bad IORT table\n");
       return;
     }
     iort_add_block(iort, iort_node, IoVirtTable, &next_block);
@@ -544,8 +575,9 @@ pal_iovirt_get_rc_smmu_base (
   }
 
   if (!mapping_found) {
-      acs_print(ACS_PRINT_ERR,
-               L"\n       RID to Stream ID/Dev ID map not found ", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n       RID to Stream ID/Dev ID map not found ",
+                    0);
       return 0xFFFFFFFF;
   }
 
@@ -559,8 +591,9 @@ pal_iovirt_get_rc_smmu_base (
           if (sid >= (*map).map.input_base && sid <= ((*map).map.input_base +
                                                     (*map).map.id_count))
           {
-              acs_print(ACS_PRINT_DEBUG, L"\n       RC block->data.smmu."
-                                "base: %llx    ", block->data.smmu.base);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "\n       RC block->data.smmu.base: %llx    ",
+                            block->data.smmu.base);
               return block->data.smmu.base;
           }
       }
@@ -569,6 +602,8 @@ pal_iovirt_get_rc_smmu_base (
   /* The Root Complex represented by rc_seg_num
    * is not behind any SMMU. Return NULL pointer
    */
-  acs_print(ACS_PRINT_DEBUG, L" No SMMU found behind the RootComplex with seg :%x", RcSegmentNum);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " No SMMU found behind the RootComplex with seg :%x",
+                RcSegmentNum);
   return 0;
 }

--- a/pal/uefi_acpi/src/pal_misc.c
+++ b/pal/uefi_acpi/src/pal_misc.c
@@ -38,7 +38,11 @@ VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT8 *)addr = data;
 }
@@ -56,7 +60,11 @@ VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT16 *)addr = data;
 }
@@ -74,7 +82,11 @@ VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %llx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT64 *)addr = data;
 }
@@ -95,7 +107,11 @@ pal_mmio_read8(UINT64 addr)
   data = (*(volatile UINT8 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read8 Address = %lx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -116,7 +132,11 @@ pal_mmio_read16(UINT64 addr)
   data = (*(volatile UINT16 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read16 Address = %lx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -137,7 +157,11 @@ pal_mmio_read64(UINT64 addr)
   data = (*(volatile UINT64 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read64 Address = %lx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -158,7 +182,11 @@ pal_mmio_read(UINT64 addr)
   data = (*(volatile UINT32 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read Address = %lx  Data = %x\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %x\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -177,7 +205,11 @@ pal_mmio_write(UINT64 addr, UINT32 data)
 {
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %x\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT32 *)addr = data;
 }
@@ -204,7 +236,8 @@ pal_print(UINT64 data)
     AsciiPrint("%a", buf);
     Status = ShellWriteFile(g_acs_log_file_handle, &BufferSize, (VOID *)buf);
     if (EFI_ERROR(Status))
-      acs_print(ACS_PRINT_ERR, L" Error in writing to log file\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Error in writing to log file\n");
   }
   else
   {
@@ -289,7 +322,8 @@ pal_mem_free(VOID *Buffer)
   UINT32 Status;
   Status = gBS->FreePool(Buffer);
   if (EFI_ERROR(Status)) {
-    acs_print(ACS_PRINT_ERR, L"\n       Failed to free memory    ");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "\n       Failed to free memory    ");
   }
 }
 
@@ -311,10 +345,14 @@ pal_mem_allocate_shared(UINT32 num_pe, UINT32 sizeofentry)
                                (num_pe * sizeofentry),
                                (VOID **) &gSharedMemory );
 
-  acs_print(ACS_PRINT_INFO, L" Shared memory is %llx\n", gSharedMemory);
+  pal_print_msg(ACS_PRINT_INFO,
+                " Shared memory is %llx\n",
+                gSharedMemory);
 
   if (EFI_ERROR(Status)) {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool shared memory failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool shared memory failed %x\n",
+                  Status);
   }
   pal_pe_data_cache_ops_by_va((UINT64)&gSharedMemory, CLEAN_AND_INVALIDATE);
 
@@ -373,7 +411,9 @@ pal_mem_alloc (
                               (VOID **) &Buffer);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -404,7 +444,9 @@ pal_mem_calloc (
                               (VOID **) &Buffer);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -493,7 +535,9 @@ pal_mem_alloc_pages (
                                &PageBase);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pages failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pages failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -547,7 +591,8 @@ pal_mem_free_aligned(VOID *Buffer)
     UINT32 Status;
     Status = gBS->FreePool(((VOID **)Buffer)[-1]);
     if (EFI_ERROR (Status)) {
-        acs_print(ACS_PRINT_ERR, L"\n       Failed to free aligned memory    ");
+        pal_print_msg(ACS_PRINT_ERR,
+                      "\n       Failed to free aligned memory    ");
     }
 }
 
@@ -594,7 +639,9 @@ pal_mem_alloc_at_address (
                                &PageBase);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pages failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pages failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -643,14 +690,18 @@ pal_mem_alloc_cacheable (
                                EFI_SIZE_TO_PAGES(Size),
                                &Address);
   if (EFI_ERROR(Status)) {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool failed %x\n",
+                  Status);
     return NULL;
   }
 
   /* Check Whether Cpu architectural protocol is installed */
   Status = gBS->LocateProtocol ( &gEfiCpuArchProtocolGuid, NULL, (VOID **)&Cpu);
   if (EFI_ERROR(Status)) {
-    acs_print(ACS_PRINT_ERR, L" Could not get Cpu Arch Protocol %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Could not get Cpu Arch Protocol %x\n",
+                  Status);
     return NULL;
   }
 
@@ -660,7 +711,9 @@ pal_mem_alloc_cacheable (
                                      Size,
                                      EFI_MEMORY_WB);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_ERR, L" Could not Set Memory Attribute %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Could not Set Memory Attribute %x\n",
+                  Status);
     return NULL;
   }
 
@@ -709,14 +762,18 @@ pal_mem_set_wb_executable (
   /* Step 1: Locate CPU Architectural Protocol */
   Status = gBS->LocateProtocol(&gEfiCpuArchProtocolGuid, NULL, (VOID **)&Cpu);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR, L"Could not get CPU Arch Protocol: %x\n", Status);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "Could not get CPU Arch Protocol: %x\n",
+                    Status);
       return 1;
   }
 
   /* Step 2: Set Memory Attributes to Ensure Execution */
   Status = Cpu->SetMemoryAttributes(Cpu, (EFI_PHYSICAL_ADDRESS) addr, Size, EFI_MEMORY_WB);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR, L"Could not set memory attributes: %x\n", Status);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "Could not set memory attributes: %x\n",
+                    Status);
       return 1;
   }
 
@@ -733,7 +790,8 @@ void pal_uart_putc(char c)
         UINTN n = 1;
         EFI_STATUS Status = ShellWriteFile(g_acs_log_file_handle, &n, &ch);
         if (EFI_ERROR(Status)) {
-            acs_print(ACS_PRINT_ERR, L" Error in writing to log file\n");
+            pal_print_msg(ACS_PRINT_ERR,
+                          " Error in writing to log file\n");
         }
     }
 }

--- a/pal/uefi_acpi/src/pal_mpam.c
+++ b/pal/uefi_acpi/src/pal_mpam.c
@@ -52,26 +52,38 @@ pal_mpam_dump_table(MPAM_INFO_TABLE *MpamTable)
   curr_entry = &(MpamTable->msc_node[0]);
 
   for (i = 0; i < MpamTable->msc_count; i++) {
-      acs_print(ACS_PRINT_INFO, L"\nMSC node Index         :%d ", i);
-      acs_print(ACS_PRINT_INFO, L"\nMSC base addr          :%llx ",
-                                        curr_entry->msc_base_addr);
-      acs_print(ACS_PRINT_INFO, L"\nMSC Overflow interrupt :%llx ",
-                                        curr_entry->of_intr);
-      acs_print(ACS_PRINT_INFO, L"\nMSC Error interrupt    :%llx ",
-                                        curr_entry->err_intr);
-      acs_print(ACS_PRINT_INFO, L"\nMSC resource count     :%lx ",
-                                        curr_entry->rsrc_count);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC node Index         :%d ",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC base addr          :%llx ",
+                    curr_entry->msc_base_addr);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC Overflow interrupt :%llx ",
+                    curr_entry->of_intr);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC Error interrupt    :%llx ",
+                    curr_entry->err_intr);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nMSC resource count     :%lx ",
+                    curr_entry->rsrc_count);
 
       for (j = 0; j < curr_entry->rsrc_count; j++) {
-          acs_print(ACS_PRINT_INFO, L"\nRESOURCE index  :%d ", j);
-          acs_print(ACS_PRINT_INFO, L"\nRIS index       :%d ",
-                               curr_entry->rsrc_node[j].ris_index);
-          acs_print(ACS_PRINT_INFO, L"\nlocator type    :%08X ",
-                            curr_entry->rsrc_node[j].locator_type);
-          acs_print(ACS_PRINT_INFO, L"\ndescriptor1     :%llx ",
-                             curr_entry->rsrc_node[j].descriptor1);
-          acs_print(ACS_PRINT_INFO, L"\ndescriptor2     :%x ",
-                             curr_entry->rsrc_node[j].descriptor2);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nRESOURCE index  :%d ",
+                        j);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nRIS index       :%d ",
+                        curr_entry->rsrc_node[j].ris_index);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nlocator type    :%08X ",
+                        curr_entry->rsrc_node[j].locator_type);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\ndescriptor1     :%llx ",
+                        curr_entry->rsrc_node[j].descriptor1);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\ndescriptor2     :%x ",
+                        curr_entry->rsrc_node[j].descriptor2);
       }
       curr_entry = MPAM_NEXT_MSC(curr_entry);
   }
@@ -97,18 +109,23 @@ pal_srat_dump_table(SRAT_INFO_TABLE *SratTable)
   for (i = 0; i < SratTable->num_of_srat_entries; i++) {
       curr_entry = &(SratTable->srat_info[i]);
       if (curr_entry->node_type == SRAT_NODE_MEM_AFF) {
-          acs_print(ACS_PRINT_INFO, L"\n       SRAT mem prox domain :%x ",
-                                                   curr_entry->node_data.mem_aff.prox_domain);
-          acs_print(ACS_PRINT_INFO, L"\n       SRAT mem addr_base :%llx ",
-                                                     curr_entry->node_data.mem_aff.addr_base);
-          acs_print(ACS_PRINT_INFO, L"\n       SRAT mem addr_len :%llx ",
-                                                      curr_entry->node_data.mem_aff.addr_len);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT mem prox domain :%x ",
+                        curr_entry->node_data.mem_aff.prox_domain);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT mem addr_base :%llx ",
+                        curr_entry->node_data.mem_aff.addr_base);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT mem addr_len :%llx ",
+                        curr_entry->node_data.mem_aff.addr_len);
       }
       else if (curr_entry->node_type == SRAT_NODE_GICC_AFF) {
-          acs_print(ACS_PRINT_INFO, L"\n       SRAT Gicc prox domain :%x ",
-                                                   curr_entry->node_data.gicc_aff.prox_domain);
-          acs_print(ACS_PRINT_INFO, L"\n       SRAT Gicc processor uid :%x ",
-                                                   curr_entry->node_data.gicc_aff.proc_uid);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT Gicc prox domain :%x ",
+                        curr_entry->node_data.gicc_aff.prox_domain);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\n       SRAT Gicc processor uid :%x ",
+                        curr_entry->node_data.gicc_aff.proc_uid);
       }
   }
 }
@@ -131,7 +148,8 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
   MPAM_MSC_NODE *curr_entry;
 
   if (MpamTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L" Input MPAM Table Pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Input MPAM Table Pointer is NULL\n");
       return;
   }
 
@@ -143,7 +161,8 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
 
   mpam = (EFI_ACPI_MPAM_TABLE *)pal_get_mpam_ptr();
   if (mpam == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" MPAM table not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " MPAM table not found\n");
       return;
   }
 
@@ -217,7 +236,8 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
   UINT32  Length = 0;
 
   if (SratTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L" Input SRAT Table Pointer is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Input SRAT Table Pointer is NULL\n");
       return;
   }
 
@@ -229,9 +249,13 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
 
   if (SratHdr != NULL) {
     TableLength =  SratHdr->Header.Length;
-    acs_print(ACS_PRINT_INFO, L" SRAT is at %x and length is %x\n", SratHdr, TableLength);
+    pal_print_msg(ACS_PRINT_INFO,
+                  " SRAT is at %x and length is %x\n",
+                  SratHdr,
+                  TableLength);
   } else {
-    acs_print(ACS_PRINT_DEBUG, L" SRAT not found\n");
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " SRAT not found\n");
     return;
   }
 
@@ -251,9 +275,15 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr->node_data.mem_aff.addr_len    = ((UINT64) Mem_Aff_Entry->LengthHigh << 32) |
                                                               Mem_Aff_Entry->LengthLow;
       Ptr->node_data.mem_aff.flags       = Mem_Aff_Entry->Flags;
-      acs_print(ACS_PRINT_DEBUG, L" Proximity Domain %x\n", Ptr->node_data.mem_aff.prox_domain);
-      acs_print(ACS_PRINT_DEBUG, L" Address %x\n", Ptr->node_data.mem_aff.addr_base);
-      acs_print(ACS_PRINT_DEBUG, L" Length %x\n", Ptr->node_data.mem_aff.addr_len);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Proximity Domain %x\n",
+                    Ptr->node_data.mem_aff.prox_domain);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Address %x\n",
+                    Ptr->node_data.mem_aff.addr_base);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Length %x\n",
+                    Ptr->node_data.mem_aff.addr_len);
       pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
       Ptr++;
       SratTable->num_of_mem_ranges++;
@@ -267,9 +297,15 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr->node_data.gicc_aff.proc_uid = Gicc_Aff_Entry->AcpiProcessorUid;
       Ptr->node_data.gicc_aff.flags = Gicc_Aff_Entry->Flags;
       Ptr->node_data.gicc_aff.clk_domain = Gicc_Aff_Entry->ClockDomain;
-      acs_print(ACS_PRINT_DEBUG, L" Proximity Domain %x\n", Ptr->node_data.gicc_aff.prox_domain);
-      acs_print(ACS_PRINT_DEBUG, L" Processor UID %x\n", Ptr->node_data.gicc_aff.proc_uid);
-      acs_print(ACS_PRINT_DEBUG, L" Clock Domain %x\n", Ptr->node_data.gicc_aff.clk_domain);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Proximity Domain %x\n",
+                    Ptr->node_data.gicc_aff.prox_domain);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Processor UID %x\n",
+                    Ptr->node_data.gicc_aff.proc_uid);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Clock Domain %x\n",
+                    Ptr->node_data.gicc_aff.clk_domain);
       pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
       Ptr++;
       SratTable->num_of_srat_entries++;

--- a/pal/uefi_acpi/src/pal_pcc.c
+++ b/pal/uefi_acpi/src/pal_pcc.c
@@ -44,7 +44,7 @@ pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
     /* initialise pcc info count */
     g_pcc_info_table->subspace_cnt = 0;
 
-    /* this API doesn't parse PCC structure, pal_pcc_store_info API should be
+    /* this API doesn't parse PCC structure, the PCC store helper should be
        called by component (e.g, MPAM) which defines PCC shared memory region, to
        populate PCC info table  */
 
@@ -82,9 +82,10 @@ pal_pcc_store_info(UINT32 subspace_idx)
     if (index == subspace_idx) {
         /* this API only supports parsing of type 3 PCC structure info */
         if (pcct_subspace->Type != EFI_ACPI_6_5_PCCT_SUBSPACE_TYPE_3_EXTENDED_PCC) {
-            acs_print(ACS_PRINT_ERR,
-                      L"\n    pal_pcc_store_info API doesn't support PCC structure type : 0x%x",
-                      pcct_subspace->Type);
+            pal_print_msg(ACS_PRINT_ERR,
+                          "\n    %a API doesn't support PCC structure type : 0x%x",
+                          __func__,
+                          pcct_subspace->Type);
         }
 
         /* parse PCC structure type 3 */
@@ -120,4 +121,3 @@ pal_pcc_store_info(UINT32 subspace_idx)
   }
 
 }
-

--- a/pal/uefi_acpi/src/pal_pcie.c
+++ b/pal/uefi_acpi/src/pal_pcie.c
@@ -56,7 +56,8 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
   gMcfgHdr = (EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *) pal_get_mcfg_ptr();
 
   if (gMcfgHdr == NULL) {
-      acs_print(ACS_PRINT_WARN, L" ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
+      pal_print_msg(ACS_PRINT_WARN,
+                    " ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
       return 0x0;
   }
 
@@ -69,7 +70,9 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
   {
       if ((bus >= Entry->StartBusNumber) && (bus <= Entry->EndBusNumber) &&
           (seg == Entry->PciSegmentGroupNumber)) {
-          acs_print(ACS_PRINT_INFO, L" ECAM base address is %llx\n", Entry->BaseAddress);
+          pal_print_msg(ACS_PRINT_INFO,
+                        " ECAM base address is %llx\n",
+                        Entry->BaseAddress);
           return Entry->BaseAddress;
       }
 
@@ -78,7 +81,9 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
       sizeof(EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE);
   }
 
-  acs_print(ACS_PRINT_ERR, L" ECAM base address for bdf 0x%x is 0\n", bdf);
+  pal_print_msg(ACS_PRINT_ERR,
+                " ECAM base address for bdf 0x%x is 0\n",
+                bdf);
   return 0;
 }
 
@@ -99,7 +104,8 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   UINT32 i = 0;
 
   if (PcieTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
     return;
   }
 
@@ -108,7 +114,8 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   gMcfgHdr = (EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *) pal_get_mcfg_ptr();
 
   if (gMcfgHdr == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" ACPI - MCFG Table not found.\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " ACPI - MCFG Table not found.\n");
       return;
   }
 
@@ -129,11 +136,21 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
       PcieTable->block[i].segment_num   = Entry->PciSegmentGroupNumber;
       PcieTable->block[i].start_bus_num = Entry->StartBusNumber;
       PcieTable->block[i].end_bus_num   = Entry->EndBusNumber;
-      acs_print(ACS_PRINT_INFO, L"  Ecam Index = %d\n", i);
-      acs_print(ACS_PRINT_INFO, L"  Base Address = 0x%llx\n", Entry->BaseAddress);
-      acs_print(ACS_PRINT_INFO, L"  Segment   = 0x%llx\n", Entry->PciSegmentGroupNumber);
-      acs_print(ACS_PRINT_INFO, L"  Start Bus = 0x%llx\n", Entry->StartBusNumber);
-      acs_print(ACS_PRINT_INFO, L"  End Bus   = 0x%llx\n", Entry->EndBusNumber);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Ecam Index = %d\n",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Base Address = 0x%llx\n",
+                    Entry->BaseAddress);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Segment   = 0x%llx\n",
+                    Entry->PciSegmentGroupNumber);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Start Bus = 0x%llx\n",
+                    Entry->StartBusNumber);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  End Bus   = 0x%llx\n",
+                    Entry->EndBusNumber);
       length += sizeof(EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE);
       Entry++;
       i++;
@@ -167,7 +184,8 @@ pal_pcie_io_read_cfg(UINT32 Bdf, UINT32 offset, UINT32 *data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return PCIE_NO_MAPPING;
   }
 
@@ -219,7 +237,8 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return;
   }
 
@@ -264,7 +283,8 @@ pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No Root Bridge found in the system\n");
     return PCIE_NO_MAPPING;
   }
 
@@ -312,7 +332,8 @@ pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No Root Bridge found in the system\n");
     return PCIE_NO_MAPPING;
   }
 
@@ -355,8 +376,10 @@ pal_pcie_p2p_support()
       return 0;
   else {
       pal_warn_not_implemented(__func__);
-      acs_print(ACS_PRINT_WARN, L"\n       Test is applicable only if the system supports P2P."
-                                 "\n       Pass command line option '-p2p' when running.");
+      pal_print_msg(ACS_PRINT_WARN,
+                    "\n       Test is applicable only if the system supports P2P.");
+      pal_print_msg(ACS_PRINT_WARN,
+                    "\n       Pass command line option '-p2p' when running.");
       return PAL_STATUS_NOT_IMPLEMENTED;
   }
 }

--- a/pal/uefi_acpi/src/pal_pcie_enumeration.c
+++ b/pal/uefi_acpi/src/pal_pcie_enumeration.c
@@ -83,7 +83,8 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return EFI_SUCCESS;
   }
 
@@ -107,8 +108,13 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
           Status = Pci->Pci.Read (Pci, EfiPciIoWidthUint32, 0, sizeof (PciHeader)/sizeof (UINT32), &PciHeader);
           if (!EFI_ERROR (Status)) {
             Hdr = &PciHeader.Bridge.Hdr;
-            acs_print(ACS_PRINT_INFO,L"  %03d.%02d.%02d class_code = %d %d\n",
-                        Bus, Dev, Index, Hdr->ClassCode[1], Hdr->ClassCode[2]);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "  %03d.%02d.%02d class_code = %d %d\n",
+                          Bus,
+                          Dev,
+                          Index,
+                          Hdr->ClassCode[1],
+                          Hdr->ClassCode[2]);
             if (Hdr->ClassCode[2] == ((ClassCode >> 16) & 0xFF)) {
               if (Hdr->ClassCode[1] == ((ClassCode >> 8) & 0xFF)) {
                  /* Found our device */
@@ -172,7 +178,8 @@ palPcieGetBase(UINT32 bdf, UINT32 bar_index)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return EFI_SUCCESS;
   }
 

--- a/pal/uefi_acpi/src/pal_pe.c
+++ b/pal/uefi_acpi/src/pal_pe.c
@@ -82,7 +82,8 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
   PE_SMBIOS_TYPE4_INFO *Type4Entry = NULL;
 
   if (SmbiosTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
     return;
   }
 
@@ -104,7 +105,9 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
     /* Check of record if of type 4 */
     if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
-      acs_print(ACS_PRINT_DEBUG, L" Smbios type %d found\n", Record->Type);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Smbios type %d found\n",
+                    Record->Type);
 
       Type4Record = (SMBIOS_TABLE_TYPE4 *)Record;
 
@@ -114,7 +117,9 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
       else
         Type4Entry->processor_family = Type4Record->ProcessorFamily;
 
-      acs_print(ACS_PRINT_DEBUG, L"  Processor Family 0x%x\n", Type4Entry->processor_family);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Processor Family 0x%x\n",
+                    Type4Entry->processor_family);
 
       /* Save Processor core count */
       if (Type4Record->CoreCount == SMBIOS_OBTAIN_CORE_COUNT2)
@@ -122,21 +127,28 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
       else
         Type4Entry->core_count = Type4Record->CoreCount;
 
-      acs_print(ACS_PRINT_DEBUG, L"  Processor Count 0x%x\n", Type4Entry->core_count);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Processor Count 0x%x\n",
+                    Type4Entry->core_count);
 
       Type4Entry++;
       SmbiosTable->slot_count++;
 
       if (SmbiosTable->slot_count >= MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED) {
-        acs_print(ACS_PRINT_WARN, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
-        acs_print(ACS_PRINT_WARN, L" Number of SMBIOS Slots greater than %d\n",
-                        MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
+        pal_print_msg(ACS_PRINT_WARN,
+                      " Total Slots/Sockets 0x%x\n",
+                      SmbiosTable->slot_count);
+        pal_print_msg(ACS_PRINT_WARN,
+                      " Number of SMBIOS Slots greater than %d\n",
+                      MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
         SmbiosTable->slot_count = MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED;
         return;
       }
     }
   }
-  acs_print(ACS_PRINT_DEBUG, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " Total Slots/Sockets 0x%x\n",
+                SmbiosTable->slot_count);
 }
 
 /**
@@ -160,7 +172,8 @@ pal_psci_get_conduit (
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_ERR, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " XSDT not found\n");
       return CONDUIT_NO_TABLE;
   }
 
@@ -254,14 +267,26 @@ PalCaptureMmuConfig(VOID)
         gMmuConfig.ttbr1 = read_ttbr1_el1();
   }
 
-  acs_print(ACS_PRINT_DEBUG, L"  MMU Config captured at EL%d\n", gMmuConfig.current_el);
-  acs_print(ACS_PRINT_DEBUG, L"    TTBR0: 0x%lx\n", gMmuConfig.ttbr0);
-  acs_print(ACS_PRINT_DEBUG, L"    TCR:   0x%lx\n", gMmuConfig.tcr);
-  acs_print(ACS_PRINT_DEBUG, L"    MAIR:  0x%lx\n", gMmuConfig.mair);
-  acs_print(ACS_PRINT_DEBUG, L"    SCTLR: 0x%lx\n", gMmuConfig.sctlr);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  MMU Config captured at EL%d\n",
+                gMmuConfig.current_el);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TTBR0: 0x%lx\n",
+                gMmuConfig.ttbr0);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TCR:   0x%lx\n",
+                gMmuConfig.tcr);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    MAIR:  0x%lx\n",
+                gMmuConfig.mair);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    SCTLR: 0x%lx\n",
+                gMmuConfig.sctlr);
 
   if (!SkipTtbr1)
-    acs_print(ACS_PRINT_DEBUG, L"    TTBR1: 0x%lx\n", gMmuConfig.ttbr1);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  "    TTBR1: 0x%lx\n",
+                  gMmuConfig.ttbr1);
 
   /* Clean cache to ensure secondary PEs see the config */
   pal_pe_data_cache_ops_by_va((UINT64)&gMmuConfig, CLEAN_AND_INVALIDATE);
@@ -314,7 +339,9 @@ PalAllocateSecondaryStack(UINT64 mpidr)
                     StackSize,
                     (VOID **) &Buffer);
       if (EFI_ERROR(Status)) {
-          acs_print(ACS_PRINT_ERR, L"\n FATAL - Allocation for Seconday stack failed %x\n", Status);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "\n FATAL - Allocation for Seconday stack failed %x\n",
+                        Status);
       }
       pal_pe_data_cache_ops_by_va((UINT64)&Buffer, CLEAN_AND_INVALIDATE);
 
@@ -352,7 +379,8 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
   UINT32                        i;
 
   if (PeTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input PE Table Pointer is NULL. Cannot create PE INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input PE Table Pointer is NULL. Cannot create PE INFO\n");
     return;
   }
 
@@ -363,9 +391,13 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
-    acs_print(ACS_PRINT_INFO, L"  MADT is at %x and length is %x\n", gMadtHdr, TableLength);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "  MADT is at %x and length is %x\n",
+                  gMadtHdr,
+                  TableLength);
   } else {
-    acs_print(ACS_PRINT_ERR, L" MADT not found\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " MADT not found\n");
     return;
   }
 
@@ -378,8 +410,13 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
     if (Entry->Type == EFI_ACPI_6_1_GIC) {
       //Fill in the cpu num and the mpidr in pe info table
       Flags           = Entry->Flags;
-      acs_print(ACS_PRINT_INFO, L"  Flags %x\n", Flags);
-      acs_print(ACS_PRINT_DEBUG, L"  PE Enabled %d, Online Capable %d\n", ENABLED_BIT(Flags), ONLINE_CAP_BIT(Flags));
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Flags %x\n",
+                    Flags);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  PE Enabled %d, Online Capable %d\n",
+                    ENABLED_BIT(Flags),
+                    ONLINE_CAP_BIT(Flags));
 
       /* As per MADT (GICC CPU Interface Flags) Processor is usable when
            Enabled bit is set
@@ -404,11 +441,16 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
               Ptr->trbe_interrupt = ((EFI_ACPI_6_5_GIC_STRUCTURE *)
                                      ((UINT8 *)Entry))->TrbeInterrupt;
 
-          acs_print(ACS_PRINT_DEBUG, L"  MADT Revision %llx \n", gMadtHdr->Header.Revision);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  MADT Revision %llx \n",
+                        gMadtHdr->Header.Revision);
 
           for (i = 0; i < MAX_L1_CACHE_RES; i++)
               Ptr->level_1_res[i] = DEFAULT_CACHE_IDX; //initialize cache index fields with all 1's
-          acs_print(ACS_PRINT_DEBUG, L" MPIDR %llx PE num %x\n", Ptr->mpidr, Ptr->pe_num);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        " MPIDR %llx PE num %x\n",
+                        Ptr->mpidr,
+                        Ptr->pe_num);
           pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
           Ptr++;
           PeTable->header.num_of_pe++;

--- a/pal/uefi_acpi/src/pal_peripherals.c
+++ b/pal/uefi_acpi/src/pal_peripherals.c
@@ -59,8 +59,8 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE *spcr = NULL;
 
   if (peripheralInfoTable == NULL) {
-    acs_print(ACS_PRINT_ERR,
-              L" Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
     return;
   }
 
@@ -86,8 +86,9 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           }
           per_info->bdf   = DeviceBdf;
           per_info->platform_type = PLATFORM_TYPE_ACPI;
-          acs_print(ACS_PRINT_INFO, L"  Found a USB controller %4x\n",
-                                                            per_info->base0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Found a USB controller %4x\n",
+                        per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -111,8 +112,9 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           }
           per_info->bdf   = DeviceBdf;
           per_info->platform_type = PLATFORM_TYPE_ACPI;
-          acs_print(ACS_PRINT_INFO, L"  Found a SATA controller %4x\n",
-                                                            per_info->base0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Found a SATA controller %4x\n",
+                        per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -143,8 +145,12 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
     per_info++;
   }
   else {
-    acs_print(ACS_PRINT_DEBUG, L"  WARNING:SPCR acpi table not found\n", 0);
-    acs_print(ACS_PRINT_DEBUG, L"  UEFI console setting must be set to serial\n", 0);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  "  WARNING:SPCR acpi table not found\n",
+                  0);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  "  UEFI console setting must be set to serial\n",
+                  0);
   }
 
   if (PLATFORM_GENERIC_UART_BASE) {
@@ -277,7 +283,8 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   UINT32                Index, i = 0;
 
   if (memoryInfoTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
     return;
   }
 
@@ -303,9 +310,12 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   if (!EFI_ERROR (Status)) {
     MemoryMapPtr = MemoryMap;
     for (Index = 0; Index < (MemoryMapSize / DescriptorSize); Index++) {
-          acs_print(ACS_PRINT_INFO, L"  Reserved region of type %d [0x%lX, 0x%lX]\n",
-            MemoryMapPtr->Type, (UINTN)MemoryMapPtr->PhysicalStart,
-            (UINTN)(MemoryMapPtr->PhysicalStart + MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE));
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Reserved region of type %d [0x%lX, 0x%lX]\n",
+                        MemoryMapPtr->Type,
+                        (UINTN)MemoryMapPtr->PhysicalStart,
+                        (UINTN)(MemoryMapPtr->PhysicalStart +
+                                MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE));
       if (IsUefiMemory ((EFI_MEMORY_TYPE)MemoryMapPtr->Type)) {
         memoryInfoTable->info[i].type      = MEMORY_TYPE_RESERVED;
       } else {
@@ -328,7 +338,9 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
       memoryInfoTable->info[i].size      = (MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE);
       i++;
       if (i >= MEM_INFO_TBL_MAX_ENTRY) {
-        acs_print(ACS_PRINT_DEBUG, L"  Memory Info tbl limit exceeded, Skipping remaining\n", 0);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  Memory Info tbl limit exceeded, Skipping remaining\n",
+                      0);
         break;
       }
 
@@ -361,7 +373,9 @@ pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance)
   Status = gDS->GetMemorySpaceMap(&NumberOfDescriptors, &MemorySpaceMap);
   if (Status != EFI_SUCCESS)
   {
-    acs_print(ACS_PRINT_ERR, L" Failed to get GCD memory with error: %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Failed to get GCD memory with error: %x\n",
+                  Status);
     if (Status == EFI_NO_MAPPING)
     {
         return MEM_MAP_NO_MEM;
@@ -380,7 +394,9 @@ pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance)
         if (*addr == 0)
           continue;
 
-        acs_print(ACS_PRINT_INFO, L" Unpopulated region with base address 0x%lX found\n", *addr);
+        pal_print_msg(ACS_PRINT_INFO,
+                      " Unpopulated region with base address 0x%lX found\n",
+                      *addr);
         return MEM_MAP_SUCCESS;
       }
 

--- a/pal/uefi_acpi/src/pal_pmu.c
+++ b/pal/uefi_acpi/src/pal_pmu.c
@@ -47,17 +47,28 @@ pal_pmu_dump_info_table(PMU_INFO_TABLE *PmuTable)
   }
 
   for (i = 0; i < PmuTable->pmu_count; i++) {
-      acs_print(ACS_PRINT_INFO, L"\nPMU info Index      :%d ", i);
-      acs_print(ACS_PRINT_INFO, L"\nPMU node type       :%02X ", PmuTable->info[i].type);
-      acs_print(ACS_PRINT_INFO, L"\nDual page extension :%d ",
-                 PmuTable->info[i].dual_page_extension);
-      acs_print(ACS_PRINT_INFO, L"\nBase Address 0      :%llX ", PmuTable->info[i].base0);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nPMU info Index      :%d ",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nPMU node type       :%02X ",
+                    PmuTable->info[i].type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nDual page extension :%d ",
+                    PmuTable->info[i].dual_page_extension);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nBase Address 0      :%llX ",
+                    PmuTable->info[i].base0);
       if(PmuTable->info[i].dual_page_extension)
-          acs_print(ACS_PRINT_INFO, L"\nBase Address 1      :%llX ", PmuTable->info[i].base1);
-      acs_print(ACS_PRINT_INFO, L"\nPrimary Instance    :%llX ",
-                 PmuTable->info[i].primary_instance);
-      acs_print(ACS_PRINT_INFO, L"\nSecondary Instance  :%08X ",
-                 PmuTable->info[i].secondary_instance);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "\nBase Address 1      :%llX ",
+                        PmuTable->info[i].base1);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nPrimary Instance    :%llX ",
+                    PmuTable->info[i].primary_instance);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\nSecondary Instance  :%08X ",
+                    PmuTable->info[i].secondary_instance);
 
   }
 }
@@ -77,7 +88,8 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
   APMT_NODE *apmt_node, *apmt_end;
 
   if (PmuTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L"\n Input PMU Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input PMU Table Pointer is NULL");
       return;
   }
 
@@ -86,7 +98,8 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
 
   apmt = (APMT_TABLE *)pal_get_apmt_ptr();
   if (apmt == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" APMT table not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " APMT table not found\n");
       return;
   }
 
@@ -104,8 +117,9 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
       PmuTable->info[PmuTable->pmu_count].secondary_instance = apmt_node->secondary_instance;
       PmuTable->pmu_count++;
       if (PmuTable->pmu_count >= MAX_NUM_OF_PMU_SUPPORTED) {
-          acs_print(ACS_PRINT_WARN, L"\n Number of PMUs greater than %d",
-                     MAX_NUM_OF_PMU_SUPPORTED);
+          pal_print_msg(ACS_PRINT_WARN,
+                        "\n Number of PMUs greater than %d",
+                        MAX_NUM_OF_PMU_SUPPORTED);
           break;
       }
       apmt_node = ADD_PTR(APMT_NODE, apmt_node, apmt_node->length);

--- a/pal/uefi_acpi/src/pal_pptt.c
+++ b/pal/uefi_acpi/src/pal_pptt.c
@@ -47,27 +47,50 @@ pal_cache_dump_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable)
 
   /*Iterate cache info table and print cache info entries*/
   for (i = 0 ; i < CacheTable->num_of_cache ; i++) {
-    acs_print(ACS_PRINT_INFO, L"\nCache info * Index %d *", i);
-    acs_print(ACS_PRINT_INFO, L"\n  Offset:                  0x%llx", curr_entry->my_offset);
-    acs_print(ACS_PRINT_INFO, L"\n  Type:                    0x%llx", curr_entry->cache_type);
-    acs_print(ACS_PRINT_INFO, L"\n  Cache ID:                0x%llx", curr_entry->cache_id);
-    acs_print(ACS_PRINT_INFO, L"\n  Size:                    0x%llx", curr_entry->size);
-    acs_print(ACS_PRINT_INFO, L"\n  Next level index:        %d", curr_entry->next_level_index);
-    acs_print(ACS_PRINT_INFO, L"\n  Private flag:            0x%llx", curr_entry->is_private);
-    acs_print(ACS_PRINT_INFO, L"\n  Associativity:           0x%llx\n", curr_entry->associativity);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nCache info * Index %d *",
+                  i);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Offset:                  0x%llx",
+                  curr_entry->my_offset);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Type:                    0x%llx",
+                  curr_entry->cache_type);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Cache ID:                0x%llx",
+                  curr_entry->cache_id);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Size:                    0x%llx",
+                  curr_entry->size);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Next level index:        %d",
+                  curr_entry->next_level_index);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Private flag:            0x%llx",
+                  curr_entry->is_private);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Associativity:           0x%llx\n",
+                  curr_entry->associativity);
     curr_entry++;
   }
 
-  acs_print(ACS_PRINT_INFO, L"\nPE level one cache index info");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nPE level one cache index info");
   /*Iterate PE info table and print level one cache index info*/
   for (i = 0 ; i < PeTable->header.num_of_pe; i++) {
-    acs_print(ACS_PRINT_INFO, L"\nPE Index * %d *", i);
-    acs_print(ACS_PRINT_INFO, L"\n  Level 1 Cache index(s) :");
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\nPE Index * %d *",
+                  i);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n  Level 1 Cache index(s) :");
 
     for (j = 0; j < MAX_L1_CACHE_RES && pe_entry->level_1_res[j] != DEFAULT_CACHE_IDX; j++) {
-      acs_print(ACS_PRINT_INFO, L" %d,", pe_entry->level_1_res[j]);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %d,",
+                    pe_entry->level_1_res[j]);
     }
-    acs_print(ACS_PRINT_INFO, L"\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n");
     pe_entry++;
   }
 }
@@ -161,8 +184,9 @@ pal_cache_store_pe_res(PE_INFO_TABLE *PeTable, UINT32 acpi_uid,
     }
   }
   else
-    acs_print(ACS_PRINT_ERR,
-      L"\n  The input resource index is greater than supported value %d", MAX_L1_CACHE_RES);
+    pal_print_msg(ACS_PRINT_ERR,
+                  "\n  The input resource index is greater than supported value %d",
+                  MAX_L1_CACHE_RES);
 }
 
 
@@ -187,7 +211,8 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
   UINT32 next_index;
 
   if (CacheTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Unable to create cache info table, input pointer is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Unable to create cache info table, input pointer is NULL\n");
     return;
   }
 
@@ -196,13 +221,16 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
 
   PpttHdr = (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_HEADER *) pal_get_pptt_ptr();
   if (PpttHdr == NULL) {
-    acs_print(ACS_PRINT_ERR, L" PPTT Table not found\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " PPTT Table not found\n");
     return;
   }
   else {
     TableLength = PpttHdr->Header.Length;
-    acs_print(ACS_PRINT_INFO, L"PPTT table found at 0x%llx with length 0x%x\n",
-               PpttHdr, TableLength);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "PPTT table found at 0x%llx with length 0x%x\n",
+                  PpttHdr,
+                  TableLength);
   }
 
 /* Pointer to first PPTT structure in PPTT ACPI table */

--- a/pal/uefi_acpi/src/pal_ras.c
+++ b/pal/uefi_acpi/src/pal_ras.c
@@ -121,48 +121,78 @@ pal_ras_dump_info_table(RAS_INFO_TABLE *RasInfoTable)
       return;
   }
 
-  acs_print(ACS_PRINT_INFO, L"\nRAS Info :");
-  acs_print(ACS_PRINT_INFO, L"\nRAS Num Nodes : %d ", RasInfoTable->num_nodes);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nRAS Info :");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\nRAS Num Nodes : %d ",
+                RasInfoTable->num_nodes);
 
   curr = &(RasInfoTable->node[0]);
 
   for (i = 0; i < RasInfoTable->num_nodes; i++) {
-      acs_print(ACS_PRINT_INFO, L"\n Index    : %d ", i);
-      acs_print(ACS_PRINT_INFO, L"\n Type     : 0x%x ", curr->type);
-      acs_print(ACS_PRINT_INFO, L"\n Num Intr : 0x%x ", curr->num_intr_entries);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Index    : %d ",
+                    i);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Type     : 0x%x ",
+                    curr->type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Num Intr : 0x%x ",
+                    curr->num_intr_entries);
 
       switch (curr->type) {
        case NODE_TYPE_PE:
            /* Print Processor Node Details */
-           acs_print(ACS_PRINT_INFO, L"\n ProcessorID : 0x%x ", curr->node_data.pe.processor_id);
-           acs_print(ACS_PRINT_INFO, L"\n resource_type : 0x%x ",
-                                      curr->node_data.pe.resource_type);
-           acs_print(ACS_PRINT_INFO, L"\n flags : 0x%x ", curr->node_data.pe.flags);
-           acs_print(ACS_PRINT_INFO, L"\n affinity : 0x%x ", curr->node_data.pe.affinity);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n ProcessorID : 0x%x ",
+                         curr->node_data.pe.processor_id);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n resource_type : 0x%x ",
+                         curr->node_data.pe.resource_type);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n flags : 0x%x ",
+                         curr->node_data.pe.flags);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n affinity : 0x%x ",
+                         curr->node_data.pe.affinity);
            break;
        case NODE_TYPE_MC:
            /* Print Memory Controller Node Details */
-           acs_print(ACS_PRINT_INFO, L"\n proximity_domain : 0x%x ",
-                                      curr->node_data.mc.proximity_domain);
+           pal_print_msg(ACS_PRINT_INFO,
+                         "\n proximity_domain : 0x%x ",
+                         curr->node_data.mc.proximity_domain);
            break;
        default:
            break;
       }
 
-      acs_print(ACS_PRINT_INFO, L"\n Interface Info :");
-      acs_print(ACS_PRINT_INFO, L"\n  type    : 0x%x ", curr->intf_info.intf_type);
-      acs_print(ACS_PRINT_INFO, L"\n  base    : 0x%x ", curr->intf_info.base_addr);
-      acs_print(ACS_PRINT_INFO, L"\n  num_err : 0x%x ", curr->intf_info.num_err_rec);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Interface Info :");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  type    : 0x%x ",
+                    curr->intf_info.intf_type);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  base    : 0x%x ",
+                    curr->intf_info.base_addr);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n  num_err : 0x%x ",
+                    curr->intf_info.num_err_rec);
 
-      acs_print(ACS_PRINT_INFO, L"\n Interrupt Info :");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Interrupt Info :");
       for (j = 0; j < curr->num_intr_entries; j++) {
-        acs_print(ACS_PRINT_INFO, L"\n  type    : 0x%x ", curr->intr_info[j].type);
-        acs_print(ACS_PRINT_INFO, L"\n  gsiv    : 0x%x ", curr->intr_info[j].gsiv);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  type    : 0x%x ",
+                      curr->intr_info[j].type);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  gsiv    : 0x%x ",
+                      curr->intr_info[j].gsiv);
       }
 
       curr++;
   }
-  acs_print(ACS_PRINT_INFO, L"\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n");
 }
 
 void fill_node_specific_data (
@@ -261,7 +291,8 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
   RAS_NODE_INFO *curr_node;
 
   if (RasInfoTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L"\n Input RAS Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -272,13 +303,15 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
 
   aest = (EFI_ACPI_ARM_ERROR_SOURCE_TABLE *)pal_get_aest_ptr();
   if (aest == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" AEST table not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " AEST table not found\n");
       return;
   }
 
   if (aest->Header.Revision == 2) {
-      acs_print(ACS_PRINT_WARN, L" NOT_SUPPORTED: AEST Revision %d detected.\n",
-                                  aest->Header.Revision);
+      pal_print_msg(ACS_PRINT_WARN,
+                    " NOT_SUPPORTED: AEST Revision %d detected.\n",
+                    aest->Header.Revision);
       return;
   }
 
@@ -309,8 +342,9 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
       RasInfoTable->num_nodes++;
 
       if (RasInfoTable->num_nodes >= MAX_NUM_OF_RAS_SUPPORTED) {
-          acs_print(ACS_PRINT_WARN, L"\n Number of RAS nodes greater than %d",
-                     MAX_NUM_OF_RAS_SUPPORTED);
+          pal_print_msg(ACS_PRINT_WARN,
+                        "\n Number of RAS nodes greater than %d",
+                        MAX_NUM_OF_RAS_SUPPORTED);
           break;
       }
 
@@ -335,37 +369,44 @@ pal_ras2_dump_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   RAS2_BLOCK *curr_block;
 
   if (RasFeatInfoTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L"\n Input RAS Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input RAS Table Pointer is NULL");
       return;
   }
 
   curr_block = RasFeatInfoTable->blocks;
   UINT32 i;
 
-  acs_print(ACS_PRINT_INFO, L"\n RAS2 Feature Info :");
-  acs_print(ACS_PRINT_INFO,
-             L"\n Total number of RAS2 feature info blocks  : %d",
-             RasFeatInfoTable->num_all_block);
-  acs_print(ACS_PRINT_INFO,
-             L"\n Number of RAS2 memory feature info blocks : %d\n",
-             RasFeatInfoTable->num_of_mem_block);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n RAS2 Feature Info :");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n Total number of RAS2 feature info blocks  : %d",
+                RasFeatInfoTable->num_all_block);
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n Number of RAS2 memory feature info blocks : %d\n",
+                RasFeatInfoTable->num_of_mem_block);
 
   /*Iterate RAS2 feature info table and print info fields */
   for (i = 0 ; i < RasFeatInfoTable->num_all_block ; i++) {
-    acs_print(ACS_PRINT_INFO, L"\n RAS2 feature info * Index %d *", i);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "\n RAS2 feature info * Index %d *",
+                  i);
     switch(curr_block->type) {
     case RAS2_FEATURE_TYPE_MEMORY:
-        acs_print(ACS_PRINT_INFO, L"\n  Type                            : 0x%x",
-                   curr_block->type);
-        acs_print(ACS_PRINT_INFO, L"\n  Proximity Domain                : 0x%llx",
-                   curr_block->block_info.mem_feat_info.proximity_domain);
-        acs_print(ACS_PRINT_INFO, L"\n  Patrol scrub support            : 0x%lx\n",
-                   curr_block->block_info.mem_feat_info.patrol_scrub_support);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Type                            : 0x%x",
+                      curr_block->type);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Proximity Domain                : 0x%llx",
+                      curr_block->block_info.mem_feat_info.proximity_domain);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Patrol scrub support            : 0x%lx\n",
+                      curr_block->block_info.mem_feat_info.patrol_scrub_support);
         break;
     default:
-        acs_print(ACS_PRINT_INFO,
-             L"\n  Invalid RAS feature type : 0x%x",
-                   curr_block->type);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "\n  Invalid RAS feature type : 0x%x",
+                      curr_block->type);
     }
     curr_block++;
   }
@@ -422,7 +463,9 @@ VOID pal_ras2_fill_mem_pcct_info(
   }
 
   if (ras2_pcc_shared_mem == NULL) {
-      acs_print(ACS_PRINT_ERR, L"\n No PCC subspace found for PCCT index : 0x%x", pcct_array_idx);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n No PCC subspace found for PCCT index : 0x%x",
+                    pcct_array_idx);
       return;
   }
 
@@ -448,7 +491,8 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   UINT8 pcct_array_idx;
 
   if (RasFeatInfoTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L"\n Input RAS Table Pointer is NULL");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -458,14 +502,16 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
 
   ras2 = (RAS_FEATURE_2_TABLE_HEADER *)pal_get_acpi_table_ptr(EFI_ACPI_6_5_RAS2_FEATURE_TABLE_SIGNATURE);
   if (ras2 == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" RAS2 ACPI table not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " RAS2 ACPI table not found\n");
       return;
   }
 
   pcct = (EFI_ACPI_6_4_PLATFORM_COMMUNICATION_CHANNEL_TABLE_HEADER * )
           pal_get_acpi_table_ptr(EFI_ACPI_6_4_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE);
   if (pcct == NULL) {
-      acs_print(ACS_PRINT_DEBUG, L" PCCT ACPI table not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " PCCT ACPI table not found\n");
       return;
   }
   /* pointer to the start of RAS2 PCC descriptor array */

--- a/pal/uefi_acpi/src/pal_timer_wd.c
+++ b/pal/uefi_acpi/src/pal_timer_wd.c
@@ -75,7 +75,8 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   UINTN                       el2_virt_timer_offset;
 
   if (TimerTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
     return;
   }
 
@@ -85,15 +86,20 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   gGtdtHdr = (EFI_ACPI_6_1_GENERIC_TIMER_DESCRIPTION_TABLE *) pal_get_gtdt_ptr();
 
   if (gGtdtHdr == NULL) {
-    acs_print(ACS_PRINT_ERR, L" GTDT not found\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " GTDT not found\n");
     return;
   }
   gtdt_ptr = (UINT8 *)gGtdtHdr;
-  acs_print(ACS_PRINT_INFO, L"  GTDT is at %x and length is %x\n",
-           gGtdtHdr, gGtdtHdr->Header.Length);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  GTDT is at %x and length is %x\n",
+                gGtdtHdr,
+                gGtdtHdr->Header.Length);
 
   revision = gGtdtHdr->Header.Revision;
-  acs_print(ACS_PRINT_INFO, L"  GTDT revision is at %d\n", revision);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  GTDT revision is at %d\n",
+                revision);
 
   //Fill in our internal table
   TimerTable->header.s_el1_timer_flag  = gGtdtHdr->SecurePL1TimerFlags;
@@ -116,15 +122,19 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   while(num_of_entries) {
 
     if (Entry->Type == EFI_ACPI_6_1_GTDT_GT_BLOCK) {
-      acs_print(ACS_PRINT_INFO, L"  Found block entry\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Found block entry\n");
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
-      acs_print(ACS_PRINT_DEBUG, L"  CNTCTLBase = %llx\n", GtEntry->block_cntl_base);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  CNTCTLBase = %llx\n",
+                    GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)
                         (((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
-        acs_print(ACS_PRINT_INFO, L"  Found timer entry\n");
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  Found timer entry\n");
         GtEntry->frame_num[i]    = GtBlockTimer->GTFrameNumber;
         GtEntry->GtCntBase[i]    = GtBlockTimer->CntBaseX;
         GtEntry->GtCntEl0Base[i] = GtBlockTimer->CntEL0BaseX;
@@ -133,8 +143,10 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
         GtEntry->flags[i]        = GtBlockTimer->GTxPhysicalTimerFlags |
                                    (GtBlockTimer->GTxVirtualTimerFlags << 8) |
                                    (GtBlockTimer->GTxCommonFlags << 16);
-        acs_print(ACS_PRINT_DEBUG, L"  CNTBaseN = %llx for sys counter = %d\n",
-                                                     GtEntry->GtCntBase[i], i);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  CNTBaseN = %llx for sys counter = %d\n",
+                      GtEntry->GtCntBase[i],
+                      i);
         GtBlockTimer++;
         TimerTable->header.num_platform_timer++;
       }
@@ -158,7 +170,8 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
             sizeof(UINT32));
       }
       if (TimerTable->header.el2_virt_timer_gsiv == 0)
-         acs_print(ACS_PRINT_DEBUG, L"  GTDT don't have el2 virt timer info\n");
+         pal_print_msg(ACS_PRINT_DEBUG,
+                       "  GTDT don't have el2 virt timer info\n");
   }
   else
       pal_timer_platform_override(TimerTable);
@@ -206,8 +219,8 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
   UINT32                      num_of_entries;
 
   if (WdTable == NULL) {
-    acs_print(ACS_PRINT_ERR,
-              L" Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
     return;
   }
 
@@ -216,7 +229,8 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
   gGtdtHdr = (EFI_ACPI_6_1_GENERIC_TIMER_DESCRIPTION_TABLE *) pal_get_gtdt_ptr();
 
   if (gGtdtHdr == NULL) {
-    acs_print(ACS_PRINT_ERR, L" GTDT not found\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " GTDT not found\n");
     return;
   }
 
@@ -239,8 +253,10 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_gsiv         = Entry->WatchdogTimerGSIV;
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
-      acs_print(ACS_PRINT_DEBUG, L"  Watchdog base = 0x%llx INTID = 0x%x\n",
-                                      WdEntry->wd_ctrl_base, WdEntry->wd_gsiv);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Watchdog base = 0x%llx INTID = 0x%x\n",
+                    WdEntry->wd_ctrl_base,
+                    WdEntry->wd_gsiv);
       WdEntry++;
     }
     Entry = (EFI_ACPI_6_1_GTDT_SBSA_GENERIC_WATCHDOG_STRUCTURE *)

--- a/pal/uefi_acpi/src/pal_tpm2.c
+++ b/pal/uefi_acpi/src/pal_tpm2.c
@@ -49,7 +49,9 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   UINT64 TpmPresent, status_flag = 0;
 
   if (Tpm2InfoTable == NULL) {
-      acs_print(ACS_PRINT_ERR, L" TPM2 Info Table pointer is NULL. Cannot create TPM2 info.\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    " TPM2 Info Table pointer is NULL. Cannot create TPM2 info.\n",
+                    0);
       return;
   }
 
@@ -61,14 +63,18 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   /* Locate TCG2 protocol */
   Status = gBS->LocateProtocol(&gEfiTcg2ProtocolGuid, NULL, (VOID **)&Tcg2);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR, L" TCG2 Protocol Not Found\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    " TCG2 Protocol Not Found\n",
+                    0);
       status_flag = 1;
   }
 
   /* Get pointer to TPM2 ACPI table */
   gtpm2ptr = (EFI_TPM2_ACPI_TABLE *)pal_get_tpm2_ptr();
   if (gtpm2ptr == NULL) {
-      acs_print(ACS_PRINT_ERR, L" TPM2 ACPI Table not found\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    " TPM2 ACPI Table not found\n",
+                    0);
       status_flag = 1;
   }
 
@@ -80,9 +86,9 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   Capability.Size = sizeof(EFI_TCG2_BOOT_SERVICE_CAPABILITY);
   Status = Tcg2->GetCapability(Tcg2, &Capability);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR,
-                L" Failed to retrieve TPM capability from TCG2 protocol, Status: 0x%x\n",
-                Status);
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Failed to retrieve TPM capability from TCG2 protocol, Status: 0x%x\n",
+                    Status);
       return;
   }
 
@@ -95,10 +101,15 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   Tpm2InfoTable->base = gtpm2ptr->AddressOfControlArea;
 
   /* Log TPM presence and configuration */
-  acs_print(ACS_PRINT_INFO, L" TPM2 Protocol Present\n", 0);
-  acs_print(ACS_PRINT_TEST, L" TPM2 Interface Type (StartMethod): %llx\n",
-                                                 Tpm2InfoTable->tpm_interface);
-  acs_print(ACS_PRINT_TEST, L" TPM2 Base Address: %llx\n", Tpm2InfoTable->base);
+  pal_print_msg(ACS_PRINT_INFO,
+                " TPM2 Protocol Present\n",
+                0);
+  pal_print_msg(ACS_PRINT_TEST,
+                " TPM2 Interface Type (StartMethod): %llx\n",
+                Tpm2InfoTable->tpm_interface);
+  pal_print_msg(ACS_PRINT_TEST,
+                " TPM2 Base Address: %llx\n",
+                Tpm2InfoTable->base);
 
 
   return;
@@ -131,14 +142,18 @@ pal_tpm2_get_version()
   /* Locate the TCG2 protocol */
   Status = gBS->LocateProtocol(&gEfiTcg2ProtocolGuid, NULL, (VOID **)&Tcg2);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR, L"       TCG2 Protocol Not Found\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "       TCG2 Protocol Not Found\n",
+                    0);
       return Status;
   }
 
   /* Allocate temporary buffer for capability data */
   Status = gBS->AllocatePool(EfiBootServicesData, TempBufferSize, (VOID **)&TempBuffer);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR, L"       Failed to allocate memory for TPM capability data.\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "       Failed to allocate memory for TPM capability data.\n",
+                    0);
       return Status;
   }
 
@@ -162,14 +177,17 @@ pal_tpm2_get_version()
                               (UINT8 *)&RecvBuffer);
 
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_ERR, L"       TPM2 command submission failed\n", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "       TPM2 command submission failed\n",
+                    0);
       return Status;
   }
 
   /* Check response status */
   if (SwapBytes32 (RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
-      acs_print(ACS_PRINT_ERR, L"       Tpm2GetCapability failed: Response Code error! 0x%08x\n",
-             SwapBytes32 (RecvBuffer.Header.responseCode));
+      pal_print_msg(ACS_PRINT_ERR,
+                    "       Tpm2GetCapability failed: Response Code error! 0x%08x\n",
+                    SwapBytes32 (RecvBuffer.Header.responseCode));
       return Status;
   }
 
@@ -179,15 +197,21 @@ pal_tpm2_get_version()
 
 
   PropertyCount = SwapBytes32(cap_data->data.tpmProperties.count);
-  acs_print(ACS_PRINT_INFO, L"      TPM Property Count: %d\n", PropertyCount);
+  pal_print_msg(ACS_PRINT_INFO,
+                "      TPM Property Count: %d\n",
+                PropertyCount);
 
   /* Search for TPM_PT_FAMILY_INDICATOR */
   for (UINT32 i = 0; i < PropertyCount; i++) {
       UINT32 PropertyId  = SwapBytes32(cap_data->data.tpmProperties.tpmProperty[i].property);
       UINT32 PropertyVal = cap_data->data.tpmProperties.tpmProperty[i].value;
 
-      acs_print(ACS_PRINT_INFO, L"       TPM Property ID   : 0x%08x\n", PropertyId);
-      acs_print(ACS_PRINT_INFO, L"       TPM Property Value: 0x%08x\n", PropertyVal);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "       TPM Property ID   : 0x%08x\n",
+                    PropertyId);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "       TPM Property Value: 0x%08x\n",
+                    PropertyVal);
 
 
       if (PropertyId == TPM_PT_FAMILY_INDICATOR) {
@@ -195,7 +219,9 @@ pal_tpm2_get_version()
 
           CopyMem(family, &PropertyVal, 4);
           family[4] = '\0';
-          acs_print(ACS_PRINT_TEST, L"       TPM Family: %a\n", family);
+          pal_print_msg(ACS_PRINT_TEST,
+                        "       TPM Family: %a\n",
+                        family);
 
           FreePool(TempBuffer);
 

--- a/pal/uefi_dt/include/pal_uefi.h
+++ b/pal/uefi_dt/include/pal_uefi.h
@@ -73,9 +73,6 @@ typedef struct {
   UINT64   Arg7;
 } ARM_SMC_ARGS;
 
-#define acs_print(verbose, string, ...) \
-    PAL_PRINT_FORMAT((verbose), (string), ##__VA_ARGS__)
-
 /**
   Conduits for service calls (SMC vs HVC).
 **/

--- a/pal/uefi_dt/src/pal_acpi.c
+++ b/pal/uefi_dt/src/pal_acpi.c
@@ -90,7 +90,8 @@ pal_get_madt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_INFO, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -124,7 +125,8 @@ pal_get_gtdt_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_INFO, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -157,7 +159,8 @@ pal_get_mcfg_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_INFO, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    " XSDT not found\n");
       return 0;
   }
 
@@ -222,7 +225,8 @@ pal_get_iort_ptr()
 
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
-      acs_print(ACS_PRINT_INFO, L" XSDT not found\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    " XSDT not found\n");
       return 0;
   }
 

--- a/pal/uefi_dt/src/pal_dt.c
+++ b/pal/uefi_dt/src/pal_dt.c
@@ -49,11 +49,13 @@ pal_target_is_dt()
   // Find the interrupt controller protocol.
   Status = gBS->LocateProtocol (&gHardwareInterruptProtocolGuid, NULL, (VOID **)&Interrupt);
   if (EFI_ERROR(Status)) {
-      acs_print(ACS_PRINT_INFO, L"  Using ACS interrupt API's\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Using ACS interrupt API's\n");
       return 1; /* Not able to locate HW Interrupt Protocol, use ACS interrupt handlers API */
   }
   else {
-      acs_print(ACS_PRINT_INFO, L"  Using F/W interrupt API's\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Using F/W interrupt API's\n");
       return 0; /* Use F/W interrupt handlers */
   }
 }
@@ -74,18 +76,22 @@ pal_get_dt_ptr()
   for (Index = 0; Index < gST->NumberOfTableEntries; Index++) {
     if (CompareGuid (&gFdtTableGuid, &(gST->ConfigurationTable[Index].VendorGuid))) {
       DTB = gST->ConfigurationTable[Index].VendorTable;
-      acs_print(ACS_PRINT_DEBUG, L"  Platform DTB PTR %x\n", DTB);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Platform DTB PTR %x\n",
+                    DTB);
       break;
     }
   }
 
   if (!DTB) {
-    acs_print(ACS_PRINT_ERR, L" DTB not present in platform\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " DTB not present in platform\n");
     return 0; //No fdt blob addr found
   }
 
   if (fdt_check_header(DTB)) {
-    acs_print(ACS_PRINT_ERR, L" fdt hdr check failed\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " fdt hdr check failed\n");
     return 0;
   }
 
@@ -144,7 +150,8 @@ int fdt_interrupt_cells(const void *fdt, int nodeoffset)
   } while (nodeoffset >= 0);
 
   if (nodeoffset < 0) {
-      acs_print(ACS_PRINT_DEBUG, L"  No interrupt cell found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  No interrupt cell found\n");
       return 3; /* default value 3*/
   }
 
@@ -198,11 +205,13 @@ pal_dump_dtb()
 
     BufferSize = fdt_totalsize(dtb);
     if (!BufferSize) {
-        acs_print(ACS_PRINT_ERR, L" dtb size 0\n");
+        pal_print_msg(ACS_PRINT_ERR,
+                      " dtb size 0\n");
         return;
     }
     Status = ShellWriteFile(g_dtb_log_file_handle, &BufferSize, (VOID *)dtb);
     if (EFI_ERROR(Status))
-      acs_print(ACS_PRINT_ERR, L" Error in writing to dtb log file\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Error in writing to dtb log file\n");
   }
 }

--- a/pal/uefi_dt/src/pal_dt_debug.c
+++ b/pal/uefi_dt/src/pal_dt_debug.c
@@ -33,22 +33,37 @@ dt_dump_pe_table(PE_INFO_TABLE *PeTable)
   UINT32 Index = 0;
 
   if (!PeTable) {
-    acs_print(ACS_PRINT_ERR, L" PeTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " PeTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************PE TABLE DUMP************\n");
-  acs_print(ACS_PRINT_DEBUG, L" NUM PE %d\n", PeTable->header.num_of_pe);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************PE TABLE DUMP************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " NUM PE %d\n",
+                PeTable->header.num_of_pe);
 
   while (Index < PeTable->header.num_of_pe) {
-    acs_print(ACS_PRINT_DEBUG, L" PE NUM      :%x\n", PeTable->pe_info[Index].pe_num);
-    acs_print(ACS_PRINT_DEBUG, L" MPIDR       :%llx\n", PeTable->pe_info[Index].mpidr);
-//    acs_print(ACS_PRINT_DEBUG, L"    ATTR     :%x\n", PeTable->pe_info[Index].attr);
-    acs_print(ACS_PRINT_DEBUG, L" PMU GSIV    :%x\n", PeTable->pe_info[Index].pmu_gsiv);
-    acs_print(ACS_PRINT_DEBUG, L" GIC MAINT GSIV    :%x\n", PeTable->pe_info[Index].gmain_gsiv);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " PE NUM      :%x\n",
+                  PeTable->pe_info[Index].pe_num);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " MPIDR       :%llx\n",
+                  PeTable->pe_info[Index].mpidr);
+//    pal_print_msg(ACS_PRINT_DEBUG,
+//                  "    ATTR     :%x\n",
+//                  PeTable->pe_info[Index].attr);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " PMU GSIV    :%x\n",
+                  PeTable->pe_info[Index].pmu_gsiv);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GIC MAINT GSIV    :%x\n",
+                  PeTable->pe_info[Index].gmain_gsiv);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }
 
 /**
@@ -64,25 +79,46 @@ dt_dump_gic_table(GIC_INFO_TABLE *GicTable)
   UINT32 Index = 0;
 
   if (!GicTable) {
-    acs_print(ACS_PRINT_ERR, L" GicTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " GicTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************GIC TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" GIC version %d\n", GicTable->header.gic_version);
-  acs_print(ACS_PRINT_DEBUG, L" GIC num D %d\n", GicTable->header.num_gicd);
-  acs_print(ACS_PRINT_DEBUG, L" GIC num GICC RD %d\n", GicTable->header.num_gicc_rd);
-  acs_print(ACS_PRINT_DEBUG, L" GIC num GICR RD %d\n", GicTable->header.num_gicr_rd);
-//  acs_print(ACS_PRINT_DEBUG, L" GIC num ITS %d\n", GicTable->header.num_its);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************GIC TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " GIC version %d\n",
+                GicTable->header.gic_version);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " GIC num D %d\n",
+                GicTable->header.num_gicd);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " GIC num GICC RD %d\n",
+                GicTable->header.num_gicc_rd);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " GIC num GICR RD %d\n",
+                GicTable->header.num_gicr_rd);
+//  pal_print_msg(ACS_PRINT_DEBUG,
+//                " GIC num ITS %d\n",
+//                GicTable->header.num_its);
 
   while (GicTable->gic_info[Index].type != 0xFF) {
-    acs_print(ACS_PRINT_DEBUG, L" GIC TYPE     :%x\n", GicTable->gic_info[Index].type);
-    acs_print(ACS_PRINT_DEBUG, L" BASE         :%x\n", GicTable->gic_info[Index].base);
-    acs_print(ACS_PRINT_DEBUG, L" LEN          :%x\n", GicTable->gic_info[Index].length);
-//    acs_print(ACS_PRINT_DEBUG, L"     ITS ID   :%x\n", GicTable->gic_info[Index].entry_id);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GIC TYPE     :%x\n",
+                  GicTable->gic_info[Index].type);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " BASE         :%x\n",
+                  GicTable->gic_info[Index].base);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " LEN          :%x\n",
+                  GicTable->gic_info[Index].length);
+//    pal_print_msg(ACS_PRINT_DEBUG,
+//                  "     ITS ID   :%x\n",
+//                  GicTable->gic_info[Index].entry_id);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }
 
 /**
@@ -98,21 +134,34 @@ dt_dump_wd_table(WD_INFO_TABLE *WdTable)
   UINT32 Index = 0;
 
   if (!WdTable) {
-    acs_print(ACS_PRINT_ERR, L" WdTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " WdTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************WD TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" NUM WD %d\n", WdTable->header.num_wd);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************WD TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " NUM WD %d\n",
+                WdTable->header.num_wd);
 
   while (Index < WdTable->header.num_wd) {
-    acs_print(ACS_PRINT_DEBUG, L" REFRESH BASE  :%x\n", WdTable->wd_info[Index].wd_refresh_base);
-    acs_print(ACS_PRINT_DEBUG, L" CONTROL BASE  :%x\n", WdTable->wd_info[Index].wd_ctrl_base);
-    acs_print(ACS_PRINT_DEBUG, L" GSIV          :%x\n", WdTable->wd_info[Index].wd_gsiv);
-    acs_print(ACS_PRINT_DEBUG, L" FLAGS         :%x\n", WdTable->wd_info[Index].wd_flags);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " REFRESH BASE  :%x\n",
+                  WdTable->wd_info[Index].wd_refresh_base);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " CONTROL BASE  :%x\n",
+                  WdTable->wd_info[Index].wd_ctrl_base);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GSIV          :%x\n",
+                  WdTable->wd_info[Index].wd_gsiv);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " FLAGS         :%x\n",
+                  WdTable->wd_info[Index].wd_flags);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }
 
 /**
@@ -129,21 +178,34 @@ dt_dump_pcie_table(PCIE_INFO_TABLE *PcieTable)
   UINT32 Index = 0;
 
   if (!PcieTable) {
-    acs_print(ACS_PRINT_ERR, L" PcieTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " PcieTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************PCIE TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" NUM ECAM %d\n", PcieTable->num_entries);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************PCIE TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " NUM ECAM %d\n",
+                PcieTable->num_entries);
 
   while (Index < PcieTable->num_entries) {
-    acs_print(ACS_PRINT_DEBUG, L" ECAM BASE          :%x\n", PcieTable->block[Index].ecam_base);
-    acs_print(ACS_PRINT_DEBUG, L" START BUS          :%x\n", PcieTable->block[Index].start_bus_num);
-    acs_print(ACS_PRINT_DEBUG, L" END BUS            :%x\n", PcieTable->block[Index].end_bus_num);
-//    acs_print(ACS_PRINT_DEBUG, L"      SEGMENT NUM   :%x\n", PcieTable->block[Index].segment_num);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " ECAM BASE          :%x\n",
+                  PcieTable->block[Index].ecam_base);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " START BUS          :%x\n",
+                  PcieTable->block[Index].start_bus_num);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " END BUS            :%x\n",
+                  PcieTable->block[Index].end_bus_num);
+//    pal_print_msg(ACS_PRINT_DEBUG,
+//                  "      SEGMENT NUM   :%x\n",
+//                  PcieTable->block[Index].segment_num);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }
 
 /**
@@ -159,23 +221,40 @@ dt_dump_memory_table(MEMORY_INFO_TABLE *memoryInfoTable)
   UINT32 Index = 0;
 
   if (!memoryInfoTable) {
-    acs_print(ACS_PRINT_ERR, L" memoryInfoTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " memoryInfoTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************MEMORY TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" dram base  :%x\n", memoryInfoTable->dram_base);
-  acs_print(ACS_PRINT_DEBUG, L" dram size  :%x\n", memoryInfoTable->dram_size);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************MEMORY TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " dram base  :%x\n",
+                memoryInfoTable->dram_base);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " dram size  :%x\n",
+                memoryInfoTable->dram_size);
 
   while (memoryInfoTable->info[Index].type < 0x1004) {
-    acs_print(ACS_PRINT_DEBUG, L" Type      :%x\n", memoryInfoTable->info[Index].type);
-    acs_print(ACS_PRINT_DEBUG, L" PHY addr  :%x\n", memoryInfoTable->info[Index].phy_addr);
-    acs_print(ACS_PRINT_DEBUG, L" VIRT addr :%x\n", memoryInfoTable->info[Index].virt_addr);
-    acs_print(ACS_PRINT_DEBUG, L" size      :%x\n", memoryInfoTable->info[Index].size);
-    acs_print(ACS_PRINT_DEBUG, L" flags     :%x\n", memoryInfoTable->info[Index].flags);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " Type      :%x\n",
+                  memoryInfoTable->info[Index].type);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " PHY addr  :%x\n",
+                  memoryInfoTable->info[Index].phy_addr);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " VIRT addr :%x\n",
+                  memoryInfoTable->info[Index].virt_addr);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " size      :%x\n",
+                  memoryInfoTable->info[Index].size);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " flags     :%x\n",
+                  memoryInfoTable->info[Index].flags);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }
 
 /**
@@ -191,34 +270,73 @@ dt_dump_timer_table(TIMER_INFO_TABLE *TimerTable)
   UINT32 Index = 0;
 
   if (!TimerTable) {
-    acs_print(ACS_PRINT_ERR, L" TimerTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " TimerTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************TIMER TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" Num of system timers %d\n", TimerTable->header.num_platform_timer);
-  acs_print(ACS_PRINT_DEBUG, L" s_el1_timer_flag %x\n", TimerTable->header.s_el1_timer_flag);
-  acs_print(ACS_PRINT_DEBUG, L" ns_el1_timer_flag %x\n", TimerTable->header.ns_el1_timer_flag);
-  acs_print(ACS_PRINT_DEBUG, L" el2_timer_flag %x\n", TimerTable->header.el2_timer_flag);
-  acs_print(ACS_PRINT_DEBUG, L" el2_virt_timer_flag %x\n", TimerTable->header.el2_virt_timer_flag);
-  acs_print(ACS_PRINT_DEBUG, L" s_el1_timer_gsiv %x\n", TimerTable->header.s_el1_timer_gsiv);
-  acs_print(ACS_PRINT_DEBUG, L" ns_el1_timer_gsiv %x\n", TimerTable->header.ns_el1_timer_gsiv);
-  acs_print(ACS_PRINT_DEBUG, L" el2_timer_gsiv %x\n", TimerTable->header.el2_timer_gsiv);
-  acs_print(ACS_PRINT_DEBUG, L" virtual_timer_flag %x\n", TimerTable->header.virtual_timer_flag);
-  acs_print(ACS_PRINT_DEBUG, L" virtual_timer_gsiv %x\n", TimerTable->header.virtual_timer_gsiv);
-  acs_print(ACS_PRINT_DEBUG, L" el2_virt_timer_gsiv %x\n", TimerTable->header.el2_virt_timer_gsiv);
-  acs_print(ACS_PRINT_DEBUG, L" CNTBase             %x\n", TimerTable->gt_info->block_cntl_base);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************TIMER TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " Num of system timers %d\n",
+                TimerTable->header.num_platform_timer);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " s_el1_timer_flag %x\n",
+                TimerTable->header.s_el1_timer_flag);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ns_el1_timer_flag %x\n",
+                TimerTable->header.ns_el1_timer_flag);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " el2_timer_flag %x\n",
+                TimerTable->header.el2_timer_flag);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " el2_virt_timer_flag %x\n",
+                TimerTable->header.el2_virt_timer_flag);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " s_el1_timer_gsiv %x\n",
+                TimerTable->header.s_el1_timer_gsiv);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ns_el1_timer_gsiv %x\n",
+                TimerTable->header.ns_el1_timer_gsiv);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " el2_timer_gsiv %x\n",
+                TimerTable->header.el2_timer_gsiv);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " virtual_timer_flag %x\n",
+                TimerTable->header.virtual_timer_flag);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " virtual_timer_gsiv %x\n",
+                TimerTable->header.virtual_timer_gsiv);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " el2_virt_timer_gsiv %x\n",
+                TimerTable->header.el2_virt_timer_gsiv);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " CNTBase             %x\n",
+                TimerTable->gt_info->block_cntl_base);
 
   while (Index < TimerTable->gt_info->timer_count) {
-    acs_print(ACS_PRINT_DEBUG, L" Frame num   :%x\n", TimerTable->gt_info->frame_num[Index]);
-    acs_print(ACS_PRINT_DEBUG, L" GtCntBase   :%x\n", TimerTable->gt_info->GtCntBase[Index]);
-    acs_print(ACS_PRINT_DEBUG, L" GtCntEl0Base:%x\n", TimerTable->gt_info->GtCntEl0Base[Index]);
-    acs_print(ACS_PRINT_DEBUG, L" gsiv        :%x\n", TimerTable->gt_info->gsiv[Index]);
-    acs_print(ACS_PRINT_DEBUG, L" virt_gsiv   :%x\n", TimerTable->gt_info->virt_gsiv[Index]);
-    acs_print(ACS_PRINT_DEBUG, L" flags       :%x\n", TimerTable->gt_info->flags[Index]);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " Frame num   :%x\n",
+                  TimerTable->gt_info->frame_num[Index]);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GtCntBase   :%x\n",
+                  TimerTable->gt_info->GtCntBase[Index]);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GtCntEl0Base:%x\n",
+                  TimerTable->gt_info->GtCntEl0Base[Index]);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " gsiv        :%x\n",
+                  TimerTable->gt_info->gsiv[Index]);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " virt_gsiv   :%x\n",
+                  TimerTable->gt_info->virt_gsiv[Index]);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " flags       :%x\n",
+                  TimerTable->gt_info->flags[Index]);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }
 
 /**
@@ -234,44 +352,83 @@ dt_dump_peripheral_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   UINT32 Index = 0;
 
   if (!peripheralInfoTable) {
-    acs_print(ACS_PRINT_ERR, L" peripheralInfoTable ptr NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " peripheralInfoTable ptr NULL\n");
     return;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************USB TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" NUM USB %d\n", peripheralInfoTable->header.num_usb);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************USB TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " NUM USB %d\n",
+                peripheralInfoTable->header.num_usb);
 
   while (Index < peripheralInfoTable->header.num_usb) {
-    acs_print(ACS_PRINT_DEBUG, L" TYPE          :%x\n", peripheralInfoTable->info[Index].type);
-    acs_print(ACS_PRINT_DEBUG, L" CONTROL BASE  :%x\n", peripheralInfoTable->info[Index].base0);
-    acs_print(ACS_PRINT_DEBUG, L" GSIV          :%d\n", peripheralInfoTable->info[Index].irq);
-    acs_print(ACS_PRINT_DEBUG, L" FLAGS         :%x\n", peripheralInfoTable->info[Index].flags);
-    acs_print(ACS_PRINT_DEBUG, L" BDF           :%x\n", peripheralInfoTable->info[Index].bdf);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " TYPE          :%x\n",
+                  peripheralInfoTable->info[Index].type);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " CONTROL BASE  :%x\n",
+                  peripheralInfoTable->info[Index].base0);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GSIV          :%d\n",
+                  peripheralInfoTable->info[Index].irq);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " FLAGS         :%x\n",
+                  peripheralInfoTable->info[Index].flags);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " BDF           :%x\n",
+                  peripheralInfoTable->info[Index].bdf);
     Index++;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************SATA TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" NUM SATA %d\n", peripheralInfoTable->header.num_sata);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************SATA TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " NUM SATA %d\n",
+                peripheralInfoTable->header.num_sata);
 
   while (Index < (peripheralInfoTable->header.num_sata + peripheralInfoTable->header.num_usb)) {
-    acs_print(ACS_PRINT_DEBUG, L" TYPE          :%x\n", peripheralInfoTable->info[Index].type);
-    acs_print(ACS_PRINT_DEBUG, L" CONTROL BASE  :%x\n", peripheralInfoTable->info[Index].base0);
-    acs_print(ACS_PRINT_DEBUG, L" GSIV          :%d\n", peripheralInfoTable->info[Index].irq);
-    acs_print(ACS_PRINT_DEBUG, L" FLAGS         :%x\n", peripheralInfoTable->info[Index].flags);
-    acs_print(ACS_PRINT_DEBUG, L" BDF           :%x\n", peripheralInfoTable->info[Index].bdf);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " TYPE          :%x\n",
+                  peripheralInfoTable->info[Index].type);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " CONTROL BASE  :%x\n",
+                  peripheralInfoTable->info[Index].base0);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GSIV          :%d\n",
+                  peripheralInfoTable->info[Index].irq);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " FLAGS         :%x\n",
+                  peripheralInfoTable->info[Index].flags);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " BDF           :%x\n",
+                  peripheralInfoTable->info[Index].bdf);
     Index++;
   }
 
-  acs_print(ACS_PRINT_DEBUG, L" ************UART TABLE************\n");
-  acs_print(ACS_PRINT_DEBUG, L" NUM UART %d\n", peripheralInfoTable->header.num_uart);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " ************UART TABLE************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " NUM UART %d\n",
+                peripheralInfoTable->header.num_uart);
 
   while (Index < (peripheralInfoTable->header.num_sata + peripheralInfoTable->header.num_usb +
       peripheralInfoTable->header.num_uart)) {
-    acs_print(ACS_PRINT_DEBUG, L" TYPE          :%x\n", peripheralInfoTable->info[Index].type);
-    acs_print(ACS_PRINT_DEBUG, L" CONTROL BASE  :%x\n", peripheralInfoTable->info[Index].base0);
-    acs_print(ACS_PRINT_DEBUG, L" GSIV          :%d\n", peripheralInfoTable->info[Index].irq);
-    acs_print(ACS_PRINT_DEBUG, L" FLAGS         :%x\n", peripheralInfoTable->info[Index].flags);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " TYPE          :%x\n",
+                  peripheralInfoTable->info[Index].type);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " CONTROL BASE  :%x\n",
+                  peripheralInfoTable->info[Index].base0);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " GSIV          :%d\n",
+                  peripheralInfoTable->info[Index].irq);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  " FLAGS         :%x\n",
+                  peripheralInfoTable->info[Index].flags);
     Index++;
   }
-  acs_print(ACS_PRINT_DEBUG, L" *************************************\n");
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " *************************************\n");
 }

--- a/pal/uefi_dt/src/pal_gic.c
+++ b/pal/uefi_dt/src/pal_gic.c
@@ -85,7 +85,8 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -94,11 +95,15 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
       /* Search for GICv3 nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv3_dt_arr[i]);
       if (offset < 0) {
-        acs_print(ACS_PRINT_DEBUG, L"  GICv3 compatible value not found for index : %d\n", i);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  GICv3 compatible value not found for index : %d\n",
+                      i);
         continue; /* Search for next compatible item*/
       }
       else {
-        acs_print(ACS_PRINT_DEBUG, L"  GIC_V3: NODE Int Ctrl offset  %x\n", offset);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  GIC_V3: NODE Int Ctrl offset  %x\n",
+                      offset);
         break;
       }
   }
@@ -108,33 +113,43 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
           /* Search for GICv2 nodes*/
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv2_dt_arr[i]);
           if (offset < 0) {
-              acs_print(ACS_PRINT_DEBUG, L"  GICv2 compatible value not found for index : %d\n", i);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  GICv2 compatible value not found for index : %d\n",
+                            i);
               continue; /* Search for next compatible item*/
           }
           else {
-            acs_print(ACS_PRINT_DEBUG, L"  GIC_V2: NODE Int Ctrl offset  %x\n", offset);
+            pal_print_msg(ACS_PRINT_DEBUG,
+                          "  GIC_V2: NODE Int Ctrl offset  %x\n",
+                          offset);
             break;
           }
       }
   }
 
   if (offset < 0) {
-      acs_print(ACS_PRINT_DEBUG, L"  GIC compatible node not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  GIC compatible node not found\n");
       return;
   }
 
   /* read the interrupt property value */
   Pintr = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
   if ((prop_len < 0) || (Pintr == NULL)) {
-      acs_print(ACS_PRINT_DEBUG, L"  PROPERTY interrupts read Error %d\n",
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  PROPERTY interrupts read Error %d\n",
                     prop_len);
       return;
   }
 
   interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-  acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  interrupt_cell  %d\n",
+                interrupt_cell);
   if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell : %d\n", interrupt_cell);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid interrupt cell : %d\n",
+                    interrupt_cell);
       return;
   }
 
@@ -143,7 +158,9 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
           if (Pintr[0])
               Ptr->gmain_gsiv = fdt32_to_cpu(Pintr[1]) + PPI_OFFSET;
           else
-              acs_print(ACS_PRINT_WARN, L"  Int is not PPI\n", 0);
+              pal_print_msg(ACS_PRINT_WARN,
+                            "  Int is not PPI\n",
+                            0);
       }
       else
           Ptr->gmain_gsiv = fdt32_to_cpu(Pintr[0]) + PPI_OFFSET;
@@ -168,7 +185,8 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   UINT32                         TableLength;
 
   if (GicTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
     return;
   }
 
@@ -188,7 +206,10 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
 
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
-    acs_print(ACS_PRINT_INFO, L"  MADT is at %x and length is %x\n", gMadtHdr, TableLength);
+    pal_print_msg(ACS_PRINT_INFO,
+                  "  MADT is at %x and length is %x\n",
+                  gMadtHdr,
+                  TableLength);
   }
 
   Entry = (EFI_ACPI_6_1_GIC_STRUCTURE *) (gMadtHdr + 1);
@@ -201,7 +222,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
       if (Entry->PhysicalBaseAddress != 0) {
         GicEntry->type = ENTRY_TYPE_CPUIF;
         GicEntry->base = Entry->PhysicalBaseAddress;
-        acs_print(ACS_PRINT_INFO, L"  GIC CPUIF base %x\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC CPUIF base %x\n",
+                      GicEntry->base);
         GicEntry++;
       }
 
@@ -209,7 +232,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICC_GICRD;
         GicEntry->base = Entry->GICRBaseAddress;
         GicEntry->length = 0;
-        acs_print(ACS_PRINT_INFO, L"  GICC RD base %x\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GICC RD base %x\n",
+                      GicEntry->base);
         GicTable->header.num_gicc_rd++;
         GicEntry++;
       }
@@ -218,7 +243,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICH;
         GicEntry->base = Entry->GICH;
         GicEntry->length = 0;
-        acs_print(ACS_PRINT_INFO, L" GICH base %x\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      " GICH base %x\n",
+                      GicEntry->base);
         GicEntry++;
       }
     }
@@ -227,7 +254,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICD;
         GicEntry->base = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicTable->header.gic_version = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->GicVersion;
-        acs_print(ACS_PRINT_INFO, L"  GIC DIS base %x\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC DIS base %x\n",
+                      GicEntry->base);
         GicTable->header.num_gicd++;
         GicEntry++;
     }
@@ -236,7 +265,9 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICR_GICRD;
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
-        acs_print(ACS_PRINT_INFO, L"  GICR RD base %x\n", GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GICR RD base %x\n",
+                      GicEntry->base);
         GicTable->header.num_gicr_rd++;
         GicEntry++;
     }
@@ -245,8 +276,12 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_GICITS;
         GicEntry->base = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicEntry->entry_id = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->GicItsId;
-        acs_print(ACS_PRINT_INFO, L"  GIC ITS base %x\n", GicEntry->base);
-        acs_print(ACS_PRINT_INFO, L"  GIC ITS ID%x\n", GicEntry->entry_id);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC ITS base %x\n",
+                      GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  GIC ITS ID%x\n",
+                      GicEntry->entry_id);
         GicTable->header.num_its++;
         GicEntry++;
     }
@@ -258,9 +293,15 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->flags = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->Flags;
         GicEntry->spi_count = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPICount;
         GicEntry->spi_base = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPIBase;
-        acs_print(ACS_PRINT_INFO, L" GIC MSI Frame base %x\n", GicEntry->base);
-        acs_print(ACS_PRINT_INFO, L" GIC MSI SPI base %x\n", GicEntry->spi_base);
-        acs_print(ACS_PRINT_INFO, L" GIC MSI SPI Count %x\n", GicEntry->spi_count);
+        pal_print_msg(ACS_PRINT_INFO,
+                      " GIC MSI Frame base %x\n",
+                      GicEntry->base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      " GIC MSI SPI base %x\n",
+                      GicEntry->spi_base);
+        pal_print_msg(ACS_PRINT_INFO,
+                      " GIC MSI SPI Count %x\n",
+                      GicEntry->spi_count);
         GicTable->header.num_msi_frame++;
         GicEntry++;
     }
@@ -373,7 +414,8 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -384,27 +426,36 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       /* Search for GICv3 nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv3_dt_arr[i]);
       if (offset < 0) {
-        acs_print(ACS_PRINT_DEBUG, L"  GICv3 compatible value not found for index : %d\n", i);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  GICv3 compatible value not found for index : %d\n",
+                      i);
         continue; /* Search for next compatible item*/
       }
       else {
-        acs_print(ACS_PRINT_DEBUG, L"  NODE Int Ctrl offset  %x\n", offset);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  NODE Int Ctrl offset  %x\n",
+                      offset);
         GicTable->header.gic_version = 3;
         break;
       }
   }
 
   if (offset < 0) {
-      acs_print(ACS_PRINT_DEBUG, L"  GIC v3 compatible node not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  GIC v3 compatible node not found\n");
       for (i = 0; i < (sizeof(gicv2_dt_arr)/GIC_COMPATIBLE_STR_LEN); i++) {
           /* Search for GICv2 nodes*/
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv2_dt_arr[i]);
           if (offset < 0) {
-            acs_print(ACS_PRINT_DEBUG, L"  GICv2 compatible value not found for index : %d\n", i);
+            pal_print_msg(ACS_PRINT_DEBUG,
+                          "  GICv2 compatible value not found for index : %d\n",
+                          i);
             continue; /* Search for next compatible item*/
           }
           else {
-            acs_print(ACS_PRINT_DEBUG, L"  NODE Int Ctrl offset  %x\n", offset);
+            pal_print_msg(ACS_PRINT_DEBUG,
+                          "  NODE Int Ctrl offset  %x\n",
+                          offset);
             GicTable->header.gic_version = 2;
             break;
           }
@@ -412,7 +463,8 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
   }
 
   if (offset < 0) {
-      acs_print(ACS_PRINT_DEBUG, L"  GIC v2 compatible node not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  GIC v2 compatible node not found\n");
       return;
   }
 
@@ -420,28 +472,39 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
   parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
 
   size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-  acs_print(ACS_PRINT_DEBUG, L"  NODE gic size cell %d\n", size_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  NODE gic size cell %d\n",
+                size_cell);
   if (size_cell < 0) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid size cell for node gic\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid size cell for node gic\n");
       return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-  acs_print(ACS_PRINT_DEBUG, L"  NODE gic addr cell %d\n", addr_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  NODE gic addr cell %d\n",
+                addr_cell);
   if (addr_cell < 0) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid address cell for node gic\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid address cell for node gic\n");
       return;
   }
 
   /* read the reg property value */
   Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
   if ((prop_len < 0) || (Preg_val == NULL)) {
-      acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  PROPERTY reg offset %x, Error %d\n",
+                    offset,
+                    prop_len);
       return;
   }
 
   num_gic_interfaces = (prop_len/sizeof(int))/(addr_cell + size_cell);
-  acs_print(ACS_PRINT_DEBUG, L"  Gic frame count : %d\n", num_gic_interfaces);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  Gic frame count : %d\n",
+                num_gic_interfaces);
 
   /* Fill details for Distributor */
   GicEntry->type = ENTRY_TYPE_GICD;
@@ -457,7 +520,9 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
   } else
     GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
-  acs_print(ACS_PRINT_DEBUG, L"  GIC DIS base %lx\n", GicEntry->base);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  GIC DIS base %lx\n",
+                GicEntry->base);
   GicTable->header.num_gicd++;
   GicEntry++;
 
@@ -466,12 +531,15 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       Prdregions_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset,
                                     "redistributor-regions", 21, &prop_len);
       if (prop_len < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  Single redistributor regions present\n");
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  Single redistributor regions present\n");
           num_of_rd = 1;
       } else
           num_of_rd = fdt32_to_cpu(Prdregions_val[0]);
 
-      acs_print(ACS_PRINT_DEBUG, L"  NUM GIC RD %d\n", num_of_rd);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NUM GIC RD %d\n",
+                    num_of_rd);
       i = num_of_rd;
       /* Fill details for Redistributor */
       while (i--) {
@@ -488,7 +556,9 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           } else
               GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
-          acs_print(ACS_PRINT_DEBUG, L"  GICR RD base %lx\n", GicEntry->base);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  GICR RD base %lx\n",
+                        GicEntry->base);
           GicTable->header.num_gicr_rd++;
           GicEntry++;
     }
@@ -509,7 +579,9 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
         cpuif_length = fdt32_to_cpu(Preg_val[Index++]);
 
       num_of_pe = pal_pe_get_num();
-      acs_print(ACS_PRINT_DEBUG, L"  GIC CPUIF base %lx\n", cpuif_base);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  GIC CPUIF base %lx\n",
+                    cpuif_base);
       while (num_of_pe--) {
           GicEntry->type = ENTRY_TYPE_CPUIF;
           GicEntry->base = cpuif_base;
@@ -517,13 +589,20 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           GicEntry++;
       }
   } else
-    acs_print(ACS_PRINT_WARN, L"  GIC CPUIF not present\n");
+    pal_print_msg(ACS_PRINT_WARN,
+                  "  GIC CPUIF not present\n");
 
-  acs_print(ACS_PRINT_INFO, L"  Number of gic interface %d\n", num_gic_interfaces);
-  acs_print(ACS_PRINT_INFO, L"  Number of RD %d\n", num_of_rd);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  Number of gic interface %d\n",
+                num_gic_interfaces);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  Number of RD %d\n",
+                num_of_rd);
 
   num_gic_interfaces -= (num_of_rd + 1);
-  acs_print(ACS_PRINT_INFO, L"  Number of gic interface %d\n", num_gic_interfaces);
+  pal_print_msg(ACS_PRINT_INFO,
+                "  Number of gic interface %d\n",
+                num_gic_interfaces);
 
   if (GicTable->header.gic_version == 2) { /* parse v2m frame if present */
       /* fill details of GICH needed for gic v2 */
@@ -540,14 +619,18 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
             GicEntry->length = (GicEntry->length << 32) | fdt32_to_cpu(Preg_val[Index++]);
           } else
             GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
-          acs_print(ACS_PRINT_DEBUG, L"  GICH base %x\n", GicEntry->base);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  GICH base %x\n",
+                        GicEntry->base);
           GicEntry++;
       }
 
       /* Search for GICv2m-frame nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv2m_frame_dt_arr[0]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  No v2m-frame present\n", 0);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  No v2m-frame present\n",
+                        0);
           GicEntry->type = 0xFF;
           return;
       }
@@ -556,26 +639,37 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE gic size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE gic size cell %d\n",
+                    size_cell);
       if (size_cell < 0) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell for node gic\n");
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell for node gic\n");
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE gic addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE gic addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 0) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell for node gic\n");
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell for node gic\n");
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
-          acs_print(ACS_PRINT_DEBUG, L"  NODE v2m frame offset %x\n", offset);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  NODE v2m frame offset %x\n",
+                        offset);
           Index = 0;
           /* read the reg property value */
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY reg offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -595,13 +689,17 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           } else
              GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
-          acs_print(ACS_PRINT_DEBUG, L"  GIC v2m frame base %x\n", GicEntry->base);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  GIC v2m frame base %x\n",
+                        GicEntry->base);
 
           /* read the arm,msi-base-spi property value */
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "arm,msi-base-spi", 16,
                                                     &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
-              acs_print(ACS_PRINT_DEBUG, L"  PROPERTY arm,msi-base-spi Error %d\n", prop_len);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  PROPERTY arm,msi-base-spi Error %d\n",
+                            prop_len);
               GicEntry->spi_base = 0;
           } else
               GicEntry->spi_base = fdt32_to_cpu(Preg_val[0]);
@@ -610,7 +708,9 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "arm,msi-num-spis", 16,
                                                     &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
-              acs_print(ACS_PRINT_DEBUG, L"  PROPERTY arm,msi-num-spis Error %d\n", prop_len);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  PROPERTY arm,msi-num-spis Error %d\n",
+                            prop_len);
               GicEntry->spi_count = 0;
           } else
               GicEntry->spi_count = fdt32_to_cpu(Preg_val[0]);
@@ -619,14 +719,18 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                  gicv2m_frame_dt_arr[0]);
       }
-      acs_print(ACS_PRINT_DEBUG, L"  Num of v2m frame %x\n", GicTable->header.num_msi_frame);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Num of v2m frame %x\n",
+                    GicTable->header.num_msi_frame);
   }
 
   if (GicTable->header.gic_version == 3) { /* Check if ITS sub-node present */
       /* Search for its nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, its_dt_arr[0]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  No ITS present\n", 0);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  No ITS present\n",
+                        0);
           GicEntry->type = 0xFF;
           return;
       }
@@ -634,7 +738,9 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           GicTable->header.num_its++;
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset, its_dt_arr[0]);
       }
-      acs_print(ACS_PRINT_DEBUG, L"  Num of ITS frame %x\n", GicTable->header.num_its);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Num of ITS frame %x\n",
+                    GicTable->header.num_its);
   }
 
   /* Mark end of table */

--- a/pal/uefi_dt/src/pal_iovirt.c
+++ b/pal/uefi_dt/src/pal_iovirt.c
@@ -77,37 +77,57 @@ dump_block(IOVIRT_BLOCK *block) {
   NODE_DATA_MAP *map = &block->data_map[0];
   switch(block->type) {
       case IOVIRT_NODE_ITS_GROUP:
-      acs_print(ACS_PRINT_INFO, L"\n ITS Group:\n Num ITS:%d\n", (*map).id[0]);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n ITS Group:\n Num ITS:%d\n",
+                    (*map).id[0]);
       for(i = 0; i < block->data.its_count; i++)
-          acs_print(ACS_PRINT_INFO, L"  %d ", (*map).id[i]);
-      acs_print(ACS_PRINT_INFO, L"\n");
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  %d ",
+                        (*map).id[i]);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n");
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
-      acs_print(ACS_PRINT_INFO, L"\n Named Component:\n Device Name:%a\n",
-                 block->data.named_comp.name);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Named Component:\n Device Name:%a\n",
+                    block->data.named_comp.name);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
-      acs_print(ACS_PRINT_INFO, L"\n Root Complex:\n PCI segment number:%d\n",
-                                block->data.rc.segment);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n Root Complex:\n PCI segment number:%d\n",
+                    block->data.rc.segment);
       break;
       case IOVIRT_NODE_SMMU:
       case IOVIRT_NODE_SMMU_V3:
-      acs_print(ACS_PRINT_INFO, L"\n SMMU:\n Major Rev:%d\n Base Address:0x%llx\n",
-                 block->data.smmu.arch_major_rev, block->data.smmu.base);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n SMMU:\n Major Rev:%d\n Base Address:0x%llx\n",
+                    block->data.smmu.arch_major_rev,
+                    block->data.smmu.base);
       break;
       case IOVIRT_NODE_PMCG:
-      acs_print(ACS_PRINT_INFO, L"\n PMCG:\n Base:0x%x\n Overflow GSIV:0x%x\n Node Reference:0x%x\n",
-                 block->data.pmcg.base, block->data.pmcg.overflow_gsiv, block->data.pmcg.node_ref);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n PMCG:\n Base:0x%x\n Overflow GSIV:0x%x\n Node Reference:0x%x\n",
+                    block->data.pmcg.base,
+                    block->data.pmcg.overflow_gsiv,
+                    block->data.pmcg.node_ref);
       break;
   }
-  acs_print(ACS_PRINT_INFO, L" Number of ID Mappings:%d\n", block->num_data_map);
+  pal_print_msg(ACS_PRINT_INFO,
+                " Number of ID Mappings:%d\n",
+                block->num_data_map);
   for(i = 0; i < block->num_data_map; i++, map++) {
-      acs_print(ACS_PRINT_INFO, L"\n input_base:0x%x\n id_count:0x%x\n output_base:0x%x\n",
-            (*map).map.input_base, (*map).map.id_count, (*map).map.output_base);
-      acs_print(ACS_PRINT_INFO, L"\n output ref:0x%x\n", (*map).map.output_ref);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n input_base:0x%x\n id_count:0x%x\n output_base:0x%x\n",
+                    (*map).map.input_base,
+                    (*map).map.id_count,
+                    (*map).map.output_base);
+      pal_print_msg(ACS_PRINT_INFO,
+                    "\n output ref:0x%x\n",
+                    (*map).map.output_ref);
 
   }
-  acs_print(ACS_PRINT_INFO, L"\n");
+  pal_print_msg(ACS_PRINT_INFO,
+                "\n");
 }
 
 /**
@@ -142,7 +162,9 @@ dump_iort_table(IOVIRT_INFO_TABLE *iovirt)
 {
   UINT32 i;
   IOVIRT_BLOCK *block = &iovirt->blocks[0];
-  acs_print(ACS_PRINT_INFO, L" Number of IOVIRT blocks = %d\n", iovirt->num_blocks);
+  pal_print_msg(ACS_PRINT_INFO,
+                " Number of IOVIRT blocks = %d\n",
+                iovirt->num_blocks);
   for(i = 0; i < iovirt->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
     dump_block(block);
 }
@@ -201,14 +223,22 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
             if(tmp->type == IOVIRT_NODE_ITS_GROUP) {
                key_block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
-               acs_print(ACS_PRINT_INFO, L"\n Overlapping device ids %x-%x and %x-%x\n",
-                          key_start, key_end, start, end);
+               pal_print_msg(ACS_PRINT_INFO,
+                             "\n Overlapping device ids %x-%x and %x-%x\n",
+                             key_start,
+                             key_end,
+                             start,
+                             end);
             }
             else {
                key_block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
-               acs_print(ACS_PRINT_INFO, L"\n Overlapping stream ids %x-%x and %x-%x\n",
-                          key_start, key_end, start, end);
+               pal_print_msg(ACS_PRINT_INFO,
+                             "\n Overlapping stream ids %x-%x and %x-%x\n",
+                             key_start,
+                             key_end,
+                             start,
+                             end);
             }
           }
         }
@@ -271,7 +301,10 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
   NODE_DATA *data = &((*block)->data);
   VOID *node_data = &(iort_node->node_data[0]);
 
-  acs_print(ACS_PRINT_INFO, L" IORT node offset:%x, type: %d\n", (UINT8*)iort_node - (UINT8*)iort, iort_node->type);
+  pal_print_msg(ACS_PRINT_INFO,
+                " IORT node offset:%x, type: %d\n",
+                (UINT8 *)iort_node - (UINT8 *)iort,
+                iort_node->type);
 
   SetMem(data, sizeof(NODE_DATA), 0);
 
@@ -324,7 +357,8 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
       count = &IoVirtTable->num_pmcgs;
       break;
     default:
-       acs_print(ACS_PRINT_ERR, L" Invalid IORT node type\n");
+       pal_print_msg(ACS_PRINT_ERR,
+                     " Invalid IORT node type\n");
        return (UINT32) -1;
   }
 
@@ -437,7 +471,8 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   /* Create iovirt block for each IORT node*/
   for (i = 0; i < iort->node_count; i++) {
     if (iort_node >= iort_end) {
-      acs_print(ACS_PRINT_ERR, L" Bad IORT table\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Bad IORT table\n");
       return;
     }
     iort_add_block(iort, iort_node, IoVirtTable, &next_block);
@@ -529,8 +564,9 @@ pal_iovirt_get_rc_smmu_base (
   }
 
   if (!mapping_found) {
-      acs_print(ACS_PRINT_ERR,
-               L"\n       RID to Stream ID/Dev ID map not found ", 0);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "\n       RID to Stream ID/Dev ID map not found ",
+                    0);
       return 0xFFFFFFFF;
   }
 
@@ -544,9 +580,9 @@ pal_iovirt_get_rc_smmu_base (
           if(sid >= (*map).map.input_base && sid <= ((*map).map.input_base +
                                                     (*map).map.id_count))
           {
-              acs_print(ACS_PRINT_DEBUG,
-                        L"  find RC block->data.smmu.base : %llx",
-                        block->data.smmu.base);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  find RC block->data.smmu.base : %llx",
+                            block->data.smmu.base);
               return block->data.smmu.base;
           }
       }
@@ -555,8 +591,9 @@ pal_iovirt_get_rc_smmu_base (
   /* The Root Complex represented by rc_seg_num
    * is not behind any SMMU. Return NULL pointer
    */
-  acs_print(ACS_PRINT_DEBUG, L"  No SMMU found behind the RootComplex with segment :%d",
-                                                                            RcSegmentNum);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  No SMMU found behind the RootComplex with segment :%d",
+                RcSegmentNum);
   return 0;
 
 }
@@ -588,7 +625,8 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
     return;
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-    acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " dt_ptr is NULL\n");
     return;
   }
 
@@ -611,33 +649,48 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
           continue; /* Search for next compatible smmuv3*/
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Parent Node offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  size cell %d\n",
+                    size_cell);
       if (size_cell < 1) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell :%d\n",
+                        size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 1) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell : %d\n",
+                        addr_cell);
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
-          acs_print(ACS_PRINT_DEBUG, L"  SMMUv3 node:%d offset:%d\n", IoVirtTable->num_smmus,
-                    offset);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  SMMUv3 node:%d offset:%d\n",
+                        IoVirtTable->num_smmus,
+                        offset);
 
           /* Consider only the SMMU which is visible in non-secure world
              Status fields either not present or if present should not be disabled */
           Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
           if ((prop_len > 0) && (Pstatus != NULL)) {
-              acs_print(ACS_PRINT_DEBUG, L"  Status field length %d\n", prop_len);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  Status field length %d\n",
+                            prop_len);
               if (pal_strncmp(Pstatus, "disabled", 9) == 0) {
-                  acs_print(ACS_PRINT_DEBUG, L"  SMMU instance is disabled\n");
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  SMMU instance is disabled\n");
                   offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                           smmu3_dt_arr[i]);
                   continue;
@@ -646,7 +699,10 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
 
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY reg offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -679,33 +735,48 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
           continue; /* Search for next compatible smmuv2*/
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Parent Node offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  size cell %d\n",
+                    size_cell);
       if (size_cell < 1) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell :%d\n",
+                        size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 1) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell : %d\n",
+                        addr_cell);
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
-          acs_print(ACS_PRINT_DEBUG, L"  SMMUv2 node:%d offset:%d\n", IoVirtTable->num_smmus,
-                    offset);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  SMMUv2 node:%d offset:%d\n",
+                        IoVirtTable->num_smmus,
+                        offset);
 
           /* Consider only the SMMU which is visible in non-secure world
              Status fields either not present or if present should not be disabled */
           Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
           if ((prop_len > 0) && (Pstatus != NULL)) {
-              acs_print(ACS_PRINT_DEBUG, L"  Status field length %d\n", prop_len);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  Status field length %d\n",
+                            prop_len);
               if (pal_strncmp(Pstatus, "disabled", 9) == 0) {
-                  acs_print(ACS_PRINT_DEBUG, L"  SMMU instance is disabled\n");
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  SMMU instance is disabled\n");
                   offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                           smmu3_dt_arr[i]);
                   continue;
@@ -714,7 +785,10 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
 
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY reg offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -742,30 +816,42 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
   /* Parse PCIe node and add smmu base to rc node */
   offset = fdt_node_offset_by_prop_value((const void *) dt_ptr, -1, "device_type", "pci", 4);
   if (offset < 0) {
-    acs_print(ACS_PRINT_DEBUG, L"  PCIE node not found %d\n", offset);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  "  PCIE node not found %d\n",
+                  offset);
     return;
   }
 
   parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-  acs_print(ACS_PRINT_DEBUG, L"  NODE pcie offset %d\n", offset);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  NODE pcie offset %d\n",
+                offset);
 
   size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-  acs_print(ACS_PRINT_DEBUG, L"  NODE pcie size cell %d\n", size_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  NODE pcie size cell %d\n",
+                size_cell);
   if (size_cell < 0) {
-    acs_print(ACS_PRINT_ERR, L"  Invalid size cell\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "  Invalid size cell\n");
     return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-  acs_print(ACS_PRINT_DEBUG, L"  NODE pcie addr cell %d\n", addr_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  NODE pcie addr cell %d\n",
+                addr_cell);
   if (addr_cell <= 0 || addr_cell > 2) {
-    acs_print(ACS_PRINT_ERR, L"  Invalid address cell\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "  Invalid address cell\n");
     return;
   }
 
   /* Perform a DT traversal till all pcie node are parsed */
   while (offset != -FDT_ERR_NOTFOUND) {
-      acs_print(ACS_PRINT_DEBUG, L"  SUBNODE  offset %x\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  SUBNODE  offset %x\n",
+                    offset);
 
       /* parse iommu-map is present */
       Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "iommu-map", 9, &prop_len);

--- a/pal/uefi_dt/src/pal_misc.c
+++ b/pal/uefi_dt/src/pal_misc.c
@@ -40,7 +40,11 @@ VOID
 pal_mmio_write8(UINT64 addr, UINT8 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write8 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT8 *)addr = data;
 }
@@ -58,7 +62,11 @@ VOID
 pal_mmio_write16(UINT64 addr, UINT16 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write16 Address = %llx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT16 *)addr = data;
 }
@@ -76,7 +84,11 @@ VOID
 pal_mmio_write64(UINT64 addr, UINT64 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write64 Address = %llx  Data = %llx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %llx\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT64 *)addr = data;
 }
@@ -97,7 +109,11 @@ pal_mmio_read8(UINT64 addr)
   data = (*(volatile UINT8 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read8 Address = %lx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -118,7 +134,11 @@ pal_mmio_read16(UINT64 addr)
   data = (*(volatile UINT16 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read16 Address = %lx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -139,7 +159,11 @@ pal_mmio_read64(UINT64 addr)
   data = (*(volatile UINT64 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read64 Address = %lx  Data = %lx\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %lx\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -160,7 +184,11 @@ pal_mmio_read(UINT64 addr)
   data = (*(volatile UINT32 *)addr);
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_read Address = %lx  Data = %x\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %lx  Data = %x\n",
+                    __func__,
+                    addr,
+                    data);
 
   return data;
 }
@@ -178,7 +206,11 @@ VOID
 pal_mmio_write(UINT64 addr, UINT32 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
-      acs_print(ACS_PRINT_INFO, L" pal_mmio_write Address = %llx  Data = %x\n", addr, data);
+      pal_print_msg(ACS_PRINT_INFO,
+                    " %a Address = %llx  Data = %x\n",
+                    __func__,
+                    addr,
+                    data);
 
   *(volatile UINT32 *)addr = data;
 }
@@ -204,7 +236,8 @@ pal_print(UINT64 data)
     AsciiPrint("%a", buf);
     Status = ShellWriteFile(g_acs_log_file_handle, &BufferSize, (VOID *)buf);
     if (EFI_ERROR(Status))
-      acs_print(ACS_PRINT_ERR, L" Error in writing to log file\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " Error in writing to log file\n");
   }
   else
   {
@@ -289,7 +322,8 @@ pal_mem_free(VOID *Buffer)
   UINT32 Status;
   Status = gBS->FreePool(Buffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_ERR, L"\n       Failed to free memory    ");
+    pal_print_msg(ACS_PRINT_ERR,
+                  "\n       Failed to free memory    ");
   }
 }
 
@@ -311,10 +345,14 @@ pal_mem_allocate_shared(UINT32 num_pe, UINT32 sizeofentry)
                                (num_pe * sizeofentry),
                                (VOID **) &gSharedMemory );
 
-  acs_print(ACS_PRINT_INFO, L" Shared memory is %llx\n", gSharedMemory);
+  pal_print_msg(ACS_PRINT_INFO,
+                " Shared memory is %llx\n",
+                gSharedMemory);
 
   if (EFI_ERROR(Status)) {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool shared memory failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool shared memory failed %x\n",
+                  Status);
   }
   pal_pe_data_cache_ops_by_va((UINT64)&gSharedMemory, CLEAN_AND_INVALIDATE);
 
@@ -373,7 +411,9 @@ pal_mem_alloc (
                               (VOID **) &Buffer);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -404,7 +444,9 @@ pal_mem_calloc (
                               (VOID **) &Buffer);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -438,7 +480,9 @@ pal_mem_alloc_cacheable (
                                EFI_SIZE_TO_PAGES(Size),
                                &Address);
   if (EFI_ERROR(Status)) {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pool failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pool failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -567,7 +611,9 @@ pal_mem_alloc_pages (
                                &PageBase);
   if (EFI_ERROR(Status))
   {
-    acs_print(ACS_PRINT_ERR, L" Allocate Pages failed %x\n", Status);
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Allocate Pages failed %x\n",
+                  Status);
     return NULL;
   }
 
@@ -621,7 +667,8 @@ pal_mem_free_aligned (VOID *Buffer)
     UINT32 Status;
     Status = gBS->FreePool(((VOID **)Buffer)[-1]);
     if (EFI_ERROR (Status)) {
-        acs_print(ACS_PRINT_ERR, L"\n       Failed to free aligned memory    ");
+        pal_print_msg(ACS_PRINT_ERR,
+                      "\n       Failed to free aligned memory    ");
     }
 }
 
@@ -652,7 +699,8 @@ void pal_uart_putc(char c)
         UINTN n = 1;
         EFI_STATUS Status = ShellWriteFile(g_acs_log_file_handle, &n, &ch);
         if (EFI_ERROR(Status)) {
-            acs_print(ACS_PRINT_ERR, L" Error in writing to log file\n");
+            pal_print_msg(ACS_PRINT_ERR,
+                          " Error in writing to log file\n");
         }
     }
 }

--- a/pal/uefi_dt/src/pal_pcie.c
+++ b/pal/uefi_dt/src/pal_pcie.c
@@ -65,7 +65,8 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
   gMcfgHdr = (EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *) pal_get_mcfg_ptr();
 
   if (gMcfgHdr == NULL) {
-      acs_print(ACS_PRINT_WARN, L" ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
+      pal_print_msg(ACS_PRINT_WARN,
+                    " ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
       return 0x0;
   }
 
@@ -78,7 +79,9 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
   {
       if ((bus >= Entry->StartBusNumber) && (bus <= Entry->EndBusNumber) &&
           (seg == Entry->PciSegmentGroupNumber)) {
-          acs_print(ACS_PRINT_INFO, L" ECAM base address is %llx\n", Entry->BaseAddress);
+          pal_print_msg(ACS_PRINT_INFO,
+                        " ECAM base address is %llx\n",
+                        Entry->BaseAddress);
           return Entry->BaseAddress;
       }
 
@@ -87,7 +90,9 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
       sizeof(EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE);
   }
 
-  acs_print(ACS_PRINT_ERR, L" ECAM base address for bdf 0x%x is 0\n", bdf);
+  pal_print_msg(ACS_PRINT_ERR,
+                " ECAM base address for bdf 0x%x is 0\n",
+                bdf);
   return 0;
 }
 
@@ -108,7 +113,8 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
   UINT32 i = 0;
 
   if (PcieTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
     return;
   }
 
@@ -170,7 +176,8 @@ pal_pcie_io_read_cfg(UINT32 Bdf, UINT32 offset, UINT32 *data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return PCIE_NO_MAPPING;
   }
 
@@ -222,7 +229,8 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return;
   }
 
@@ -267,7 +275,8 @@ pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No Root Bridge found in the system\n");
     return PCIE_NO_MAPPING;
   }
 
@@ -315,7 +324,8 @@ pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No Root Bridge found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No Root Bridge found in the system\n");
     return PCIE_NO_MAPPING;
   }
 
@@ -356,8 +366,10 @@ pal_pcie_p2p_support()
       return 0;
   else {
       pal_warn_not_implemented(__func__);
-      acs_print(ACS_PRINT_WARN, L"\n       Test is applicable only if the system supports P2P."
-                                 "\n       Pass command line option '-p2p' when running.");
+      pal_print_msg(ACS_PRINT_WARN,
+                    "\n       Test is applicable only if the system supports P2P.");
+      pal_print_msg(ACS_PRINT_WARN,
+                    "\n       Pass command line option '-p2p' when running.");
       return PAL_STATUS_NOT_IMPLEMENTED;
   }
 }
@@ -566,7 +578,8 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-    acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " dt_ptr is NULL\n");
     return;
   }
 
@@ -575,24 +588,34 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
   for (i = 0; i < sizeof(pci_dt_arr)/PCI_COMPATIBLE_STR_LEN ; i++) {
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, pci_dt_arr[i]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  PCI node offset not found %d\n", offset);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  PCI node offset not found %d\n",
+                        offset);
           continue; /* Search for next compatible node*/
       }
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE pcie offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE pcie offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE pcie size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE pcie size cell %d\n",
+                    size_cell);
       if (size_cell < 0) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell\n");
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell\n");
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE pcie addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE pcie addr cell %d\n",
+                    addr_cell);
       if (addr_cell <= 0 || addr_cell > 2) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell\n");
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell\n");
           return;
       }
 
@@ -601,7 +624,10 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
 
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((Preg_val == NULL) || prop_len < 0) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY reg offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -613,7 +639,10 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
           Pbus_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "bus-range", 9,
                                                                 &prop_len);
           if ((Pbus_val == NULL) || prop_len < 0) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY reg offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
           PcieTable->block[PcieTable->num_entries].segment_num = 0;

--- a/pal/uefi_dt/src/pal_pcie_enumeration.c
+++ b/pal/uefi_dt/src/pal_pcie_enumeration.c
@@ -83,7 +83,8 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return EFI_SUCCESS;
   }
 
@@ -107,7 +108,13 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
           Status = Pci->Pci.Read (Pci, EfiPciIoWidthUint32, 0, sizeof (PciHeader)/sizeof (UINT32), &PciHeader);
           if (!EFI_ERROR (Status)) {
             Hdr = &PciHeader.Bridge.Hdr;
-            acs_print(ACS_PRINT_INFO,L"\n%03d.%02d.%02d class_code = %d %d", Bus, Dev, Index, Hdr->ClassCode[1], Hdr->ClassCode[2]);
+            pal_print_msg(ACS_PRINT_INFO,
+                          "\n%03d.%02d.%02d class_code = %d %d",
+                          Bus,
+                          Dev,
+                          Index,
+                          Hdr->ClassCode[1],
+                          Hdr->ClassCode[2]);
             if (Hdr->ClassCode[2] == ((ClassCode >> 16) & 0xFF)) {
               if (Hdr->ClassCode[1] == ((ClassCode >> 8) & 0xFF)) {
                  /* Found our device */
@@ -171,7 +178,8 @@ palPcieGetBase(UINT32 bdf, UINT32 bar_index)
 
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    acs_print(ACS_PRINT_INFO,L" No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_INFO,
+                  " No PCI devices found in the system\n");
     return EFI_SUCCESS;
   }
 

--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -109,7 +109,8 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
   PE_SMBIOS_TYPE4_INFO *Type4Entry = NULL;
 
   if (SmbiosTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
     return;
   }
 
@@ -131,7 +132,9 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
     /* Check of record if of type 4 */
     if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
-      acs_print(ACS_PRINT_DEBUG, L" Smbios type %d found\n", Record->Type);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    " Smbios type %d found\n",
+                    Record->Type);
 
       Type4Record = (SMBIOS_TABLE_TYPE4 *)Record;
 
@@ -141,7 +144,9 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
       else
         Type4Entry->processor_family = Type4Record->ProcessorFamily;
 
-      acs_print(ACS_PRINT_DEBUG, L"  Processor Family 0x%x\n", Type4Entry->processor_family);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Processor Family 0x%x\n",
+                    Type4Entry->processor_family);
 
       /* Save Processor core count */
       if (Type4Record->CoreCount == SMBIOS_OBTAIN_CORE_COUNT2)
@@ -149,21 +154,28 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
       else
         Type4Entry->core_count = Type4Record->CoreCount;
 
-      acs_print(ACS_PRINT_DEBUG, L"  Processor Count 0x%x\n", Type4Entry->core_count);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Processor Count 0x%x\n",
+                    Type4Entry->core_count);
 
       Type4Entry++;
       SmbiosTable->slot_count++;
 
       if (SmbiosTable->slot_count >= MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED) {
-        acs_print(ACS_PRINT_WARN, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
-        acs_print(ACS_PRINT_WARN, L" Number of SMBIOS Slots greater than %d\n",
-                        MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
+        pal_print_msg(ACS_PRINT_WARN,
+                      " Total Slots/Sockets 0x%x\n",
+                      SmbiosTable->slot_count);
+        pal_print_msg(ACS_PRINT_WARN,
+                      " Number of SMBIOS Slots greater than %d\n",
+                      MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
         SmbiosTable->slot_count = MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED;
         return;
       }
     }
   }
-  acs_print(ACS_PRINT_DEBUG, L" Total Slots/Sockets 0x%x\n", SmbiosTable->slot_count);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                " Total Slots/Sockets 0x%x\n",
+                SmbiosTable->slot_count);
 }
 
 /**
@@ -188,7 +200,8 @@ pal_psci_get_conduit (
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return CONDUIT_NO_TABLE;
   }
 
@@ -199,19 +212,24 @@ pal_psci_get_conduit (
         break;
   }
   if (offset < 0) {
-      acs_print(ACS_PRINT_ERR, L"  psci node offset not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  psci node offset not found\n");
       return CONDUIT_UNKNOWN;
   }
 
   Pmethod = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "method", 6, &prop_len);
   if ((prop_len > 0) && (Pmethod != NULL)) {
-      acs_print(ACS_PRINT_DEBUG, L"  method field length %d\n", prop_len);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  method field length %d\n",
+                    prop_len);
       if (pal_strncmp(Pmethod, "hvc", 4) == 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  psci method hvc\n");
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  psci method hvc\n");
           return CONDUIT_HVC;
       }
       if (pal_strncmp(Pmethod, "smc", 4) == 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  psci method smc\n");
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  psci method smc\n");
           return CONDUIT_SMC;
       }
   }
@@ -297,14 +315,26 @@ PalCaptureMmuConfig(VOID)
         gMmuConfig.ttbr1 = read_ttbr1_el1();
   }
 
-  acs_print(ACS_PRINT_DEBUG, L"  MMU Config captured at EL%d\n", gMmuConfig.current_el);
-  acs_print(ACS_PRINT_DEBUG, L"    TTBR0: 0x%lx\n", gMmuConfig.ttbr0);
-  acs_print(ACS_PRINT_DEBUG, L"    TCR:   0x%lx\n", gMmuConfig.tcr);
-  acs_print(ACS_PRINT_DEBUG, L"    MAIR:  0x%lx\n", gMmuConfig.mair);
-  acs_print(ACS_PRINT_DEBUG, L"    SCTLR: 0x%lx\n", gMmuConfig.sctlr);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  MMU Config captured at EL%d\n",
+                gMmuConfig.current_el);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TTBR0: 0x%lx\n",
+                gMmuConfig.ttbr0);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    TCR:   0x%lx\n",
+                gMmuConfig.tcr);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    MAIR:  0x%lx\n",
+                gMmuConfig.mair);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "    SCTLR: 0x%lx\n",
+                gMmuConfig.sctlr);
 
   if (!SkipTtbr1)
-    acs_print(ACS_PRINT_DEBUG, L"    TTBR1: 0x%lx\n", gMmuConfig.ttbr1);
+    pal_print_msg(ACS_PRINT_DEBUG,
+                  "    TTBR1: 0x%lx\n",
+                  gMmuConfig.ttbr1);
 
   /* Clean cache to ensure secondary PEs see the config */
   pal_pe_data_cache_ops_by_va((UINT64)&gMmuConfig, CLEAN_AND_INVALIDATE);
@@ -357,7 +387,9 @@ PalAllocateSecondaryStack(UINT64 mpidr)
                     StackSize,
                     (VOID **) &Buffer);
       if (EFI_ERROR(Status)) {
-          acs_print(ACS_PRINT_ERR, L"\n FATAL - Allocation for Seconday stack failed %x\n", Status);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "\n FATAL - Allocation for Seconday stack failed %x\n",
+                        Status);
       }
       pal_pe_data_cache_ops_by_va((UINT64)&Buffer, CLEAN_AND_INVALIDATE);
 
@@ -387,7 +419,8 @@ VOID
 pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 {
   if (PeTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input PE Table Pointer is NULL. Cannot create PE INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input PE Table Pointer is NULL. Cannot create PE INFO\n");
     return;
   }
   PeTable->header.num_of_pe = 0;
@@ -574,7 +607,8 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -585,7 +619,9 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
       /* Search for pmu nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, pmu_dt_arr[arr_idx]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  PMU compatible value not found for index:%d\n", arr_idx);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  PMU compatible value not found for index:%d\n",
+                        arr_idx);
           continue; /* Search for next compatible item*/
       }
 
@@ -594,23 +630,32 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
           Pintr = (UINT32 *)
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n",
-                        offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-          acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  interrupt_cell  %d\n",
+                        interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-              acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell : %d\n", interrupt_cell);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  Invalid interrupt cell : %d\n",
+                            interrupt_cell);
               return;
           }
 
           interrupt_frame_count = ((prop_len/sizeof(int))/interrupt_cell);
-          acs_print(ACS_PRINT_DEBUG, L"  interrupt frame count : %d\n", interrupt_frame_count);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  interrupt frame count : %d\n",
+                        interrupt_frame_count);
 
           if (interrupt_frame_count == 0) {
-              acs_print(ACS_PRINT_ERR, L"  interrupt_frame_count is invalid\n");
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  interrupt_frame_count is invalid\n");
               return;
           }
 
@@ -631,12 +676,17 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
                     Ptr->pmu_gsiv = 0; /* Set to zero*/
                     Ptr++;
                 }
-                acs_print(ACS_PRINT_WARN, L"  PMU interrupt type not mentioned\n");
+                pal_print_msg(ACS_PRINT_WARN,
+                              "  PMU interrupt type not mentioned\n");
                 return;
               }
 
-              acs_print(ACS_PRINT_DEBUG, L"  intr_type    : %d\n", intr_type);
-              acs_print(ACS_PRINT_DEBUG, L"  pmu_intr_num : %d\n", curr_pmu_intr_num);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  intr_type    : %d\n",
+                            intr_type);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  pmu_intr_num : %d\n",
+                            curr_pmu_intr_num);
 
               if (intr_type == INTERRUPT_TYPE_PPI) {
                 curr_pmu_intr_num += PPI_OFFSET;
@@ -646,7 +696,8 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
                       Ptr->pmu_gsiv = 0; /* Set to zero*/
                       Ptr++;
                     }
-                    acs_print(ACS_PRINT_WARN, L"  PMU interrupt number mismatch found\n");
+                    pal_print_msg(ACS_PRINT_WARN,
+                                  "  PMU interrupt number mismatch found\n");
                     return;
                 }
                 if (prev_pmu_intr_num == 0) { /* Update table first time with same id*/
@@ -694,7 +745,8 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-    acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " dt_ptr is NULL\n");
     return;
   }
 
@@ -703,23 +755,32 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
 
   if (offset != -FDT_ERR_NOTFOUND) {
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE cpu offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE cpu offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE cpu size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE cpu size cell %d\n",
+                    size_cell);
       if (size_cell != 0) {
-        acs_print(ACS_PRINT_ERR, L"  Invalid size cell for node cpu\n");
+        pal_print_msg(ACS_PRINT_ERR,
+                      "  Invalid size cell for node cpu\n");
         return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  NODE cpu  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  NODE cpu  addr cell %d\n",
+                    addr_cell);
       if (addr_cell <= 0 || addr_cell > 2) {
-        acs_print(ACS_PRINT_ERR, L"  Invalid address cell for node cpu\n");
+        pal_print_msg(ACS_PRINT_ERR,
+                      "  Invalid address cell for node cpu\n");
         return;
       }
   } else {
-        acs_print(ACS_PRINT_ERR, L"  No CPU node found\n");
+        pal_print_msg(ACS_PRINT_ERR,
+                      "  No CPU node found\n");
         return;
   }
 
@@ -727,11 +788,17 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
 
   /* Perform a DT traversal till all cpu node are parsed */
   while (offset != -FDT_ERR_NOTFOUND) {
-      acs_print(ACS_PRINT_DEBUG, L"  SUBNODE cpu%d offset %x\n", PeTable->header.num_of_pe, offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  SUBNODE cpu%d offset %x\n",
+                    PeTable->header.num_of_pe,
+                    offset);
 
       prop_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
       if ((prop_len < 0) || (prop_val == NULL)) {
-        acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+        pal_print_msg(ACS_PRINT_ERR,
+                      "  PROPERTY reg offset %x, Error %d\n",
+                      offset,
+                      prop_len);
         return;
       }
 
@@ -740,9 +807,12 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
       */
       Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
       if ((prop_len > 0) && (Pstatus != NULL)) {
-          acs_print(ACS_PRINT_DEBUG, L"  Status field length %d\n", prop_len);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  Status field length %d\n",
+                        prop_len);
           if (pal_strncmp(Pstatus, "fail", 5) == 0) {
-              acs_print(ACS_PRINT_DEBUG, L"  CPU is not operational..SKIP\n");
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  CPU is not operational..SKIP\n");
               offset = fdt_node_offset_by_prop_value((const void *) dt_ptr, offset,
                                                       "device_type", "cpu", 4);
               continue;
@@ -750,10 +820,14 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
       }
 
       reg_val[0] = fdt32_to_cpu(prop_val[0]);
-      acs_print(ACS_PRINT_DEBUG, L"  reg_val<0> = %x\n", reg_val[0]);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  reg_val<0> = %x\n",
+                    reg_val[0]);
       if (addr_cell == 2) {
         reg_val[1] = fdt32_to_cpu(prop_val[1]);
-        acs_print(ACS_PRINT_DEBUG, L"  reg_val<1> = %x\n", reg_val[1]);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  reg_val<1> = %x\n",
+                      reg_val[1]);
         Ptr->mpidr = (((INT64)(reg_val[0] & PROPERTY_MASK_PE_AFF3) << 32) |
                      (reg_val[1] & PROPERTY_MASK_PE_AFF0_AFF2));
       } else {

--- a/pal/uefi_dt/src/pal_peripherals.c
+++ b/pal/uefi_dt/src/pal_peripherals.c
@@ -88,7 +88,8 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -100,25 +101,37 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
       /* Search for USB nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, usb_dt_compatible[i]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  USB compatible value not found for index:%d\n", i);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  USB compatible value not found for index:%d\n",
+                        i);
           continue; /* Search for next compatible item*/
       }
 
       /* Get Address_cell & Size_cell length to parse reg property of timer*/
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Parent Node offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  size cell %d\n",
+                    size_cell);
       if (size_cell < 0) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell :%d\n",
+                        size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell : %d\n",
+                        addr_cell);
           return;
       }
       while (offset != -FDT_ERR_NOTFOUND) {
@@ -128,7 +141,10 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
           /* Get reg property to update base */
           Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY REG offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY REG offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -136,15 +152,21 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
           Pintr = (UINT32 *)
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n",
-                        offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-          acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  interrupt_cell  %d\n",
+                        interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-              acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell : %d\n", interrupt_cell);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  Invalid interrupt cell : %d\n",
+                            interrupt_cell);
               return;
           }
 
@@ -208,7 +230,8 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -221,25 +244,37 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
       /* Search for sata node*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, sata_dt_compatible[i]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  SATA compatible value not found for index:%d\n", i);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  SATA compatible value not found for index:%d\n",
+                        i);
           continue; /* Search for next compatible item*/
       }
 
       /* Get Address_cell & Size_cell length to parse reg property of timer*/
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Parent Node offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  size cell %d\n",
+                    size_cell);
       if (size_cell < 0) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell :%d\n",
+                        size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell : %d\n",
+                        addr_cell);
           return;
       }
       while (offset != -FDT_ERR_NOTFOUND) {
@@ -249,7 +284,10 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           /* Get reg property to update base */
           Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY REG offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY REG offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -257,15 +295,21 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           Pintr = (UINT32 *)
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n",
-                        offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-          acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  interrupt_cell  %d\n",
+                        interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-              acs_print(ACS_PRINT_ERR, L" Invalid interrupt cell : %d\n", interrupt_cell);
+              pal_print_msg(ACS_PRINT_ERR,
+                            " Invalid interrupt cell : %d\n",
+                            interrupt_cell);
               return;
           }
 
@@ -332,7 +376,8 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -346,25 +391,37 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
       /* Search for uart nodes*/
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, uart_dt_compatible[i]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  UART compatible value not found for index:%d\n", i);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  UART compatible value not found for index:%d\n",
+                        i);
           continue; /* Search for next compatible item*/
       }
 
       /* Get Address_cell & Size_cell length to parse reg property of uart*/
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Parent Node offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  size cell %d\n",
+                    size_cell);
       if (size_cell < 0) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell :%d\n",
+                        size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell : %d\n",
+                        addr_cell);
           return;
       }
       while (offset != -FDT_ERR_NOTFOUND) {
@@ -373,9 +430,12 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
              Status fields either not present or if present should not be disabled */
           Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
           if ((prop_len > 0) && (Pstatus != NULL)) {
-              acs_print(ACS_PRINT_DEBUG, L"  Status field length %d\n", prop_len);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  Status field length %d\n",
+                            prop_len);
               if (pal_strncmp(Pstatus, "disabled", 9) == 0) {
-                  acs_print(ACS_PRINT_DEBUG, L"  UART access is secure\n");
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  UART access is secure\n");
                   offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                           uart_dt_compatible[i]);
                   continue;
@@ -385,7 +445,10 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           /* Get reg property to update base */
           Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY REG offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY REG offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
@@ -412,15 +475,19 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           while (range_node_left > 0) {
               Pranges = (UINT32 *)
                   fdt_getprop_namelen((void *)dt_ptr, range_parent_offset, "ranges", 6, &prop_len);
-              acs_print(ACS_PRINT_DEBUG, L"  Parent ranges length %d\n", prop_len);
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  Parent ranges length %d\n",
+                            prop_len);
               if ((prop_len < 0) || (Pranges == NULL)) {
-                  acs_print(ACS_PRINT_DEBUG, L"  No ranges is present\n");
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  No ranges is present\n");
                   range_node_left = 0;
                   break;
               }
               range_node_left--;
               if ((Pranges != NULL) && (prop_len == 0)) {// Empty ranges
-                  acs_print(ACS_PRINT_DEBUG, L"  Empty ranges is present\n");
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  Empty ranges is present\n");
                   range_parent_offset = fdt_parent_offset((const void *) dt_ptr,
                                                                              range_parent_offset);
               } else {
@@ -431,9 +498,15 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
                   parent_addr_cell = fdt_address_cells((const void *) dt_ptr, range_parent_offset);
                   child_size_cell = fdt_size_cells((const void *) dt_ptr, range_node_offset);
 
-                  acs_print(ACS_PRINT_DEBUG, L"  child addr cell %d\n", child_addr_cell);
-                  acs_print(ACS_PRINT_DEBUG, L"  parent addr cell %d\n", parent_addr_cell);
-                  acs_print(ACS_PRINT_DEBUG, L"  child size cell %d\n", child_size_cell);
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  child addr cell %d\n",
+                                child_addr_cell);
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  parent addr cell %d\n",
+                                parent_addr_cell);
+                  pal_print_msg(ACS_PRINT_DEBUG,
+                                "  child size cell %d\n",
+                                child_size_cell);
                   if ((child_addr_cell < 1 || child_addr_cell > 2) ||
                      (parent_addr_cell < 1 || parent_addr_cell > 2) || (child_size_cell < 0))
                       return;
@@ -444,26 +517,39 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
                       if (parent_addr_cell == 2)
                           range_node_addr = (range_node_addr << 32) |
                                                 fdt32_to_cpu(Pranges[range_index++]);
-                      acs_print(ACS_PRINT_DEBUG, L"  range node addr %lx\n", range_node_addr);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  range node addr %lx\n",
+                                    range_node_addr);
                       continue;
                   }
                   while (range_index < (prop_len / 4)) {
-                      acs_print(ACS_PRINT_DEBUG, L"  range_index %d\n", range_index);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  range_index %d\n",
+                                    range_index);
                       temp_child_addr = fdt32_to_cpu(Pranges[range_index++]);
                       if (child_addr_cell == 2)
                           temp_child_addr = (temp_child_addr << 32) |
                                                     fdt32_to_cpu(Pranges[range_index++]);
-                      acs_print(ACS_PRINT_DEBUG, L"  temp node addr %lx\n", temp_child_addr);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  temp node addr %lx\n",
+                                    temp_child_addr);
                       if (temp_child_addr == range_node_addr) {
                           parent_offset_addr = fdt32_to_cpu(Pranges[range_index++]);
-                      acs_print(ACS_PRINT_DEBUG, L"  parent offset addr %lx\n", parent_offset_addr);
-                      acs_print(ACS_PRINT_DEBUG, L"  range index %d\n", range_index);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  parent offset addr %lx\n",
+                                    parent_offset_addr);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  range index %d\n",
+                                    range_index);
                           if (parent_addr_cell == 2) {
                               parent_offset_addr = (parent_offset_addr << 32) |
                                                             fdt32_to_cpu(Pranges[range_index++]);
-                      acs_print(ACS_PRINT_DEBUG, L"  2 parent offset addr %lx\n",
-                                                                              parent_offset_addr);
-                      acs_print(ACS_PRINT_DEBUG, L"  2 range index %d\n", range_index);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  2 parent offset addr %lx\n",
+                                    parent_offset_addr);
+                      pal_print_msg(ACS_PRINT_DEBUG,
+                                    "  2 range index %d\n",
+                                    range_index);
                           }
                           break;
                       }
@@ -473,22 +559,30 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
               }
           }
 
-         acs_print(ACS_PRINT_DEBUG, L"  parent offset addr  %lx\n", parent_offset_addr);
+         pal_print_msg(ACS_PRINT_DEBUG,
+                       "  parent offset addr  %lx\n",
+                       parent_offset_addr);
          per_info->base0 += parent_offset_addr;
 
           /* Get interrupts property from frame */
           Pintr = (UINT32 *)
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n",
-                        offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-          acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  interrupt_cell  %d\n",
+                        interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-              acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell : %d\n", interrupt_cell);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  Invalid interrupt cell : %d\n",
+                            interrupt_cell);
               return;
           }
 
@@ -539,8 +633,8 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE *spcr = NULL;
 
   if (peripheralInfoTable == NULL) {
-    acs_print(ACS_PRINT_ERR,
-              L" Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
     return;
   }
 
@@ -566,7 +660,9 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
-          acs_print(ACS_PRINT_INFO, L"  Found a USB controller %4x\n", per_info->base0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Found a USB controller %4x\n",
+                        per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -594,7 +690,9 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
-          acs_print(ACS_PRINT_INFO, L"  Found a SATA controller %4x\n", per_info->base0);
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Found a SATA controller %4x\n",
+                        per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
           per_info++;
@@ -738,7 +836,8 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   UINT32                Index, i = 0;
 
   if (memoryInfoTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
     return;
   }
 
@@ -764,9 +863,12 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
   if (!EFI_ERROR (Status)) {
     MemoryMapPtr = MemoryMap;
     for (Index = 0; Index < (MemoryMapSize / DescriptorSize); Index++) {
-          acs_print(ACS_PRINT_INFO, L"  Reserved region of type %d [0x%lX, 0x%lX]\n",
-            MemoryMapPtr->Type, (UINTN)MemoryMapPtr->PhysicalStart,
-            (UINTN)(MemoryMapPtr->PhysicalStart + MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE));
+          pal_print_msg(ACS_PRINT_INFO,
+                        "  Reserved region of type %d [0x%lX, 0x%lX]\n",
+                        MemoryMapPtr->Type,
+                        (UINTN)MemoryMapPtr->PhysicalStart,
+                        (UINTN)(MemoryMapPtr->PhysicalStart +
+                                MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE));
       if (IsUefiMemory ((EFI_MEMORY_TYPE)MemoryMapPtr->Type)) {
         memoryInfoTable->info[i].type      = MEMORY_TYPE_RESERVED;
       } else {
@@ -785,7 +887,9 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
       memoryInfoTable->info[i].size      = (MemoryMapPtr->NumberOfPages * EFI_PAGE_SIZE);
       i++;
       if (i >= MEM_INFO_TBL_MAX_ENTRY) {
-        acs_print(ACS_PRINT_DEBUG, L"  Memory Info tbl limit exceeded, Skipping remaining\n", 0);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  Memory Info tbl limit exceeded, Skipping remaining\n",
+                      0);
         break;
       }
 
@@ -864,7 +968,9 @@ pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance)
         if (*addr == 0)
           continue;
 
-        acs_print(ACS_PRINT_INFO,L"  Unpopulated region with base address 0x%lX found\n", *addr);
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  Unpopulated region with base address 0x%lX found\n",
+                      *addr);
         return EFI_SUCCESS;
       }
 

--- a/pal/uefi_dt/src/pal_timer_wd.c
+++ b/pal/uefi_dt/src/pal_timer_wd.c
@@ -94,7 +94,8 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   UINT32                      num_of_entries;
 
   if (TimerTable == NULL) {
-    acs_print(ACS_PRINT_ERR, L" Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
     return;
   }
 
@@ -106,7 +107,10 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
 
   gGtdtHdr = (EFI_ACPI_6_1_GENERIC_TIMER_DESCRIPTION_TABLE *) pal_get_gtdt_ptr();
 
-  acs_print(ACS_PRINT_INFO, L" GTDT is at %x and length is %x\n", gGtdtHdr, gGtdtHdr->Header.Length);
+  pal_print_msg(ACS_PRINT_INFO,
+                " GTDT is at %x and length is %x\n",
+                gGtdtHdr,
+                gGtdtHdr->Header.Length);
 
   //Fill in our internal table
   TimerTable->header.s_el1_timer_flag  = gGtdtHdr->SecurePL1TimerFlags;
@@ -126,21 +130,28 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   while(num_of_entries) {
 
     if (Entry->Type == EFI_ACPI_6_1_GTDT_GT_BLOCK) {
-      acs_print(ACS_PRINT_INFO, L"  Found block entry\n");
+      pal_print_msg(ACS_PRINT_INFO,
+                    "  Found block entry\n");
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
-      acs_print(ACS_PRINT_DEBUG, L"  CNTCTLBase = %llx\n", GtEntry->block_cntl_base);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  CNTCTLBase = %llx\n",
+                    GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)(((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
-        acs_print(ACS_PRINT_INFO, L"  Found timer entry\n");
+        pal_print_msg(ACS_PRINT_INFO,
+                      "  Found timer entry\n");
         GtEntry->frame_num[i]    = GtBlockTimer->GTFrameNumber;
         GtEntry->GtCntBase[i]    = GtBlockTimer->CntBaseX;
         GtEntry->GtCntEl0Base[i] = GtBlockTimer->CntEL0BaseX;
         GtEntry->gsiv[i]         = GtBlockTimer->GTxPhysicalTimerGSIV;
         GtEntry->virt_gsiv[i]    = GtBlockTimer->GTxVirtualTimerGSIV;
         GtEntry->flags[i]        = GtBlockTimer->GTxPhysicalTimerFlags | (GtBlockTimer->GTxVirtualTimerFlags << 8) | (GtBlockTimer->GTxCommonFlags << 16);
-        acs_print(ACS_PRINT_DEBUG, L"  CNTBaseN = %llx for sys counter = %d\n", GtEntry->GtCntBase[i], i);
+        pal_print_msg(ACS_PRINT_DEBUG,
+                      "  CNTBaseN = %llx for sys counter = %d\n",
+                      GtEntry->GtCntBase[i],
+                      i);
         GtBlockTimer++;
         TimerTable->header.num_platform_timer++;
       }
@@ -216,8 +227,8 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
   UINT32                      num_of_entries;
 
   if (WdTable == NULL) {
-    acs_print(ACS_PRINT_ERR,
-              L" Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
     return;
   }
 
@@ -247,10 +258,10 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_gsiv         = Entry->WatchdogTimerGSIV;
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
-      acs_print(ACS_PRINT_DEBUG,
-                L"  Watchdog base = 0x%llx INTID = 0x%x\n",
-                WdEntry->wd_ctrl_base,
-                WdEntry->wd_gsiv);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Watchdog base = 0x%llx INTID = 0x%x\n",
+                    WdEntry->wd_ctrl_base,
+                    WdEntry->wd_gsiv);
       WdEntry++;
     }
     Entry = (EFI_ACPI_6_1_GTDT_SBSA_GENERIC_WATCHDOG_STRUCTURE *) ((UINT8 *)Entry + (Entry->Length));
@@ -290,55 +301,80 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-    acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+    pal_print_msg(ACS_PRINT_ERR,
+                  " dt_ptr is NULL\n");
     return;
   }
 
   for (i = 0; i < sizeof(wd_dt_arr)/WD_COMPATIBLE_STR_LEN ; i++) {
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, wd_dt_arr[i]);
       if (offset < 0) {
-          acs_print(ACS_PRINT_DEBUG, L"  WD node offset not found %d\n", offset);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  WD node offset not found %d\n",
+                        offset);
           continue; /* Search for next compatible wd*/
       }
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Parent Node offset %d\n",
+                    offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  size cell %d\n",
+                    size_cell);
       if (size_cell < 1 || size_cell > 2) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid size cell :%d\n",
+                        size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  addr cell %d\n",
+                    addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid address cell : %d\n",
+                        addr_cell);
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
-          acs_print(ACS_PRINT_DEBUG, L"  WD node:%d offset:%d\n", WdTable->header.num_wd, offset);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  WD node:%d offset:%d\n",
+                        WdTable->header.num_wd,
+                        offset);
 
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY reg offset %x, Error %d\n", offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY reg offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
           Pintr_val =
               (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr_val == NULL)) {
-              acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n",
-                        offset, prop_len);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            offset,
+                            prop_len);
               return;
           }
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-          acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+          pal_print_msg(ACS_PRINT_DEBUG,
+                        "  interrupt_cell  %d\n",
+                        interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-              acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell : %d\n", interrupt_cell);
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  Invalid interrupt cell : %d\n",
+                            interrupt_cell);
               return;
           }
 
@@ -375,7 +411,8 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
           switch (intr_flg) /* Interrupt flag*/
           {
             case IRQ_TYPE_NONE:
-              acs_print(ACS_PRINT_DEBUG, L"  interrupt type none\n");
+              pal_print_msg(ACS_PRINT_DEBUG,
+                            "  interrupt type none\n");
               wd_mode = INTERRUPT_IS_LEVEL_TRIGGERED; /* Set default*/
               wd_polarity = INTERRUPT_IS_ACTIVE_HIGH;
               break;
@@ -396,8 +433,9 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
               wd_polarity = INTERRUPT_IS_ACTIVE_LOW;
               break;
             default:
-              acs_print(ACS_PRINT_ERR, L"  interrupt type invalid :%X\n",
-                        fdt32_to_cpu(Pintr_val[2]));
+              pal_print_msg(ACS_PRINT_ERR,
+                            "  interrupt type invalid :%X\n",
+                            fdt32_to_cpu(Pintr_val[2]));
               return;
           }
           WdEntry->wd_flags = ((wd_polarity << 1) | (wd_mode << 0));
@@ -436,7 +474,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
 
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
-      acs_print(ACS_PRINT_ERR, L" dt_ptr is NULL\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    " dt_ptr is NULL\n");
       return;
   }
 
@@ -464,26 +503,38 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   }
   /* Return if Timer node not found*/
   if (offset < 0) {
-      acs_print(ACS_PRINT_ERR, L"  timer node offset not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  timer node offset not found\n");
       return;
   }
   interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
-  acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell  %d\n", interrupt_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  interrupt_cell  %d\n",
+                interrupt_cell);
   if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell : %d\n", interrupt_cell);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid interrupt cell : %d\n",
+                    interrupt_cell);
       return;
   }
 
     /* Get Interrupt property of timer node*/
   Pintr = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
   if ((prop_len < 0) || (Pintr == NULL)) {
-      acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n", offset, prop_len);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  PROPERTY interrupts offset %x, Error %d\n",
+                    offset,
+                    prop_len);
       return;
   }
   else {
-      acs_print(ACS_PRINT_DEBUG, L"  PROPERTY Interrupts Size %d\n", prop_len);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  PROPERTY Interrupts Size %d\n",
+                    prop_len);
       num_interrupts = prop_len/(interrupt_cell * 4);
-      acs_print(ACS_PRINT_DEBUG, L"  No of interrupts defined in Property %d\n", num_interrupts);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  No of interrupts defined in Property %d\n",
+                    num_interrupts);
   }
 
   if (interrupt_cell >= 3) { /* Interrupt type available*/
@@ -492,7 +543,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
           if (fdt32_to_cpu(Pintr[index++]) == GIC_PPI)
               TimerTable->header.s_el1_timer_gsiv = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
-              acs_print(ACS_PRINT_WARN, L"  Secure EL1 Phy Timer interrupt Type is not PPI\n");
+              pal_print_msg(ACS_PRINT_WARN,
+                            "  Secure EL1 Phy Timer interrupt Type is not PPI\n");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -504,7 +556,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
           if (fdt32_to_cpu(Pintr[index++]) == GIC_PPI)
               TimerTable->header.ns_el1_timer_gsiv = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
-              acs_print(ACS_PRINT_WARN, L"  EL1 NS phy timer interrupt Type is not PPI\n");
+              pal_print_msg(ACS_PRINT_WARN,
+                            "  EL1 NS phy timer interrupt Type is not PPI\n");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -516,7 +569,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
           if (fdt32_to_cpu(Pintr[index++]) == GIC_PPI)
               TimerTable->header.virtual_timer_gsiv  = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
-              acs_print(ACS_PRINT_WARN, L"  Virtual timer interrupt Type is not PPI\n");
+              pal_print_msg(ACS_PRINT_WARN,
+                            "  Virtual timer interrupt Type is not PPI\n");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -528,7 +582,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
           if (fdt32_to_cpu(Pintr[index++]) == GIC_PPI)
               TimerTable->header.el2_timer_gsiv      = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
-              acs_print(ACS_PRINT_WARN, L"  EL2 NS phy timer interrupt Type is not PPI\n");
+              pal_print_msg(ACS_PRINT_WARN,
+                            "  EL2 NS phy timer interrupt Type is not PPI\n");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -540,7 +595,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
           if (fdt32_to_cpu(Pintr[index++]) == GIC_PPI)
               TimerTable->header.el2_virt_timer_gsiv = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
-              acs_print(ACS_PRINT_WARN, L"  EL2 Virtual timer interrupt Type is not PPI\n");
+              pal_print_msg(ACS_PRINT_WARN,
+                            "  EL2 Virtual timer interrupt Type is not PPI\n");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -581,7 +637,8 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
       TimerTable->header.el2_virt_timer_flag = TIMER_FLAG_ALWAYS_ON;
   }
   else
-      acs_print(ACS_PRINT_DEBUG, L"  PROPERTY always-on not found\n");
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  PROPERTY always-on not found\n");
 
   /* Search for mem mapped timers*/
   for (i = 0; i < sizeof(memtimer_dt_arr)/MEMTIMER_COMPATIBLE_STR_LEN ; i++) {
@@ -590,32 +647,46 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
         break;
   }
   if (offset < 0) {
-      acs_print(ACS_PRINT_ERR, L"  MEM timer node offset not found\n");
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  MEM timer node offset not found\n");
       return;
   }
 
   /* Get Address_cell & Size_cell length to parse reg property of timer*/
   parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
-  acs_print(ACS_PRINT_DEBUG, L"  Parent Node offset %d\n", offset);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  Parent Node offset %d\n",
+                offset);
 
   size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
-  acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  size cell %d\n",
+                size_cell);
   if (size_cell < 0) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid size cell :%d\n", size_cell);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid size cell :%d\n",
+                    size_cell);
       return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
-  acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  addr cell %d\n",
+                addr_cell);
   if (addr_cell < 1 || addr_cell > 2) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid address cell : %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid address cell : %d\n",
+                    addr_cell);
       return;
   }
 
   /* Get reg property to update block_cntl_base */
   Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
   if ((prop_len < 0) || (Preg == NULL)) {
-      acs_print(ACS_PRINT_ERR, L"  PROPERTY REG offset %x, Error %d\n", offset, prop_len);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  PROPERTY REG offset %x, Error %d\n",
+                    offset,
+                    prop_len);
       return;
   }
 
@@ -628,35 +699,50 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
 
   /* Get Address_cell & Size_cell length to parse reg property of frame*/
   size_cell = fdt_size_cells((const void *) dt_ptr, offset);
-  acs_print(ACS_PRINT_DEBUG, L"  size cell %d\n", size_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  size cell %d\n",
+                size_cell);
   if (size_cell < 0) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid size cell for timer node :%d\n", size_cell);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid size cell for timer node :%d\n",
+                    size_cell);
       return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, offset);
-  acs_print(ACS_PRINT_DEBUG, L"  addr cell %d\n", addr_cell);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  addr cell %d\n",
+                addr_cell);
   if (addr_cell < 1 || addr_cell > 2) {
-      acs_print(ACS_PRINT_ERR, L"  Invalid address cell for timer node: %d\n", addr_cell);
+      pal_print_msg(ACS_PRINT_ERR,
+                    "  Invalid address cell for timer node: %d\n",
+                    addr_cell);
       return;
   }
 
   /* Get frame sub node*/
   subnode_offset = fdt_subnode_offset((const void *)dt_ptr, offset, "frame");
   if (subnode_offset < 0) {
-      acs_print(ACS_PRINT_DEBUG, L"  frame node offset not found %d\n", subnode_offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  frame node offset not found %d\n",
+                    subnode_offset);
       return;
   }
 
   while (subnode_offset != -FDT_ERR_NOTFOUND) {
       /* Get frame number*/
       frame_number = fdt_frame_number((const void *)dt_ptr, subnode_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  Frame number is  %d\n", frame_number);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  Frame number is  %d\n",
+                    frame_number);
 
       /* Get reg property from frame to update GtCntBase */
       Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, subnode_offset, "reg", 3, &prop_len);
       if ((prop_len < 0) || (Preg == NULL)) {
-          acs_print(ACS_PRINT_ERR, L"  PROPERTY REG offset %x, Error %d\n", offset, prop_len);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  PROPERTY REG offset %x, Error %d\n",
+                        offset,
+                        prop_len);
           return;
       }
 
@@ -664,15 +750,21 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
       Pintr = (UINT32 *)
               fdt_getprop_namelen((void *)dt_ptr, subnode_offset, "interrupts", 10, &prop_len);
       if ((prop_len < 0) || (Pintr == NULL)) {
-          acs_print(ACS_PRINT_ERR, L"  PROPERTY interrupts offset %x, Error %d\n",
-                    offset, prop_len);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  PROPERTY interrupts offset %x, Error %d\n",
+                        offset,
+                        prop_len);
           return;
       }
 
       interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, subnode_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  interrupt_cell for subnode  %d\n", interrupt_cell);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  interrupt_cell for subnode  %d\n",
+                    interrupt_cell);
       if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
-          acs_print(ACS_PRINT_ERR, L"  Invalid interrupt cell subnode: %d\n", interrupt_cell);
+          pal_print_msg(ACS_PRINT_ERR,
+                        "  Invalid interrupt cell subnode: %d\n",
+                        interrupt_cell);
           return;
       }
 
@@ -725,9 +817,13 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
       GtEntry->timer_count++;
 
       subnode_offset = fdt_next_subnode((const void *)dt_ptr, subnode_offset);
-      acs_print(ACS_PRINT_DEBUG, L"  timer-mem-fram next node offset %d\n", subnode_offset);
+      pal_print_msg(ACS_PRINT_DEBUG,
+                    "  timer-mem-fram next node offset %d\n",
+                    subnode_offset);
   }
-  acs_print(ACS_PRINT_DEBUG, L"  GT block timer count %d\n", GtEntry->timer_count);
+  pal_print_msg(ACS_PRINT_DEBUG,
+                "  GT block timer count %d\n",
+                GtEntry->timer_count);
   TimerTable->header.num_platform_timer = GtEntry->timer_count;
 
   dt_dump_timer_table(TimerTable);


### PR DESCRIPTION
Replace the target-specific PAL print wrapper names with a single source-literal wrapper, pal_print_msg(), across baremetal and UEFI PAL call sites.

Keep backend-specific print handling in pal_print.h, including UEFI literal widening, and add pal_print_native() as an escape hatch for rare callers that already have a target-native format string.

Document the intended wrapper usage, remove the old print() and acs_print() compatibility aliases, and streamline touched print messages to address checkpatch warnings around hard-coded function names, split quoted strings, line continuations, and cast spacing.

Change-Id: I3ded835f69230b09655f885db96f8a5c148ed4af