### PR TITLE
refactor(apps): centralize shared app definitions

### DIFF
--- a/apps/baremetal/acs.h
+++ b/apps/baremetal/acs.h
@@ -21,20 +21,6 @@
 #include "platform_image_def.h"
 #include "platform_override_fvp.h"
 
-#define SIZE_4K 0x1000
-
-#define BSA_ACS_MAJOR_VER      1
-#define BSA_ACS_MINOR_VER      2
-#define BSA_ACS_SUBMINOR_VER   1
-
-#define SBSA_ACS_MAJOR_VER       8
-#define SBSA_ACS_MINOR_VER       0
-#define SBSA_ACS_SUBMINOR_VER    1
-
-#define PC_BSA_ACS_MAJOR_VER     1
-#define PC_BSA_ACS_MINOR_VER     0
-#define PC_BSA_ACS_SUBMINOR_VER  0
-
 #define INVALID_MPIDR     0xffffffff
 
 #define STACK_SIZE          0x1000
@@ -52,13 +38,6 @@
 #elif (PLATFORM_PAGE_SIZE == PAGE_SIZE_64K)
  #define PAGE_SIZE           PAGE_SIZE_64K
 #endif
-
-#define BSA_MIN_LEVEL_SUPPORTED 1
-#define BSA_MAX_LEVEL_SUPPORTED 1
-
-#define G_SBSA_LEVEL             4
-#define SBSA_MIN_LEVEL_SUPPORTED 3
-#define SBSA_MAX_LEVEL_SUPPORTED 9
 
 /*******************************************************************************
  * Used to align variables on the biggest cache line size in the platform.
@@ -80,51 +59,20 @@
 /* This .h file is included by .S assembly files, and assembler will choke on the C code, hence
    gating C code when included by .S files */
 #ifndef __ASSEMBLER__
+#include "val/include/acs_app_defs.h"
+#include "val/include/acs_app_tables.h"
+#include "val/include/acs_cfg.h"
 #include "val/include/rule_based_execution.h"
 #include "acs_runtime_init.h"
 
