### PR TITLE
fix(pcie): skip non-prefetchable BARs in P094 flow

### DIFF
--- a/apps/uefi/sbsa_main.c
+++ b/apps/uefi/sbsa_main.c
@@ -168,10 +168,10 @@ execute_tests()
         goto exit_acs;
     }
 
-    val_print(ERROR, "\n\n SBSA Architecture Compliance Suite\n");
-    val_print(ERROR, "    Version %d.", SBSA_ACS_MAJOR_VER);
-    val_print(ERROR, "%d.", SBSA_ACS_MINOR_VER);
-    val_print(ERROR, "%d\n", SBSA_ACS_SUBMINOR_VER);
+    val_print(INFO, "\n\n SBSA Architecture Compliance Suite\n");
+    val_print(INFO, "    Version %d.", SBSA_ACS_MAJOR_VER);
+    val_print(INFO, "%d.", SBSA_ACS_MINOR_VER);
+    val_print(INFO, "%d\n", SBSA_ACS_SUBMINOR_VER);
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
               SBSA_LEVEL_FR), ctx->level_value);

--- a/apps/uefi/sbsa_nist_main.c
+++ b/apps/uefi/sbsa_nist_main.c
@@ -720,10 +720,10 @@ execute_tests()
   VOID               *branch_label;
   UINT32             Status;
 
-  val_print(ERROR, "\n\n SBSA Architecture Compliance Suite\n");
-  val_print(ERROR, "    Version %d.", SBSA_ACS_MAJOR_VER);
-  val_print(ERROR, "%d.", SBSA_ACS_MINOR_VER);
-  val_print(ERROR, "%d\n", SBSA_ACS_SUBMINOR_VER);
+  val_print(INFO, "\n\n SBSA Architecture Compliance Suite\n");
+  val_print(INFO, "    Version %d.", SBSA_ACS_MAJOR_VER);
+  val_print(INFO, "%d.", SBSA_ACS_MINOR_VER);
+  val_print(INFO, "%d\n", SBSA_ACS_SUBMINOR_VER);
 
   val_print(INFO, SBSA_LEVEL_PRINT_FORMAT(g_sbsa_level, g_sbsa_only_level),
                                    (g_sbsa_level > SBSA_MAX_LEVEL_SUPPORTED) ? 0 : g_sbsa_level);

--- a/test_pool/pcie/p045.c
+++ b/test_pool/pcie/p045.c
@@ -65,7 +65,6 @@ payload(void)
   uint32_t test_skip = 1;
   uint32_t test_warn = 1;
   uint32_t test_fail = 0;
-  uint32_t test_abort = 0;
   uint64_t offset;
   uint64_t base;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -106,20 +105,31 @@ next_bdf:
               continue;
           }
 
+      val_print(DEBUG, "\n   BDF under check %08x", bdf);
+      val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
+      val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
+      base_cc = reg_value >> TYPE01_BCC_SHIFT;
+
+      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+          ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
+          || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
+          val_print(DEBUG, "\n       Skipping BDF 0x%x", bdf);
+          tbl_index++;
+          goto next_bdf;
+      }
+
       /* Configure the max BAR offset */
       dev_type = val_pcie_get_device_type(bdf);
-      if (dev_type == 0)
+      if (dev_type == 1)
           max_bar_offset = BAR_TYPE_0_MAX_OFFSET;
       else
           max_bar_offset = BAR_TYPE_1_MAX_OFFSET;
 
       offset = BAR0_OFFSET;
 
