### PR TITLE
fix(pal/uefi_acpi): update MemoryMapSize after memory map allocation

### DIFF
--- a/pal/uefi_acpi/src/pal_peripherals.c
+++ b/pal/uefi_acpi/src/pal_peripherals.c
@@ -303,6 +303,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
       Status = EFI_OUT_OF_RESOURCES;
       return;
     }
+    MemoryMapSize = EFI_PAGES_TO_SIZE (Pages);
     Status = gBS->GetMemoryMap (&MemoryMapSize, MemoryMap, &MapKey, &DescriptorSize, &DescriptorVersion);
   }
 


### PR DESCRIPTION
  Recompute MemoryMapSize from the allocated page count before retrying
  GetMemoryMap. This keeps the buffer size passed to GetMemoryMap aligned
  with the actual allocation size after AllocatePages succeeds.

  Previously, the retry path allocated memory based on the required page
  count but continued using the earlier MemoryMapSize value. Updating it
  with EFI_PAGES_TO_SIZE(Pages) ensures the firmware receives the correct
  buffer size for the allocated memory map buffer.

Fixes #357 

Change-Id: I9ceaac06f73aee6797c225ea540d502095390d99