### PR TITLE
fix: allow all three EL1 skiptrap modes in EL3 params

### DIFF
--- a/pal/baremetal/run_time_params.rst
+++ b/pal/baremetal/run_time_params.rst
@@ -61,7 +61,8 @@ The structure layout is defined in ``acs_el3_param.h`` as:
 
   uint64_t cache  :1;               /*Pass this flag to indicate that if the test system supports
                                     PCIe address translation cache\n*/
-  uint64_t el1skiptrap_mask  :1;          /*Skips EL1 register checks*/
+  uint64_t el1skiptrap_mask  :3;    /*Bitmask of EL1SKIPTRAP_* flags(b0=PMSIDR,
+                                      b1=CNTPCT, b2=DEVMEM)*/
   uint64_t mmio   :1;               /*enable pal_mmio_read/write prints use with **verbose** */
   uint64_t no_crypto_ext :1;        /*cryptography extension not supported*/
   uint64_t software_view_filter :3; /*b0 : OS software view test b1 : Hypervisior view test
@@ -80,7 +81,7 @@ The structure layout is defined in ``acs_el3_param.h`` as:
   uint64_t sys_cache :2;            /*Specify SLC cache type 0-unknown
                                     1-PPTT PE-side LLC
                                     2 - HMAT mem-side LLC */
-  uint64_t reserved :11;
+  uint64_t reserved :9;
 } acs_el3_params;
 
 Notes:

--- a/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDN2/src/platform_cfg_fvp.c
@@ -83,7 +83,9 @@ acs_get_platform_run_request_defaults(void)
  *   2 - HMAT mem-side LLC
  *
  * el1skiptrap_mask is a bitmask composed from EL1SKIPTRAP_* flags when a
- * platform needs specific EL1 register accesses skipped.
+ * platform needs specific EL1 register accesses skipped:
+ *   b0=EL1SKIPTRAP_PMSIDR, b1=EL1SKIPTRAP_CNTPCT, b2=EL1SKIPTRAP_DEVMEM.
+ *   Example: el1skiptrap_mask = EL1SKIPTRAP_CNTPCT;
  */
 static const acs_execution_policy_t g_platform_execution_policy = {
     .timeout_pass = PLATFORM_OVERRIDE_TIMEOUT,

--- a/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3/src/platform_cfg_fvp.c
@@ -83,7 +83,9 @@ acs_get_platform_run_request_defaults(void)
  *   2 - HMAT mem-side LLC
  *
  * el1skiptrap_mask is a bitmask composed from EL1SKIPTRAP_* flags when a
- * platform needs specific EL1 register accesses skipped.
+ * platform needs specific EL1 register accesses skipped:
+ *   b0=EL1SKIPTRAP_PMSIDR, b1=EL1SKIPTRAP_CNTPCT, b2=EL1SKIPTRAP_DEVMEM.
+ *   Example: el1skiptrap_mask = EL1SKIPTRAP_CNTPCT;
  */
 static const acs_execution_policy_t g_platform_execution_policy = {
     .timeout_pass = PLATFORM_OVERRIDE_TIMEOUT,

--- a/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
+++ b/pal/baremetal/target/RDV3CFG1/src/platform_cfg_fvp.c
@@ -83,7 +83,9 @@ acs_get_platform_run_request_defaults(void)
  *   2 - HMAT mem-side LLC
  *
  * el1skiptrap_mask is a bitmask composed from EL1SKIPTRAP_* flags when a
- * platform needs specific EL1 register accesses skipped.
+ * platform needs specific EL1 register accesses skipped:
+ *   b0=EL1SKIPTRAP_PMSIDR, b1=EL1SKIPTRAP_CNTPCT, b2=EL1SKIPTRAP_DEVMEM.
+ *   Example: el1skiptrap_mask = EL1SKIPTRAP_CNTPCT;
  */
 static const acs_execution_policy_t g_platform_execution_policy = {
     .timeout_pass = PLATFORM_OVERRIDE_TIMEOUT,

--- a/val/include/acs_el3_param.h
+++ b/val/include/acs_el3_param.h
@@ -54,7 +54,8 @@ typedef struct {
 
   uint64_t cache  :1;               /*Pass this flag to indicate that if the test system supports
                                     PCIe address translation cache\n*/
-  uint64_t el1skiptrap_mask  :1;    /*Skips EL1 register checks*/
+  uint64_t el1skiptrap_mask  :3;    /*Bitmask of EL1SKIPTRAP_* flags: b0=PMSIDR,
+                                      b1=CNTPCT, b2=DEVMEM*/
   uint64_t mmio   :1;               /*enable pal_mmio_read/write prints use with **verbose** */
   uint64_t no_crypto_ext :1;        /*cryptography extension not supported*/
   uint64_t software_view_filter :3; /*b0 : OS software view test b1 : Hypervisior view test
@@ -73,7 +74,7 @@ typedef struct {
   uint64_t sys_cache :2;            /*Specify SLC cache type 0-unknown
                                     1-PPTT PE-side LLC
                                     2 - HMAT mem-side LLC */
-  uint64_t reserved :11;
+  uint64_t reserved :9;
 } acs_el3_params;
 
 #endif /* ACS_EL3_PARAM_H */


### PR DESCRIPTION
  - widen el1skiptrap_mask to 3 bits in acs_el3_param and doc
  - adjust reserved field accordingly to preserve struct size


Change-Id: I65d919fe077592140e46fda6b9f13275a6d08f44