-      val_print(DEBUG, "\n   BDF under check %.6x", bdf);
-
       while (offset <= max_bar_offset) {
           val_pcie_read_cfg(bdf, offset, &bar_value);
-          val_print(DEBUG, "\n       The BAR value of bdf %.6x", bdf);
+          val_print(DEBUG, "\n       The BAR value at offset %x", offset);
           val_print(DEBUG, " is %x ", bar_value);
           base = 0;
 
@@ -127,27 +137,14 @@ next_bdf:
           {
               /** This BAR is not implemented **/
               val_print(DEBUG, "\n       BAR is not implemented for BDF 0x%x", bdf);
-              tbl_index++;
-              goto next_bdf;
+              goto next_bar;
           }
 
           /* Skip for IO address space */
           if (bar_value & 0x1) {
               val_print(DEBUG, "\n       BAR is used for IO address space request");
               val_print(DEBUG, " for BDF 0x%x", bdf);
-              tbl_index++;
-              goto next_bdf;
-          }
-
-          val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
-          val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
-          base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
-              ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
-              || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
-              val_print(DEBUG, "\n       Skipping BDF as  0x%x", bdf);
-              tbl_index++;
-              goto next_bdf;
+              goto next_bar;
           }
 
           if (BAR_REG(bar_value) == BAR_64_BIT)
@@ -172,7 +169,7 @@ next_bdf:
               /* Restore the original BAR value */
               val_pcie_write_cfg(bdf, offset + 4, bar_value_1);
               val_pcie_write_cfg(bdf, offset, bar_value);
-              base = (base << 32) | bar_value;
+              base = (base << 32) | (bar_value & BAR_MASK);
           }
 
           else {
@@ -189,10 +186,11 @@ next_bdf:
 
               /* Restore the original BAR value */
               val_pcie_write_cfg(bdf, offset, bar_value);
-              base = bar_value;
+              base = bar_value & BAR_MASK;
           }
 
           val_print(DEBUG, "\n       BAR size is %x", bar_size);
+          val_print(DEBUG, "\n       BAR base is 0x%llx", base);
 
           /* Check if bar supports the remap size */
           if (bar_size < 1024) {
@@ -216,11 +214,11 @@ next_bdf:
 
           /* Handle unimplemented PAL -> Report WARN */
           if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-            test_abort = 1;
-            break;
+            goto test_status;
           }
           else if (status) {
-            val_print(ERROR, "\n       Failed in  ioremap with status %x", status);
+            val_print(ERROR,
+                  "\n       pal_memory_ioremap failed, status: 0x%x", status);
             test_fail++;
             val_set_status(index, RESULT_FAIL(test_fail));
             goto next_bar;
@@ -255,21 +253,18 @@ next_bar:
           if (msa_en)
               val_pcie_disable_msa(bdf);
       }
-
-      if (test_abort == 1)
-         break;
   }
 
-  if (test_warn) {
-    val_set_status(index, RESULT_WARNING(0));
-    return;
-  } else if (test_skip)
+test_status:
+  if (test_skip)
       val_set_status(index, RESULT_SKIP(1));
-  else if (test_fail)
+  else if (test_warn) {
+    val_set_status(index, RESULT_WARNING(1));
+  } else if (test_fail)
       val_set_status(index, RESULT_FAIL(test_fail));
   else
       val_set_status(index, RESULT_PASS);
-
+  return;
 }
 
 uint32_t

--- a/test_pool/pcie/p094.c
+++ b/test_pool/pcie/p094.c
@@ -66,7 +66,6 @@ payload(void)
   uint32_t test_skip = 1;
   uint32_t test_warn = 1;
   uint32_t test_fail = 0;
-  uint32_t test_abort = 0;
   uint64_t offset;
   uint64_t base;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -107,48 +106,52 @@ next_bdf:
               continue;
           }
 
+      val_print(DEBUG, "\n   BDF under check %08x", bdf);
+      val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
+      val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
+      base_cc = reg_value >> TYPE01_BCC_SHIFT;
+
+      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+          ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
+          || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
+          val_print(DEBUG, "\n       Skipping BDF 0x%x", bdf);
+          tbl_index++;
+          goto next_bdf;
+      }
+
       /* Configure the max BAR offset */
       dev_type = val_pcie_get_device_type(bdf);
