### PR TITLE
val: skip log context printing in Rule-Based builds

### DIFF
--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -39,6 +39,13 @@ static acs_test_status_counters_t g_rule_test_stats;
 void
 val_log_context(char8_t *file, char8_t *func, uint32_t line)
 {
+#ifndef COMPILE_RB_EXE
+  /* Skip printing log context when built for Rule-Based execution. */
+  (void)file;
+  (void)func;
+  (void)line;
+  return;
+#else
   char8_t *trimmed_file;
   char8_t *marker;
   /* Substring to locate in full file path */
@@ -66,6 +73,7 @@ val_log_context(char8_t *file, char8_t *func, uint32_t line)
   val_print(DEBUG, "%d", line);
   val_print(DEBUG, " ");
   val_print(DEBUG, func);
+#endif /* COMPILE_RB_EXE */
 }
 
 /**


### PR DESCRIPTION
- val_log_context() emitted a file:line + function banner before every test's header line, which produced noisy and mis-aligned output in builds that use the Rule-Based execution path.
- Guard the body of val_log_context() with COMPILE_RB_EXE so the banner is suppressed in the Rule-Based build configuration while remaining available for the standard ACS build. The arguments are explicitly cast to void in the suppressed path to avoid unused-parameter warnings.

Change-Id: I3fb3de19ddd6d0e7afe7db84441dfcbbe6498302