### PR TITLE
feat: Switch skip-dp-nic-ms skips to WARN with explicit guidance

### DIFF
--- a/test_pool/pcie/p030.c
+++ b/test_pool/pcie/p030.c
@@ -106,6 +106,8 @@ payload(void)
   uint32_t base_cc;
   uint32_t test_fails;
   uint32_t test_skip = 1;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   uint64_t bar_base;
   uint32_t status;
   uint32_t timeout;
@@ -159,9 +161,10 @@ payload(void)
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+          if (skip_flag &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
+              skip_due_to_flag = true;
               val_print(DEBUG, "\n       Skipping for BDF 0x%x", bdf);
               continue;
           }
@@ -228,8 +231,19 @@ exception_return:
       bar_data = 0;
   }
 
-  if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(1));
+  if (test_skip == 1) {
+      if (skip_flag && skip_due_to_flag) {
+          val_print(WARN,
+            "\n       DP/NIC/MAS/RES devices are skipped.");
+          val_print(WARN,
+            "\n       Please individually run the test without");
+          val_print(WARN,
+            "\n       --skip-dp-nic-ms to check the compliance.");
+          val_set_status(pe_index, RESULT_WARNING(1));
+      } else {
+          val_set_status(pe_index, RESULT_SKIP(1));
+      }
+  }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));
   else

--- a/test_pool/pcie/p035.c
+++ b/test_pool/pcie/p035.c
@@ -66,6 +66,8 @@ payload(void)
   uint32_t base_cc;
   uint32_t test_fails;
   uint32_t test_skip = 1;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   uint32_t idx;
   uint32_t timeout;
   uint32_t status;