-      if (dev_type == 0)
+      if (dev_type == 1)
           max_bar_offset = BAR_TYPE_0_MAX_OFFSET;
       else
           max_bar_offset = BAR_TYPE_1_MAX_OFFSET;
 
       offset = BAR0_OFFSET;
 
-      val_print(DEBUG, "\n   BDF under check %.6x", bdf);
-
       while (offset <= max_bar_offset) {
           val_pcie_read_cfg(bdf, offset, &bar_value);
-          val_print(DEBUG, "\n       The BAR value of bdf %.6x", bdf);
-          val_print(DEBUG, " is %x ", bar_value);
+          val_print(DEBUG, "\n       The BAR value at offset %x", offset);
+          val_print(DEBUG, " is %x", bar_value);
           base = 0;
 
           if (bar_value == 0)
           {
               /** This BAR is not implemented **/
               val_print(DEBUG, "\n       BAR is not implemented for BDF 0x%x", bdf);
-              tbl_index++;
-              goto next_bdf;
+              goto next_bar;
           }
 
           /* Skip for IO address space */
           if (bar_value & BAR_VALUE_IO_MASK) {
               val_print(DEBUG, "\n       BAR is used for IO address space request");
-              val_print(DEBUG, " for BDF 0x%x", bdf);
-              tbl_index++;
-              goto next_bdf;
+              goto next_bar;
           }
 
-          val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
-          val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
-          base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
-              ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
-              || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
-              val_print(DEBUG, "\n       Skipping BDF as  0x%x", bdf);
-              tbl_index++;
-              goto next_bdf;
+          /* Skip for NP BAR to avoid side effects */
+          if (BAR_MEM(bar_value) == BAR_NP_TYPE) {
+              val_print(DEBUG, "\n       BAR is of type Non-Prefetch");
+              val_print(DEBUG, " at offset 0x%x", offset);
+              goto next_bar;
           }
 
           if (BAR_REG(bar_value) == BAR_64_BIT)
@@ -173,7 +176,7 @@ next_bdf:
               /* Restore the original BAR value */
               val_pcie_write_cfg(bdf, offset + 4, bar_value_1);
               val_pcie_write_cfg(bdf, offset, bar_value);
-              base = (base << 32) | bar_value;
+              base = (base << 32) | (bar_value & BAR_MASK);
           }
 
           else {
@@ -190,15 +193,20 @@ next_bdf:
 
               /* Restore the original BAR value */
               val_pcie_write_cfg(bdf, offset, bar_value);
-              base = bar_value;
+              base = bar_value & BAR_MASK;
           }
 
           val_print(DEBUG, "\n       BAR size is %x", bar_size);
           val_print(DEBUG, "\n       BAR base is 0x%llx", base);
 
-          /* Check if bar supports the remap size */
-          if (bar_size < 1024) {
-              val_print(ERROR, "\n       Bar size less than remap requested size");
+          /* Check if bar supports the remap size
+           * Prefetch memory of size less than 32MB is
+           * is mapped to control register/lookup tables
+           * in certain platforms. Hence skipping if size
+           * is less than 32MB
+           */
+          if (bar_size <= SIZE_32M) {
+              val_print(DEBUG, "\n       Bar size less than 32MB. Skipping this BAR");
               goto next_bar;
           }
 
@@ -211,13 +219,15 @@ next_bdf:
 
           test_skip = 0;
 
+          base = base + SIZE_32M;
+          val_print(DEBUG, "\n       BAR base accessed is 0x%llx", base);
+
           /* Map the BARs to a NORMAL memory attribute. check unaligned access */
           status = val_memory_ioremap((void *)base, 1024, NORMAL_NC, (void **)&baseptr);
 
           /* Handle unimplemented PAL -> Report WARN */
           if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-            test_abort = 1;
-            break;
+            goto test_status;
           }
           else if (status)
           {
@@ -261,21 +271,18 @@ next_bar:
           if (msa_en)
               val_pcie_disable_msa(bdf);
       }
