### PR TITLE
fix(test status): return packed skip results from entry paths

### DIFF
--- a/test_pool/drtm/interface010.c
+++ b/test_pool/drtm/interface010.c
@@ -102,7 +102,7 @@ interface010_entry(uint32_t num_pe)
 
   if (status != ACS_STATUS_SKIP) {
       if (val_gic_its_configure() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       /* execute payload, which will execute relevant functions on current and other PEs */
       payload(num_pe);
   }

--- a/test_pool/drtm/interface011.c
+++ b/test_pool/drtm/interface011.c
@@ -91,7 +91,7 @@ interface011_entry(uint32_t num_pe)
 
   if (status != ACS_STATUS_SKIP) {
       if (val_gic_its_configure() != ACS_STATUS_PASS)
-          return TEST_SKIP;
+          return RESULT_SKIP(0);
       /* execute payload, which will execute relevant functions on current and other PEs */
       payload(num_pe);
   }

--- a/val/src/test_wrappers.c
+++ b/val/src/test_wrappers.c
@@ -444,7 +444,7 @@ v_l1wk_02_05_entry(uint32_t num_pe)
 {
 #ifdef TARGET_LINUX
     // Test not applicable for Linux target
-    return TEST_SKIP;
+    return RESULT_SKIP(0);
 #endif
 
     if (acs_policy_get_el1skiptrap_mask() & EL1SKIPTRAP_CNTPCT) {


### PR DESCRIPTION
- Status reporting now expects packed RESULT_* values.
- Several early-skip paths in test entry functions returned raw TEST_SKIP(0x7), which is not encoded and was printed as STATUS:0x00000007STATUS:0x00000007 in logs.
- Fix this by replacing raw return TEST_SKIP; with return RESULT_SKIP(0); in affected entry paths.


Change-Id: I0974ec8a673f1aef62decd96f6d4e0384e6e534e