-#define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
-    ((filter_mode == LVL_FILTER_ONLY && level == fr_level) ? \
-    "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
-    ((filter_mode == LVL_FILTER_ONLY) ? \
-    "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
-
 /* Remaining baremetal execution globals from apps/baremetal/acs_globals.c */
 extern uint32_t  g_el1physkip;
-extern uint32_t  g_curr_module;
-extern uint32_t  g_enable_module;
-extern uint32_t  g_acs_tests_total;
-extern uint32_t  g_acs_tests_pass;
-extern uint32_t  g_acs_tests_fail;
-extern uint64_t  g_stack_pointer;
-extern uint64_t  g_exception_ret_addr;
-extern uint64_t  g_ret_addr;
-extern uint32_t  g_build_sbsa;
-extern uint32_t  g_build_pcbsa;
-extern uint32_t  g_its_init;
 
-/* Function declarations */
-uint32_t createPeInfoTable(void);
-uint32_t createGicInfoTable(void);
-
+/* Baremetal-only info table helpers */
 void     createMemoryInfoTable(void);
 void     createPcieInfoTable(void);
 void     createIoVirtInfoTable(void);
-void     createTimerInfoTable(void);
-void     createWatchdogInfoTable(void);
-void     createPeripheralInfoTable(void);
 void     createDmaInfoTable(void);
-void     createSmbiosInfoTable(void);
-void     createPmuInfoTable(void);
-void     createRasInfoTable(void);
-void     createCacheInfoTable(void);
-void     createMpamInfoTable(void);
-void     createHmatInfoTable(void);
-void     createSratInfoTable(void);
-void     createPccInfoTable(void);
-void     createRas2InfoTable(void);
-void     createTpm2InfoTable(void);
-void     createCxlInfoTable(void);
 
 #endif /* __ASSEMBLER__ */
 /*

--- a/apps/baremetal/acs_helpers.c
+++ b/apps/baremetal/acs_helpers.c
@@ -175,7 +175,7 @@ createPmuInfoTable(
     val_pmu_create_info_table(PmuInfoTable);
 }
 
-void
+uint32_t
 createRasInfoTable(
 )
 {
@@ -186,7 +186,7 @@ createRasInfoTable(
                     * sizeof(RAS_NODE_INFO) + PLATFORM_OVERRIDE_NUM_RAS_NODES
                     * sizeof(RAS_INTERFACE_INFO)
                     + PLATFORM_OVERRIDE_NUM_RAS_NODES * sizeof(RAS_INTERRUPT_INFO));
-    val_ras_create_info_table(RasInfoTable);
+    return val_ras_create_info_table(RasInfoTable);
 }
 
 void

--- a/apps/linux/bsa-acs-app/bsa_app_main.c
+++ b/apps/linux/bsa-acs-app/bsa_app_main.c
@@ -28,11 +28,6 @@
 #include <stdint.h>
 
 #define BSA_RULE_ID_LIST_MAX 20u
-#define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
-    ((filter_mode == LVL_FILTER_ONLY && level == fr_level) ? \
-    "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
-    ((filter_mode == LVL_FILTER_ONLY) ? \
-    "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
 
 /* Global extern for rule ID string map (defined in val/src/rule_enum_string_map.c) */
 extern char *rule_id_string[RULE_ID_SENTINEL];
@@ -243,7 +238,7 @@ main (int argc, char **argv)
 
     printf("\n ************ BSA Architecture Compliance Suite *********\n");
     printf("                        Version %d.%d.%d\n",
-            BSA_APP_VERSION_MAJOR, BSA_APP_VERSION_MINOR, BSA_APP_VERSION_SUBMINOR);
+            BSA_ACS_MAJOR_VER, BSA_ACS_MINOR_VER, BSA_ACS_SUBMINOR_VER);
 
     printf(LEVEL_PRINT_FORMAT(level_value, level_filter_mode, BSA_LEVEL_FR), level_value);
 

--- a/apps/linux/bsa-acs-app/include/bsa_app.h
+++ b/apps/linux/bsa-acs-app/include/bsa_app.h
@@ -19,18 +19,7 @@
 #ifndef __BSA_APP_LINUX_H__
 #define __BSA_APP_LINUX_H__
 
-
-#define BSA_APP_VERSION_MAJOR     1
-#define BSA_APP_VERSION_MINOR     2
-#define BSA_APP_VERSION_SUBMINOR  1
-
-#define G_SW_OS            0
-#define G_SW_HYP           1
-#define G_SW_PS            2
-
-#define BSA_MIN_LEVEL_SUPPORTED 1
-#define BSA_MAX_LEVEL_SUPPORTED 1
-
+#include "acs_app_defs.h"
 
 #include "bsa_drv_intf.h"
 

--- a/apps/linux/pcbsa-acs-app/include/pcbsa_app.h
+++ b/apps/linux/pcbsa-acs-app/include/pcbsa_app.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,14 +19,7 @@
 #ifndef __PCBSA_APP_LINUX_H__
 #define __PCBSA_APP_LINUX_H__
 
-
-/* PC BSA Release versions */
-#define PC_BSA_APP_VERSION_MAJOR     1
-#define PC_BSA_APP_VERSION_MINOR     0
-#define PC_BSA_APP_VERSION_SUBMINOR  0
-
-#define PCBSA_MIN_LEVEL_SUPPORTED 1
-#define PCBSA_MAX_LEVEL_SUPPORTED 1
+#include "acs_app_defs.h"
 
 #include "pcbsa_drv_intf.h"
 

--- a/apps/linux/pcbsa-acs-app/pcbsa_app_main.c
+++ b/apps/linux/pcbsa-acs-app/pcbsa_app_main.c
@@ -125,8 +125,8 @@ int main(int argc, char **argv)
 
 
     printf("\n ************ PC BSA Architecture Compliance Suite *********\n");
-    printf("                        Version %d.%d.%d\n", PC_BSA_APP_VERSION_MAJOR,
-            PC_BSA_APP_VERSION_MINOR, PC_BSA_APP_VERSION_SUBMINOR);
+    printf("                        Version %d.%d.%d\n", PC_BSA_ACS_MAJOR_VER,
+            PC_BSA_ACS_MINOR_VER, PC_BSA_ACS_SUBMINOR_VER);
 
 
     printf(PC_BSA_LEVEL_PRINT_FORMAT(pcbsa_level, pcbsa_only_level),

--- a/apps/linux/sbsa-acs-app/include/sbsa_app.h
+++ b/apps/linux/sbsa-acs-app/include/sbsa_app.h
@@ -19,13 +19,7 @@
 #ifndef __SBSA_APP_LINUX_H__
 #define __SBSA_APP_LINUX_H__
 
-
-#define SBSA_APP_VERSION_MAJOR      8
-#define SBSA_APP_VERSION_MINOR      0
-#define SBSA_APP_VERSION_SUBMINOR   1
-
-#define SBSA_MIN_LEVEL_SUPPORTED 3
-#define SBSA_MAX_LEVEL_SUPPORTED 9
+#include "acs_app_defs.h"
 
 #include "sbsa_drv_intf.h"
 

--- a/apps/linux/sbsa-acs-app/sbsa_app_main.c
+++ b/apps/linux/sbsa-acs-app/sbsa_app_main.c
@@ -28,11 +28,6 @@
 #include <stdint.h>
 
 #define RULE_ID_LIST_MAX 20u
-#define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
-    ((filter_mode == LVL_FILTER_ONLY && level == fr_level) ? \
-    "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
-    ((filter_mode == LVL_FILTER_ONLY) ? \
-    "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
 
 /* Global extern for rule ID string map (defined in val/src/rule_enum_string_map.c) */
 extern char *rule_id_string[RULE_ID_SENTINEL];
@@ -242,8 +237,8 @@ main (int argc, char **argv)
     }
 
     printf("\n ************ SBSA Architecture Compliance Suite *********\n");
-    printf("                        Version %d.%d.%d\n", SBSA_APP_VERSION_MAJOR,
-            SBSA_APP_VERSION_MINOR, SBSA_APP_VERSION_SUBMINOR);
+    printf("                        Version %d.%d.%d\n", SBSA_ACS_MAJOR_VER,
+            SBSA_ACS_MINOR_VER, SBSA_ACS_SUBMINOR_VER);
 
     printf(LEVEL_PRINT_FORMAT(level_value, level_filter_mode, SBSA_LEVEL_FR), level_value);
 

--- a/apps/uefi/acs.h
+++ b/apps/uefi/acs.h
@@ -20,66 +20,15 @@
 
 #include <stdbool.h>
 #include <Library/ShellLib.h>
+#include "val/include/acs_app_defs.h"
+#include "val/include/acs_cfg.h"
 #include "val/include/rule_based_execution.h"
 
-/* BSA Release versions */
-#define BSA_ACS_MAJOR_VER       1
-#define BSA_ACS_MINOR_VER       2
-#define BSA_ACS_SUBMINOR_VER    1
-
-/* SBSA Release versions */
-#define SBSA_ACS_MAJOR_VER       8
-#define SBSA_ACS_MINOR_VER       0
-#define SBSA_ACS_SUBMINOR_VER    1
-
-/* PC BSA Release versions */
-#define PC_BSA_ACS_MAJOR_VER     1
-#define PC_BSA_ACS_MINOR_VER     0
-#define PC_BSA_ACS_SUBMINOR_VER  0
-
-/* VBSA Release versions */
-#define VBSA_ACS_MAJOR_VER       1
-#define VBSA_ACS_MINOR_VER       0
-#define VBSA_ACS_SUBMINOR_VER    0
-
-/* xBSA ACS Release versions */
-#define XBSA_ACS_MAJOR_VER     1
-#define XBSA_ACS_MINOR_VER     0
-#define XBSA_ACS_SUBMINOR_VER  0
-
-/* DRTM Release versions */
-#define DRTM_ACS_MAJOR_VER      0
-#define DRTM_ACS_MINOR_VER      7
-
-/* MPAM Release versions */
-#define MPAM_ACS_MAJOR_VER      0
-#define MPAM_ACS_MINOR_VER      7
-#define MPAM_ACS_SUBMINOR_VER   0
-
-/* PFDI Release versions */
-#define PFDI_ACS_MAJOR_VER      0
-#define PFDI_ACS_MINOR_VER      8
-#define PFDI_ACS_SUBMINOR_VER   0
+#ifndef EXCLUDE_RBX
+#include "val/include/acs_app_tables.h"
+#endif
 
 #define G_PRINT_LEVEL INFO
-
-#define G_SW_OS                 0
-#define G_SW_HYP                1
-#define G_SW_PS                 2
-
-#define G_BSA_LEVEL             1
-#define BSA_MIN_LEVEL_SUPPORTED 1
-#define BSA_MAX_LEVEL_SUPPORTED 1
-
-#define G_SBSA_LEVEL             4
-#define SBSA_MIN_LEVEL_SUPPORTED 3
-#define SBSA_MAX_LEVEL_SUPPORTED 9
-
-#define G_PCBSA_LEVEL             1
-#define PCBSA_MIN_LEVEL_SUPPORTED 1
-#define PCBSA_MAX_LEVEL_SUPPORTED 1
-
-#define SIZE_4K                 0x1000
 
 /* Note : Total Size Required for Info tables ~ 550 KB
   * Table size is required to be updated whenever new members
@@ -127,12 +76,6 @@
 #define TPM2_INFO_TBL_SZ        256   /* Supports maximum of 10 TPM2 info entries */
                                       /* [24 B each: 3 x uint64_t] + 16 B Header */
 
-#define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
-    ((filter_mode == LVL_FILTER_ONLY && level == fr_level) ? \
-    "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
-    ((filter_mode == LVL_FILTER_ONLY) ? \
-    "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
-
 #ifdef _AARCH64_BUILD_
 unsigned long __stack_chk_guard = 0xBAAAAAAD;
 unsigned long __stack_chk_fail =  0xBAAFAAAD;
@@ -147,14 +90,6 @@ uint32_t command_init(void);
 /* TODO remove #if once all ACS app using this header moves to rule based infra.*/
 #ifndef EXCLUDE_RBX
 /* Extern declarations */
-extern UINT32  g_num_skip;
-extern UINT64  g_stack_pointer;
-extern UINT64  g_exception_ret_addr;
-extern UINT64  g_ret_addr;
-extern UINT32  g_build_sbsa;
-extern UINT32  g_build_pcbsa;
-extern UINT32  g_curr_module;
-extern UINT32  g_enable_module;
 extern SHELL_FILE_HANDLE g_acs_log_file_handle;
 extern SHELL_FILE_HANDLE g_dtb_log_file_handle;
 extern BOOLEAN    g_invalid_arg_seen;
@@ -164,25 +99,9 @@ extern char8_t *rule_id_string[RULE_ID_SENTINEL];
 /* Use module string map from VAL to translate -m inputs */
 extern char8_t *module_name_string[MODULE_ID_SENTINEL];
 
-/* Function declarations */
+/* UEFI-only declarations */
 void HelpMsg(VOID);
-uint32_t createPeInfoTable(void);
-uint32_t createGicInfoTable(void);
-uint32_t createRasInfoTable(void);
-void     createTimerInfoTable(void);
-void     createWatchdogInfoTable(void);
 void     createPcieVirtInfoTable(void);
-void     createCxlInfoTable(void);
-void     createPeripheralInfoTable(void);
-void     createSmbiosInfoTable(void);
-void     createPmuInfoTable(void);
-void     createCacheInfoTable(void);
-void     createMpamInfoTable(void);
-void     createHmatInfoTable(void);
-void     createSratInfoTable(void);
-void     createPccInfoTable(void);
-void     createRas2InfoTable(void);
-void     createTpm2InfoTable(void);
 void     print_selection_summary(void);
 void     FlushImage(void);
 #endif /* EXCLUDE_RBX */

--- a/val/include/acs_app_defs.h
+++ b/val/include/acs_app_defs.h
@@ -1,0 +1,44 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_APP_DEFS_H__
+#define __ACS_APP_DEFS_H__
+
+#include "acs_app_versions.h"
+#include "rule_based_execution_enum.h"
+
+#define SIZE_4K 0x1000
+
+#define G_BSA_LEVEL             1
+#define BSA_MIN_LEVEL_SUPPORTED 1
+#define BSA_MAX_LEVEL_SUPPORTED 1
+
+#define G_SBSA_LEVEL             4
+#define SBSA_MIN_LEVEL_SUPPORTED 3
+#define SBSA_MAX_LEVEL_SUPPORTED 9
+
+#define G_PCBSA_LEVEL             1
+#define PCBSA_MIN_LEVEL_SUPPORTED 1
+#define PCBSA_MAX_LEVEL_SUPPORTED 1
+
+#define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
+    ((filter_mode == LVL_FILTER_ONLY && level == fr_level) ? \
+    "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
+    ((filter_mode == LVL_FILTER_ONLY) ? \
+    "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
+
+#endif /* __ACS_APP_DEFS_H__ */

--- a/val/include/acs_app_tables.h
+++ b/val/include/acs_app_tables.h
@@ -1,0 +1,41 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_APP_TABLES_H__
+#define __ACS_APP_TABLES_H__
+
+#include "acs_stdint.h"
+
+uint32_t createPeInfoTable(void);
+uint32_t createGicInfoTable(void);
+uint32_t createRasInfoTable(void);
+
+void     createTimerInfoTable(void);
+void     createWatchdogInfoTable(void);
+void     createCxlInfoTable(void);
+void     createPeripheralInfoTable(void);
+void     createSmbiosInfoTable(void);
+void     createPmuInfoTable(void);
+void     createCacheInfoTable(void);
+void     createMpamInfoTable(void);
+void     createHmatInfoTable(void);
+void     createSratInfoTable(void);
+void     createPccInfoTable(void);
+void     createRas2InfoTable(void);
+void     createTpm2InfoTable(void);
+
+#endif /* __ACS_APP_TABLES_H__ */

--- a/val/include/acs_app_versions.h
+++ b/val/include/acs_app_versions.h
@@ -1,0 +1,60 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef __ACS_APP_VERSIONS_H__
+#define __ACS_APP_VERSIONS_H__
+
+/* BSA Release versions */
+#define BSA_ACS_MAJOR_VER          1
+#define BSA_ACS_MINOR_VER          2
+#define BSA_ACS_SUBMINOR_VER       1
+
+/* SBSA Release versions */
+#define SBSA_ACS_MAJOR_VER         8
+#define SBSA_ACS_MINOR_VER         0
+#define SBSA_ACS_SUBMINOR_VER      1
+
+/* PC BSA Release versions */
+#define PC_BSA_ACS_MAJOR_VER       1
+#define PC_BSA_ACS_MINOR_VER       0
+#define PC_BSA_ACS_SUBMINOR_VER    0
+
+/* VBSA Release versions */
+#define VBSA_ACS_MAJOR_VER         1
+#define VBSA_ACS_MINOR_VER         0
+#define VBSA_ACS_SUBMINOR_VER      0
+
+/* xBSA ACS Release versions */
+#define XBSA_ACS_MAJOR_VER         1
+#define XBSA_ACS_MINOR_VER         0
+#define XBSA_ACS_SUBMINOR_VER      0
+
+/* DRTM Release versions */
+#define DRTM_ACS_MAJOR_VER         0
+#define DRTM_ACS_MINOR_VER         7
+
+/* MPAM Release versions */
+#define MPAM_ACS_MAJOR_VER         0
+#define MPAM_ACS_MINOR_VER         7
+#define MPAM_ACS_SUBMINOR_VER      0
+
+/* PFDI Release versions */
+#define PFDI_ACS_MAJOR_VER         0
+#define PFDI_ACS_MINOR_VER         8
+#define PFDI_ACS_SUBMINOR_VER      0
+
+#endif /* __ACS_APP_VERSIONS_H__ */

--- a/val/include/acs_cfg.h
+++ b/val/include/acs_cfg.h
@@ -42,8 +42,9 @@ extern uint32_t g_num_modules;
 extern uint32_t g_build_sbsa;
 extern uint32_t g_build_pcbsa;
 extern uint32_t g_curr_module;
+extern uint32_t g_enable_module;
+extern uint32_t g_its_init;
 extern uint32_t g_drtm_acs_dlme[];
 extern uint64_t g_drtm_acs_dlme_size;
 
-
-#endif
+#endif /* __ACS_CFG_H__ */

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -394,7 +394,6 @@ uint32_t val_exerciser_test_init(void)
     uint32_t num_instances = 0;
     uint32_t num_smmu = 0;
     uint32_t instance = 0;
-    extern uint32_t g_its_init;
 
     /* If init already performed return stored status */
     if (status != ACS_STATUS_UNKNOWN) {

--- a/val/src/acs_gic_support.c
+++ b/val/src/acs_gic_support.c
@@ -27,7 +27,6 @@
 #include "pal_interface.h"
 
 extern GIC_INFO_TABLE  *g_gic_info_table;
-extern uint32_t  g_its_init;
 GIC_INFO_ENTRY  *g_gic_entry = NULL;
 GIC_ITS_INFO    *g_gic_its_info;
 

--- a/val/src/bsa_execute_test.c
+++ b/val/src/bsa_execute_test.c
@@ -38,7 +38,6 @@ extern PCIE_INFO_TABLE *g_pcie_info_table;
 extern pcie_device_bdf_table *g_pcie_bdf_table;
 extern uint32_t pcie_bdf_table_list_flag;
 extern uint32_t g_pcie_integrated_devices;
-extern uint32_t g_its_init;
 
 #define OPERATING_SYSTEM    0
 #define HYPERVISOR          1

--- a/val/src/mpam_execute_test.c
+++ b/val/src/mpam_execute_test.c
@@ -21,8 +21,6 @@
 #include "acs_std_smc.h"
 #include "acs_cfg.h"
 
-extern uint32_t g_its_init;
-
 /**
   @brief   This API will execute all MPAM Error tests
            1. Caller       -  Application layer.

--- a/val/src/sbsa_execute_test.c
+++ b/val/src/sbsa_execute_test.c
@@ -36,7 +36,6 @@
 extern uint32_t pcie_bdf_table_list_flag;
 extern pcie_device_bdf_table *g_pcie_bdf_table;
 extern uint32_t g_pcie_integrated_devices;
-extern uint32_t g_its_init;
 
 #ifndef TARGET_LINUX
 /**


### PR DESCRIPTION
Move shared app-level constants and declarations out of the target-specific baremetal and UEFI acs.h headers.

Add shared headers for:

- ACS app version macros
- suite level defaults and bounds
- common app info-table helper declarations

Use the shared definitions from baremetal, UEFI, and Linux userspace app code, and remove duplicate version, level, software-view, and print-format macros where the shared definition is now available.

Move shared runtime globals to acs_cfg.h and remove duplicate local externs from app headers and VAL sources. Align baremetal createRasInfoTable() with the UEFI signature by returning the val_ras_create_info_table() status, then centralize its declaration with the other shared table helpers.

Keep target-specific definitions, table sizes, and startup settings in their existing target headers.

Change-Id: I420e5218e3c245140048a21fd8f640708e59330c