### PR TITLE
fix(drtm): Report launch validation failures

### DIFF
--- a/test_pool/drtm/dl001.c
+++ b/test_pool/drtm/dl001.c
@@ -60,11 +60,11 @@ payload(uint32_t num_pe)
   /* This will return invalid parameter */
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ERROR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
+    val_set_status(index, RESULT_FAIL(3));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(3));
         val_set_status(index, RESULT_FAIL(4));
       }
     }

--- a/test_pool/drtm/dl007.c
+++ b/test_pool/drtm/dl007.c
@@ -94,11 +94,11 @@ payload(uint32_t num_pe)
     val_print(ERROR, "\n       DRTM Dynamic Launch failed, Expected = %d",
                             DRTM_ACS_SECONDARY_PE_NOT_OFF);
     val_print(ERROR, " Found = %d", status);
+    val_set_status(index, RESULT_FAIL(3));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(3));
         val_set_status(index, RESULT_FAIL(4));
       }
     }

--- a/test_pool/drtm/dl008.c
+++ b/test_pool/drtm/dl008.c
@@ -113,11 +113,11 @@ payload(uint32_t num_pe)
   /* This will return invalid parameter */
   if (status != DRTM_ACS_INVALID_PARAMETERS) {
     val_print(ERROR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
+    val_set_status(index, RESULT_FAIL(5));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(5));
         val_set_status(index, RESULT_FAIL(6));
       }
     }
@@ -138,11 +138,11 @@ payload(uint32_t num_pe)
     /* This will return invalid parameter */
     if (status != DRTM_ACS_INVALID_PARAMETERS) {
       val_print(ERROR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
+      val_set_status(index, RESULT_FAIL(7));
       if (status == DRTM_ACS_SUCCESS) {
         status = val_drtm_unprotect_memory();
         if (status < DRTM_ACS_SUCCESS) {
           val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-      val_set_status(index, RESULT_FAIL(7));
           val_set_status(index, RESULT_FAIL(8));
         }
       }
@@ -170,11 +170,11 @@ payload(uint32_t num_pe)
     /* This will return invalid parameter */
     if (status != DRTM_ACS_INVALID_PARAMETERS) {
       val_print(ERROR, "\n       Incorrect Status. Expected = -2 Found = %d", status);
+      val_set_status(index, RESULT_FAIL(9));
       if (status == DRTM_ACS_SUCCESS) {
         status = val_drtm_unprotect_memory();
         if (status < DRTM_ACS_SUCCESS) {
           val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-      val_set_status(index, RESULT_FAIL(9));
           val_set_status(index, RESULT_FAIL(10));
         }
       }

--- a/test_pool/drtm/dl011.c
+++ b/test_pool/drtm/dl011.c
@@ -160,11 +160,11 @@ payload(uint32_t num_pe)
   /* This will return invalid parameter */
   if (status != DRTM_ACS_MEM_PROTECT_INVALID) {
     val_print(ERROR, "\n       Incorrect Status. Expected = -6 Found = %d", status);
+    val_set_status(index, RESULT_FAIL(7));
     if (status == DRTM_ACS_SUCCESS) {
       status = val_drtm_unprotect_memory();
       if (status < DRTM_ACS_SUCCESS) {
         val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(7));
         val_set_status(index, RESULT_FAIL(8));
       }
     }


### PR DESCRIPTION
* Set failure status immediately when DRTM launch returns unexpected status.
* Preserve separate failure reporting for unprotect memory errors.


Change-Id: I76f7a8c286b58071aa5163b2b8b93dfbbbb18931