### PR TITLE
rule_metadata: include ITS rules under B_PER_08

### DIFF
--- a/docs/bsa/arm_bsa_testcase_checklist.md
+++ b/docs/bsa/arm_bsa_testcase_checklist.md
@@ -1024,8 +1024,8 @@ The checklist provides information about:
       <td>A direct test will be added in future</td>
     </tr>
     <tr>
-      <td rowspan="68">L1</td>
-      <td rowspan="68">B_PER_08</td>
+      <td rowspan="85">L1</td>
+      <td rowspan="85">B_PER_08</td>
       <td>PCI_IN_01</td>
       <td>801</td>
       <td>Check ECAM Presence</td>
@@ -1614,6 +1614,159 @@ The checklist provides information about:
     </tr>
     <tr>
       <td>PCI_PTM_1</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_01</td>
+      <td>251</td>
+      <td>Check number of ITS blocks in a group</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_02</td>
+      <td>252</td>
+      <td>Check ITS block association with group</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_03</td>
+      <td>1511</td>
+      <td>MSI-capable device linked to ITS group</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td>Exerciser VIP required</td>
+    </tr>
+    <tr>
+      <td>ITS_04</td>
+      <td>1535</td>
+      <td>MSI-cap device can target any ITS blk</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td>Exerciser VIP required</td>
+    </tr>
+    <tr>
+      <td>ITS_05</td>
+      <td>1512</td>
+      <td>MSI to ITS Blk outside assigned group</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td>Exerciser VIP required</td>
+    </tr>
+    <tr>
+      <td>ITS_06</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_07</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_08</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_1</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_2</td>
+      <td>253</td>
+      <td>Check uniqueness of StreamID</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_3</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_4</td>
+      <td>1513</td>
+      <td>MSI originating from different master</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td>Exerciser VIP required</td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_5</td>
+      <td>Not Covered</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_6</td>
+      <td>1504</td>
+      <td>MSI-X triggers intr with unique ID</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td>Exerciser VIP required</td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_7</td>
+      <td>254</td>
+      <td>Check Device's SID/RID/DID behind SMMU</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_8</td>
+      <td>255</td>
+      <td>Check Device IDs not behind SMMU</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>ITS_DEV_9</td>
       <td>Not Covered</td>
       <td></td>
       <td></td>
@@ -3609,6 +3762,7 @@ The checklist provides information about:
 </table>
 
 ## Latest Checklist Changes
+- Updated B_PER_08 to include ITS Rules.
 - **RI_ Added:** RI_PWR_1
 - Updated B_WD_02.
 - Updated checklist to be consistent with I-VGLFZ.

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -4710,6 +4710,15 @@ RULE_ID_e b_per_08_rule_list[] = {
     /* E.13 - PCIe Precision Time Measurement */
     PCI_PTM_1,
 
+    /* BSA Section H */
+    /* H.1 - ITS Groups */
+    ITS_01, ITS_02, ITS_03, ITS_04,
+    ITS_05, ITS_06, ITS_07, ITS_08,
+    /* H.2 - Generation of DeviceID Values */
+    ITS_DEV_1, ITS_DEV_2, ITS_DEV_3,
+    ITS_DEV_4, ITS_DEV_5, ITS_DEV_6,
+    ITS_DEV_7, ITS_DEV_8, ITS_DEV_9,
+
     RULE_ID_SENTINEL
 };
 


### PR DESCRIPTION
  Update the B_PER_08 alias coverage to include the BSA Section H ITS
  rules in addition to the existing PCIe Section E rules.

  B_PER_08 now includes:
  - ITS_01 through ITS_08 for ITS Groups coverage
  - ITS_DEV_1 through ITS_DEV_9 for DeviceID generation coverage

  Also update the BSA testcase checklist to match the rule metadata

Fixes #389 

Change-Id: I58964e283a228bb101fd7fab5f8f531a0c07cfb1