### PR TITLE
Fix log message format for reserved bits check

### DIFF
--- a/test_pool/drtm/interface002.c
+++ b/test_pool/drtm/interface002.c
@@ -52,7 +52,7 @@ static void payload(void)
     status = val_drtm_features(invalid_fid, &feat1, &feat2);
     if (status != DRTM_ACS_NOT_SUPPORTED) {
         val_print(WARN,
-                    "\n       Function ID Rsvd Bits:[62:32] not zero, status=%d", status);
+                    "\n       Func ID Rsvd Bits[62:32] not zero, status=%d", status);
     }
 
     val_set_status(index, RESULT_PASS);


### PR DESCRIPTION
Due to length of log message the Result value is coming in next line leading to skip of this test by lor parsing script.