### PR TITLE
fix(drtm): Correct failure status handling in tests

### DIFF
--- a/test_pool/drtm/dl003.c
+++ b/test_pool/drtm/dl003.c
@@ -86,11 +86,11 @@ payload(uint32_t num_pe)
   if (status != DRTM_ACS_DENIED) {
     val_print(ERROR, "\n       Error Code Mismatch, Expected = %d", DRTM_ACS_DENIED);
     val_print(ERROR, ", Found = %d", status);
+    val_set_status(index, RESULT_FAIL(6));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(6));
         val_set_status(index, RESULT_FAIL(7));
       }
     }

--- a/test_pool/drtm/dl008.c
+++ b/test_pool/drtm/dl008.c
@@ -79,11 +79,11 @@ payload(uint32_t num_pe)
   /* This will return invalid parameter */
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ERROR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
+    val_set_status(index, RESULT_FAIL(3));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(3));
         val_set_status(index, RESULT_FAIL(4));
       }
     }

--- a/test_pool/drtm/dl009.c
+++ b/test_pool/drtm/dl009.c
@@ -64,11 +64,11 @@ payload(uint32_t num_pe)
   /* This will return invalid parameter */
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ERROR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
+    val_set_status(index, RESULT_FAIL(3));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(3));
         val_set_status(index, RESULT_FAIL(4));
       }
     }

--- a/test_pool/drtm/dl010.c
+++ b/test_pool/drtm/dl010.c
@@ -110,11 +110,11 @@ payload(uint32_t num_pe)
     val_print(ERROR, "\n       DRTM Dynamic Launch failed, Expected = %d",
                             DRTM_ACS_DENIED);
     val_print(ERROR, " Found = %d", dl_status);
+    val_set_status(index, RESULT_FAIL(4));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(4));
         val_set_status(index, RESULT_FAIL(5));
       }
     }

--- a/test_pool/drtm/dl011.c
+++ b/test_pool/drtm/dl011.c
@@ -119,11 +119,11 @@ payload(uint32_t num_pe)
   /* This will return invalid parameter */
   if (status != DRTM_ACS_MEM_PROTECT_INVALID) {
     val_print(ERROR, "\n       Incorrect Status. Expected = -6 Found = %d", status);
+    val_set_status(index, RESULT_FAIL(5));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(5));
         val_set_status(index, RESULT_FAIL(6));
       }
     }

--- a/test_pool/drtm/interface005.c
+++ b/test_pool/drtm/interface005.c
@@ -49,12 +49,12 @@ payload(uint32_t num_pe)
     dma_prot_support = VAL_EXTRACT_BITS(g_drtm_features.dma_prot_features.value, 0, 7);
     if (dma_prot_support == 0) {
       val_print(ERROR, "\n       DMA Protection Not Supported");
+      val_set_status(index, RESULT_FAIL(3));
       return;
     }
   } else {
     val_print(ERROR,
               "\n       DMA protection feature value not available in return value");
-      val_set_status(index, RESULT_FAIL(3));
     val_set_status(index, RESULT_FAIL(4));
     return;
   }


### PR DESCRIPTION
* Remove misplaced val_set_status calls inside nested conditions


Change-Id: Ibbb85128d7cc93cb7235a2fb7d3452c4b6ecea1e