@@ -92,10 +94,11 @@ payload(void)
        * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+      if (skip_flag &&
           ((base_cc == UNCLAS_CC) || (base_cc == MAS_CC)
           || (base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC)))
       {
+          skip_due_to_flag = true;
           val_print(DEBUG, "\n       Skipping for BDF - 0x%x ", bdf);
           val_print(DEBUG, " Classcode is : 0x%x ", base_cc);
           continue;
@@ -206,9 +209,19 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(DEBUG,
-        "\n       No EP type device found with PCIe Express Cap support. Skipping test");
-      val_set_status(pe_index, RESULT_SKIP(1));
+      if (skip_flag && skip_due_to_flag) {
+          val_print(WARN,
+            "\n       DP/NIC/MAS/RES devices are skipped.");
+          val_print(WARN,
+            "\n       Please individually run the test without");
+          val_print(WARN,
+            "\n       --skip-dp-nic-ms to check the compliance.");
+          val_set_status(pe_index, RESULT_WARNING(1));
+      } else {
+          val_print(DEBUG,
+            "\n       No EP type device found with PCIe Express Cap support. Skipping test");
+          val_set_status(pe_index, RESULT_SKIP(1));
+      }
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pcie/p045.c
+++ b/test_pool/pcie/p045.c
@@ -63,6 +63,8 @@ payload(void)
   char    *baseptr;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   uint32_t test_skip = 1;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   uint32_t test_warn = 1;
   uint32_t test_fail = 0;
   uint64_t offset;
@@ -110,9 +112,10 @@ next_bdf:
       val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
 
-      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+      if (skip_flag &&
           ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
           || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
+          skip_due_to_flag = true;
           val_print(DEBUG, "\n       Skipping BDF 0x%x", bdf);
           tbl_index++;
           goto next_bdf;
@@ -256,10 +259,20 @@ next_bar:
   }
 
 test_status:
-  if (test_skip)
-      val_set_status(index, RESULT_SKIP(1));
-  else if (test_warn) {
-    val_set_status(index, RESULT_WARNING(1));
+  if (test_skip) {
+      if (skip_flag && skip_due_to_flag) {
+          val_print(WARN,
+            "\n       DP/NIC/MAS/RES devices are skipped.");
+          val_print(WARN,
+            "\n       Please individually run the test without");
+          val_print(WARN,
+            "\n       --skip-dp-nic-ms to check the compliance.");
+          val_set_status(index, RESULT_WARNING(1));
+      } else {
+          val_set_status(index, RESULT_SKIP(1));
+      }
+  } else if (test_warn) {
+      val_set_status(index, RESULT_WARNING(1));
   } else if (test_fail)
       val_set_status(index, RESULT_FAIL(test_fail));
   else

--- a/test_pool/pcie/p058.c
+++ b/test_pool/pcie/p058.c
@@ -118,6 +118,8 @@ payload(void *arg)
   uint32_t base_cc;
   uint32_t test_fails;
   uint32_t test_skip = 1;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   uint64_t bar_base;
   uint32_t dp_type;
   uint32_t status;
@@ -198,9 +200,10 @@ payload(void *arg)
           val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
           val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
           base_cc = reg_value >> TYPE01_BCC_SHIFT;
-          if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+          if (skip_flag &&
               ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
               || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
+              skip_due_to_flag = true;
               val_print(DEBUG, "\n       Skipping for BDF 0x%x", bdf);
               continue;
           }
@@ -268,9 +271,19 @@ exception_return:
   }
 
   if (test_skip == 1) {
-      val_print(DEBUG,
-        "\n       Found no target device type with MMIO BAR. Skipping test.");
-      val_set_status(pe_index, RESULT_SKIP(01));
+      if (skip_flag && skip_due_to_flag) {
+          val_print(WARN,
+            "\n       DP/NIC/MAS/RES devices are skipped.");
+          val_print(WARN,
+            "\n       Please individually run the test without");
+          val_print(WARN,
+            "\n       --skip-dp-nic-ms to check the compliance.");
+          val_set_status(pe_index, RESULT_WARNING(01));
+      } else {
+          val_print(DEBUG,
+            "\n       Found no target device type with MMIO BAR. Skipping test.");
+          val_set_status(pe_index, RESULT_SKIP(01));
+      }
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pcie/p063.c
+++ b/test_pool/pcie/p063.c
@@ -67,6 +67,8 @@ payload(void)
   uint32_t base_cc;
   uint32_t test_fails;
   bool     test_skip = 1;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   uint32_t idx;
   uint32_t timeout;
   uint32_t status;
@@ -93,10 +95,11 @@ payload(void)
        * init can get corrupted when FLR is done */
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
-      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+      if (skip_flag &&
           ((base_cc == UNCLAS_CC) || (base_cc == MAS_CC)
           || (base_cc == CNTRL_CC) || (base_cc == DP_CNTRL_CC)))
       {
+          skip_due_to_flag = true;
           val_print(DEBUG, "\n       Skipping for BDF - 0x%x ", bdf);
           val_print(DEBUG, " Classcode is : 0x%x ", base_cc);
           continue;
@@ -202,9 +205,19 @@ payload(void)
   }
 
   if (test_skip == 1) {
-      val_print(DEBUG,
-        "\n       No target device type with FLR Cap found. Skipping test");
-      val_set_status(pe_index, RESULT_SKIP(01));
+      if (skip_flag && skip_due_to_flag) {
+          val_print(WARN,
+            "\n       DP/NIC/MAS/RES devices are skipped.");
+          val_print(WARN,
+            "\n       Please individually run the test without");
+          val_print(WARN,
+            "\n       --skip-dp-nic-ms to check the compliance.");
+          val_set_status(pe_index, RESULT_WARNING(01));
+      } else {
+          val_print(DEBUG,
+            "\n       No target device type with FLR Cap found. Skipping test");
+          val_set_status(pe_index, RESULT_SKIP(01));
+      }
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pcie/p094.c
+++ b/test_pool/pcie/p094.c
@@ -66,6 +66,8 @@ payload(void)
   uint32_t test_skip = 1;
   uint32_t test_warn = 1;
   uint32_t test_fail = 0;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   uint64_t offset;
   uint64_t base;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -111,9 +113,10 @@ next_bdf:
       val_print(DEBUG, "\n       Class code is 0x%x", reg_value);
       base_cc = reg_value >> TYPE01_BCC_SHIFT;
 
-      if (acs_policy_get_pcie_skip_dp_nic_ms() &&
+      if (skip_flag &&
           ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
           || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC))) {
+          skip_due_to_flag = true;
           val_print(DEBUG, "\n       Skipping BDF 0x%x", bdf);
           tbl_index++;
           goto next_bdf;
@@ -274,10 +277,20 @@ next_bar:
   }
 
 test_status:
-  if (test_skip)
-      val_set_status(index, RESULT_SKIP(1));
-  else if (test_warn) {
-    val_set_status(index, RESULT_WARNING(1));
+  if (test_skip) {
+      if (skip_flag && skip_due_to_flag) {
+          val_print(WARN,
+            "\n       DP/NIC/MAS/RES devices are skipped.");
+          val_print(WARN,
+            "\n       Please individually run the test without");
+          val_print(WARN,
+            "\n       --skip-dp-nic-ms to check the compliance.");
+          val_set_status(index, RESULT_WARNING(1));
+      } else {
+          val_set_status(index, RESULT_SKIP(1));
+      }
+  } else if (test_warn) {
+      val_set_status(index, RESULT_WARNING(1));
   } else if (test_fail)
       val_set_status(index, RESULT_FAIL(test_fail));
   else

--- a/test_pool/pcie/p097.c
+++ b/test_pool/pcie/p097.c
@@ -121,6 +121,8 @@ payload (void)
   uint64_t current_dev_bdf;
   uint64_t next_dev_bdf;
   uint32_t test_skip = 1;
+  bool skip_due_to_flag = false;
+  bool skip_flag = acs_policy_get_pcie_skip_dp_nic_ms();
   pcie_device_bdf_table *bdf_tbl_ptr;
   uint32_t tbl_index = 0;
   uint32_t tbl_index_next = 0;
@@ -146,11 +148,13 @@ payload (void)
        * descriptors is causing an exception and for the devices
        * with base class codes greater than 13h as they
        * are reserved */
-      if ((acs_policy_get_pcie_skip_dp_nic_ms() &&
+      bool skip_by_flag = (skip_flag &&
           ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
-          || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)))
-          || (base_cc > RES_CC))
+          || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)));
+      if (skip_by_flag || (base_cc > RES_CC))
       {
+        if (skip_by_flag)
+          skip_due_to_flag = true;
         tbl_index++;
         val_print(DEBUG, "\n        Skipping DP/NIC/MAS/RES device.");
         continue;
@@ -191,11 +195,13 @@ payload (void)
                 * descriptors is causing an exception and for the devices
                 * with base class codes greater than 13h as they
                 * are reserved */
-                if ((acs_policy_get_pcie_skip_dp_nic_ms() &&
+                skip_by_flag = (skip_flag &&
                     ((base_cc == UNCLAS_CC) || (base_cc == CNTRL_CC)
-                    || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)))
-                    || (base_cc > RES_CC))
+                    || (base_cc == DP_CNTRL_CC) || (base_cc == MAS_CC)));
+                if (skip_by_flag || (base_cc > RES_CC))
                 {
+                  if (skip_by_flag)
+                    skip_due_to_flag = true;
                   val_print(DEBUG, "\n        Skipping DP/NIC/MAS/RES device.");
                   tbl_index_next++;
                   continue;
@@ -247,8 +253,18 @@ payload (void)
   }
 
   if (test_skip) {
-    val_print(ERROR, "\n       No MSI vectors found ");;
-    val_set_status (index, RESULT_SKIP(01));
+    if (skip_flag && skip_due_to_flag) {
+      val_print(WARN,
+        "\n       DP/NIC/MAS/RES devices are skipped.");
+      val_print(WARN,
+        "\n       Please individually run the test without");
+      val_print(WARN,
+        "\n       --skip-dp-nic-ms to check the compliance.");
+      val_set_status (index, RESULT_WARNING(01));
+    } else {
+      val_print(ERROR, "\n       No MSI vectors found ");
+      val_set_status (index, RESULT_SKIP(01));
+    }
   } else  if (!status) {
     val_set_status (index, RESULT_PASS);
   }


### PR DESCRIPTION
  - Treat skip-dp-nic-ms filtered PCIe cases as WARN instead of SKIP so they surface in results.
  - Emit a short, wrapped warning message directing users to rerun without --skip-dp-nic-ms.
  - Track skip_due_to_flag in PCIe tests to differentiate flag-driven skips from missing devices

Fixes https://github.com/ARM-software/arm-systemready/issues/719

Change-Id: I3691aa72275b95a55beb10436fc9cf560ac6a2f1