-
-      if (test_abort == 1)
-         break;
   }
 
-  if (test_warn) {
+test_status:
+  if (test_skip)
+      val_set_status(index, RESULT_SKIP(1));
+  else if (test_warn) {
     val_set_status(index, RESULT_WARNING(1));
-    return;
-  } else if (test_skip)
-      val_set_status(index, RESULT_FAIL(1));
-  else if (test_fail)
+  } else if (test_fail)
       val_set_status(index, RESULT_FAIL(test_fail));
   else
       val_set_status(index, RESULT_PASS);
-
+  return;
 }
 
 uint32_t

--- a/val/include/acs_pcie_spec.h
+++ b/val/include/acs_pcie_spec.h
@@ -140,6 +140,7 @@
 #define BAR_VALUE_PREFETCH_MASK   0x8
 #define BAR_VALUE_IO_MASK         0x1
 #define BAR_REG(bar_reg_value)    ((bar_reg_value >> 2) & 0x1)
+#define BAR_MEM(bar_reg_value)    ((bar_reg_value & 0xF) >> 3)
 
 #define TYPE0_MAX_BARS  6
 #define TYPE1_MAX_BARS  2

--- a/val/include/val_interface.h
+++ b/val/include/val_interface.h
@@ -774,6 +774,7 @@ uint32_t dl012_entry(uint32_t num_pe);
 #define SIZE_1K    1024ULL
 #define SIZE_16K   4 * SIZE_4K
 #define SIZE_1M    SIZE_1K * SIZE_1K
+#define SIZE_32M   32 * SIZE_1M
 #define SIZE_1G    SIZE_1M * SIZE_1K
 
 #define SOFTLIMIT_DIS 0x0

--- a/val/src/acs_iovirt.c
+++ b/val/src/acs_iovirt.c
@@ -296,7 +296,7 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
     smmu_ver = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, i);
     val_print(INFO,
-            " SMMU_INFO: SMMU index %.2d ", i);
+            " SMMU_INFO: SMMU index %02d ", i);
     val_print(INFO, "version     :    v%d", smmu_ver);
 
     if (smmu_ver == 3) {

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -78,7 +78,7 @@ val_pcie_read_cfg(uint32_t bdf, uint32_t offset, uint32_t *data)
   }
 
   if (ecam_base == 0) {
-      val_print(ERROR, "\n       PCIe_CFG_RD ECAM Base is zero %.8x", bdf);
+      val_print(ERROR, "\n       PCIe_CFG_RD ECAM Base is zero %08x", bdf);
       return PCIE_NO_MAPPING;
   }
 
@@ -154,7 +154,7 @@ val_pcie_write_cfg(uint32_t bdf, uint32_t offset, uint32_t data)
   }
 
   if (ecam_base == 0) {
-      val_print(ERROR, "\n       PCIe_CFG_WR ECAM Base is zero %.8x", bdf);
+      val_print(ERROR, "\n       PCIe_CFG_WR ECAM Base is zero %08x", bdf);
       return;
   }
 


### PR DESCRIPTION
- add BAR_MEM macro to detect non-prefetchable BAR type
- skip NP BARs and check only for Prefetch bars to avoid any side effects
- Mask the last 4 bits of the BAR value as it points to the attributes.
- Skip cndition to be verified first before checking the warn condition.
- Map Prefetch bar of base+32MB as most platforms map below 32MB to mapped to control registers, lookup tables, or routing tables.
- The endpoint check is incorrectly checked as a result only first 2 BARS were checked. Updated to check the right return type.
- When first BAR is 0, skipping to next BDF, instead of next bar, updated the changes accordingly to check for next bdf
- Replaced %.*x precision prints to zero padding prints
- Changed the SBSA Header prints from ERROR to INFO, as in logs it is considered as error
- Relates #282


Change-Id: Ieaa6609814cd25efb6495d8b5a77d4da73eabfea