### PR TITLE
fix: make p096 IRQ handling deterministic

### DIFF
--- a/pal/uefi_acpi/src/pal_peripherals.c
+++ b/pal/uefi_acpi/src/pal_peripherals.c
@@ -85,6 +85,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
+          per_info->irq   = 0;
           per_info->platform_type = PLATFORM_TYPE_ACPI;
           pal_print_msg(ACS_PRINT_INFO,
                         "  Found a USB controller %4x\n",
@@ -111,6 +112,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
+          per_info->irq   = 0;
           per_info->platform_type = PLATFORM_TYPE_ACPI;
           pal_print_msg(ACS_PRINT_INFO,
                         "  Found a SATA controller %4x\n",

--- a/pal/uefi_dt/src/pal_peripherals.c
+++ b/pal/uefi_dt/src/pal_peripherals.c
@@ -660,6 +660,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
+          per_info->irq   = 0;
           pal_print_msg(ACS_PRINT_INFO,
                         "  Found a USB controller %4x\n",
                         per_info->base0);
@@ -690,6 +691,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
                   break;
           }
           per_info->bdf   = DeviceBdf;
+          per_info->irq   = 0;
           pal_print_msg(ACS_PRINT_INFO,
                         "  Found a SATA controller %4x\n",
                         per_info->base0);


### PR DESCRIPTION
- Initialize missing IRQ values for PCIe-discovered USB and SATA peripherals.
- Prevent stale peripheral table data from triggering legacy IRQ-map checks.

Change-Id: Ibcaeda51646d79bc24fa59b337ef3da2eacec780