### PR TITLE
build: add ACS_LEVEL CMake flag for baremetal compliance level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,43 @@ if(DEFINED ACS_VERBOSE_LEVEL)
     endif()
 endif()
 
+# Propagate ACS_LEVEL into compiler definitions for all sources.
+# This selects the compliance level for the active ACS suite at compile
+# time, overriding the PLATFORM_OVERRIDE_<ACS>_LEVEL value supplied by
+# the platform header. Valid values:
+#   - A positive integer: sets ctx->level_value = <n> and selects
+#     LVL_FILTER_MAX (run all rules with level <= n).
+#   - "fr" / "FR": selects LVL_FILTER_FR (future-requirements mode);
+#     ctx->level_value is left at the platform default.
+# Per-ACS valid numeric ranges:
+#   bsa    : 1
+#   sbsa   : 3..7
+#   pc_bsa : 1
+# Usage:
+#   cmake -DACS_LEVEL=7 ...
+#   cmake -DACS_LEVEL=fr ...
+if(DEFINED ACS_LEVEL)
+    string(TOUPPER "${ACS_LEVEL}" _ACS_LEVEL_UC)
+    if("${_ACS_LEVEL_UC}" STREQUAL "FR")
+        message(STATUS "[ACS] : ACS_LEVEL=fr -> selecting LVL_FILTER_FR (compile defs: ACS_LEVEL_FR)")
+        add_compile_definitions(ACS_LEVEL_FR)
+    elseif("${ACS_LEVEL}" MATCHES "^[0-9]+$")
+        message(STATUS "[ACS] : ACS_LEVEL (compile defs) = ${ACS_LEVEL}")
+        if("${ACS}" STREQUAL "sbsa")
+            if(${ACS_LEVEL} LESS 3 OR ${ACS_LEVEL} GREATER 7)
+                message(WARNING "[ACS] : ACS_LEVEL=${ACS_LEVEL} is outside the supported SBSA range (3..7); runtime will clamp it")
+            endif()
+        elseif("${ACS}" STREQUAL "bsa" OR "${ACS}" STREQUAL "pc_bsa")
+            if(NOT ${ACS_LEVEL} EQUAL 1)
+                message(WARNING "[ACS] : ACS_LEVEL=${ACS_LEVEL} is not the only supported level for ${ACS} (1); runtime will clamp it")
+            endif()
+        endif()
+        add_compile_definitions(ACS_LEVEL=${ACS_LEVEL})
+    else()
+        message(FATAL_ERROR "[ACS] : ACS_LEVEL must be a positive integer or 'fr' (got '${ACS_LEVEL}')")
+    endif()
+endif()
+
 ### Cmake clean target ###
 list(APPEND CLEAN_LIST
         ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_HEADER}
@@ -177,6 +214,12 @@ endif()
 if(DEFINED ACS_VERBOSE_LEVEL)
     message(STATUS "[ACS] : ACS_VERBOSE_LEVEL (top-level) = ${ACS_VERBOSE_LEVEL}")
     list(APPEND DEFAULT_OVERRIDE_ARGS -DACS_VERBOSE_LEVEL=${ACS_VERBOSE_LEVEL})
+endif()
+
+#   cmake -DACS_LEVEL=7 ...
+if(DEFINED ACS_LEVEL)
+    message(STATUS "[ACS] : ACS_LEVEL (top-level) = ${ACS_LEVEL}")
+    list(APPEND DEFAULT_OVERRIDE_ARGS -DACS_LEVEL=${ACS_LEVEL})
 endif()
 
 # Enable fast-path optimizations for simulation/emulation builds.

--- a/apps/baremetal/acs_runtime_init.c
+++ b/apps/baremetal/acs_runtime_init.c
@@ -294,5 +294,25 @@ acs_apply_compile_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
     policy->print_level = FATAL;
 #endif
 
