### PR TITLE
test_pool: encode exerciser skip returns

### DIFF
--- a/test_pool/exerciser/e001.c
+++ b/test_pool/exerciser/e001.c
@@ -335,7 +335,7 @@ e001_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e002.c
+++ b/test_pool/exerciser/e002.c
@@ -491,7 +491,7 @@ e002_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e006.c
+++ b/test_pool/exerciser/e006.c
@@ -209,7 +209,7 @@ e006_entry(uint32_t num_pe)
   status = val_initialize_test (TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_payload (TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e007.c
+++ b/test_pool/exerciser/e007.c
@@ -237,7 +237,7 @@ e007_entry(uint32_t num_pe)
   status = val_initialize_test (TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+        return RESULT_SKIP(0);
       val_run_test_payload (TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e008.c
+++ b/test_pool/exerciser/e008.c
@@ -254,7 +254,7 @@ e008_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[0].test_num, test_entries[0].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_configurable_payload(&data, payload);
   }
 
@@ -278,7 +278,7 @@ e038_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[1].test_num, test_entries[1].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_configurable_payload(&data, payload);
   }
 

--- a/test_pool/exerciser/e015.c
+++ b/test_pool/exerciser/e015.c
@@ -212,7 +212,7 @@ e015_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e017.c
+++ b/test_pool/exerciser/e017.c
@@ -238,7 +238,7 @@ e017_entry(uint32_t num_pe)
   status = val_initialize_test(data.test_num, test_entries[0].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_configurable_payload(&data, payload);
   }
 

--- a/test_pool/exerciser/e026.c
+++ b/test_pool/exerciser/e026.c
@@ -250,7 +250,7 @@ e026_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[0].test_num, test_entries[0].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_configurable_payload(&data, payload);
   }
 
@@ -275,7 +275,7 @@ e032_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[1].test_num, test_entries[1].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_configurable_payload(&data, payload);
   }
 

--- a/test_pool/exerciser/e027.c
+++ b/test_pool/exerciser/e027.c
@@ -390,7 +390,7 @@ e027_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
      if (val_exerciser_test_init() != ACS_STATUS_PASS)
-         return TEST_SKIP;
+            return RESULT_SKIP(0);
      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e028.c
+++ b/test_pool/exerciser/e028.c
@@ -191,7 +191,7 @@ e028_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e029.c
+++ b/test_pool/exerciser/e029.c
@@ -212,7 +212,7 @@ e029_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e030.c
+++ b/test_pool/exerciser/e030.c
@@ -225,7 +225,7 @@ e030_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+        return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e040.c
+++ b/test_pool/exerciser/e040.c
@@ -328,7 +328,7 @@ e040_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+        return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e041.c
+++ b/test_pool/exerciser/e041.c
@@ -234,7 +234,7 @@ e041_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-      return TEST_SKIP;
+      return RESULT_SKIP(0);
 
     val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }

--- a/test_pool/exerciser/e043.c
+++ b/test_pool/exerciser/e043.c
@@ -184,7 +184,7 @@ e043_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+        return RESULT_SKIP(0);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e044.c
+++ b/test_pool/exerciser/e044.c
@@ -151,7 +151,7 @@ e044_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-      return TEST_SKIP;
+      return RESULT_SKIP(0);
     val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e045.c
+++ b/test_pool/exerciser/e045.c
@@ -152,7 +152,7 @@ e045_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-      return TEST_SKIP;
+      return RESULT_SKIP(0);
     val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 


### PR DESCRIPTION
- Replace raw TEST_SKIP returns in exerciser entry functions with RESULT_SKIP(0) so rule-based execution receives encoded skip results.
- This avoids reporting raw status values such as STATUS:0x00000007 for exerciser tests that exit early when exerciser initialization is unavailable.

Change-Id: I98a42eeddcaae9bcdb85c2d38aacef66fb829d61