### PR TITLE
Fix: Use RP Bar address when no downstream found

### DIFF
--- a/test_pool/pcie/p030.c
+++ b/test_pool/pcie/p030.c
@@ -152,10 +152,10 @@ payload(void)
        */
       if (val_pcie_function_header_type(bdf) == TYPE1_HEADER) {
           if (get_dsf_bdf(bdf, &dsf_bdf))
-              continue;
-          val_pcie_get_mmio_bar(dsf_bdf, &bar_base);
-      }
-      else {
+              val_pcie_get_mmio_bar(bdf, &bar_base);
+          else
+              val_pcie_get_mmio_bar(dsf_bdf, &bar_base);
+      } else {
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;

--- a/test_pool/pcie/p058.c
+++ b/test_pool/pcie/p058.c
@@ -191,9 +191,9 @@ payload(void *arg)
        */
       if (val_pcie_function_header_type(bdf) == TYPE1_HEADER) {
           if (get_dsf_bdf(bdf, &dsf_bdf))
-              continue;
-
-          val_pcie_get_mmio_bar(dsf_bdf, &bar_base);
+              val_pcie_get_mmio_bar(bdf, &bar_base);
+          else
+              val_pcie_get_mmio_bar(dsf_bdf, &bar_base);
       } else {
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);


### PR DESCRIPTION
	The current code does not use RP base
address when downstream is not found. Modified
the logic such a way that RP bar address is used
when downstream is not found

Fixes #366 

Change-Id: I91d0b7c24b1f499cc3e413ebe004d9caa8ab3dd8