+  /*
+   * Compile-time compliance level override (via CMake `-DACS_LEVEL=<n|fr>`):
+   *
+   *   ACS_LEVEL_FR    -> select future-requirements filter mode; leave
+   *                      ctx->level_value at whatever was set by the
+   *                      platform/user defaults so existing range
+   *                      clamping continues to apply.
+   *   ACS_LEVEL=<n>   -> set ctx->level_value = <n> and force the
+   *                      standard "levels <= n" filter (LVL_FILTER_MAX).
+   *
+   * If neither is defined the value set by apply_user_config_and_defaults()
+   * (from PLATFORM_OVERRIDE_<ACS>_LEVEL) is preserved.
+   */
+#if defined(ACS_LEVEL_FR)
+  ctx->level_filter_mode = LVL_FILTER_FR;
+#elif defined(ACS_LEVEL)
+  ctx->level_value = ACS_LEVEL;
+  ctx->level_filter_mode = LVL_FILTER_MAX;
+#endif
+
   return;
 }

--- a/pal/baremetal/module_config.rst
+++ b/pal/baremetal/module_config.rst
@@ -41,6 +41,43 @@ Examples
    cmake .. -DACS_VERBOSE_LEVEL=1
 
 -------------------------------------
+Compliance Level Control (ACS_LEVEL)
+-------------------------------------
+You can override the target compliance level of the active ACS suite at
+CMake configure time. When ``ACS_LEVEL`` is defined it takes precedence
+over the per-platform ``PLATFORM_OVERRIDE_<ACS>_LEVEL`` value supplied by
+``pal/baremetal/target/<TARGET>/include/platform_override_fvp.h``.
+
+**Default:** value of ``PLATFORM_OVERRIDE_<ACS>_LEVEL`` from the platform
+header, with ``LVL_FILTER_MAX`` filter mode.
+
+**Set Level:** define ``ACS_LEVEL=<value>`` at CMake configure time.
+
+Accepted values:
+
+- A positive integer ``<n>`` — sets ``ctx->level_value = <n>`` and
+  selects ``LVL_FILTER_MAX`` (run all rules with level ``<=`` n).
+- ``fr`` (or ``FR``) — selects ``LVL_FILTER_FR`` (future-requirements
+  mode). ``ctx->level_value`` is left at the platform default.
+
+Per-ACS valid numeric ranges:
+
+- ``-DACS=bsa``    : ``1``
+- ``-DACS=sbsa``   : ``3..7``
+- ``-DACS=pc_bsa`` : ``1``
+
+Numeric values outside the supported range are clamped to the nearest
+valid level at runtime, with a console warning.
+
+Examples
+~~~~~~~~
+.. code-block:: bash
+
+   cmake --preset sbsa -DACS_LEVEL=7
+   cmake --preset sbsa -DACS_LEVEL=fr
+   cmake --preset bsa  -DACS_LEVEL=1
+
+-------------------------------------
 MMU Control (ACS_ENABLE_MMU)
 -------------------------------------
 


### PR DESCRIPTION
Introduce a CMake build-time option, -DACS_LEVEL=<value>, that overrides the per-platform PLATFORM_OVERRIDE_<ACS>_LEVEL compliance level for baremetal ACS runs.

Accepted values:

  * Positive integer <n>: sets ctx->level_value = <n> and selects LVL_FILTER_MAX (run all rules with level <= n). Per-ACS valid ranges are validated at configure time: bsa=1, sbsa=3..7, pc_bsa=1; out-of-range values produce a warning and are clamped at runtime.
  * 'fr' (case-insensitive): selects LVL_FILTER_FR (future-requirements mode); ctx->level_value is left at the platform default.

When ACS_LEVEL is not set, the existing platform header default is used.

Changes:

  * CMakeLists.txt: validate ACS_LEVEL, define ACS_LEVEL=<n> or ACS_LEVEL_FR for the C sources, and forward the value to nested wrapper builds via DEFAULT_OVERRIDE_ARGS.
  * apps/baremetal/{bsa,sbsa,pc_bsa}_main.c: honor ACS_LEVEL / ACS_LEVEL_FR when applying user config defaults; existing runtime range clamping is preserved.
  * pal/baremetal/module_config.rst: document the new flag and accepted values.


Change-Id: I01221549662678a61b3ecf57439a79fb29c9b64d