### PR TITLE
fix : enable PCI_IN_13 on UEFI

### DIFF
--- a/docs/bsa/arm_bsa_testcase_checklist.md
+++ b/docs/bsa/arm_bsa_testcase_checklist.md
@@ -1185,7 +1185,7 @@ The checklist provides information about:
       <td rowspan="2">PCI_IN_13</td>
       <td>804</td>
       <td>Check RootPort NP Memory Access</td>
-      <td>No</td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
       <td></td>
@@ -1193,7 +1193,7 @@ The checklist provides information about:
     <tr>
       <td>805</td>
       <td>Check RootPort P Memory Access</td>
-      <td>No</td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
       <td></td>
@@ -3045,7 +3045,7 @@ The checklist provides information about:
       <td>PCI_IN_13</td>
       <td>804</td>
       <td>Check RootPort NP Memory Access</td>
-      <td>No</td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
       <td></td>

--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -1865,7 +1865,7 @@ The checklist provides information about:
       <td>PCI_IN_13</td>
       <td></td>
       <td>Check RootPort NP Memory Access</td>
-      <td>No</td>
+      <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
       <td>iEP RP</td>

--- a/docs/vbsa/arm_vbsa_testcase_checklist.md
+++ b/docs/vbsa/arm_vbsa_testcase_checklist.md
@@ -772,17 +772,17 @@ The checklist provides information about:
       <td>PCI_IN_13</td>
       <td>804</td>
       <td>Check RootPort NP Memory Access</td>
+      <td>✅</td>
       <td>❌</td>
-      <td>❌</td>
-      <td>This test is run only on Baremetal environment in BSA ACS</td>
+      <td></td>
     </tr>
     <tr>
       <td></td>
       <td>805</td>
       <td>Check RootPort P Memory Access</td>
+      <td>✅</td>
       <td>❌</td>
-      <td>❌</td>
-      <td>This test is run only on Baremetal environment in BSA ACS</td>
+      <td></td>
     </tr>
     <tr>
       <td>PCI_IN_14</td>

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -1859,7 +1859,7 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .test_entry_id    = PCI_IN_13_ENTRY,
             .module_id        = PCIE,
             .rule_desc        = "Check RootPort NP Memory Access",
-            .platform_bitmask = PLATFORM_BAREMETAL,
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
             .flag             = BASE_RULE,
         },
         [PCI_IN_16] = {


### PR DESCRIPTION
- made PCI_IN_13 rule to run in UEFI by updating platform bitmask
- updated BSA/SBSA/VBSA checklists to show UEFI coverage for PCI_IN_13


Change-Id: I1e90db16f31ec5f98278fdecd6007de3b2e3e82d