### PR TITLE
feat(pe): add SVE vector length detection support

### DIFF
--- a/test_pool/pe/pe016.c
+++ b/test_pool/pe/pe016.c
@@ -25,9 +25,76 @@
 typedef struct {
   uint64_t data;
   uint32_t status;
+  uint16_t vector_len_bits;
 } sve_reg_details;
 
 sve_reg_details *g_sve_reg_info;
+
+static
+uint16_t
+pe_get_max_sve_vector_length()
+{
+  uint16_t vl;
+  uint64_t el;
+  uint64_t cpacr, cptr_el2, hcr;
+  uint64_t original_zcr, programmed_zcr, effective_zcr;
+  bool is_host;
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  el = val_pe_reg_read(CurrentEL);
+  val_print_primary_pe(DEBUG, "\n     Current EL = %llx", el, index);
+
+  if (el == AARCH64_EL1) {
+    /* Read CPACR_EL1.ZEN bits [17:16] */
+    cpacr = VAL_EXTRACT_BITS(val_pe_reg_read(CPACR_EL1), 16, 17);
+
+    /* If ZEN = 00 or 10 (LSB == 0), SVE access is trapped */
+    if ((cpacr & 0x1) == 0) {
+      val_print_primary_pe(DEBUG, "\n       SVE disabled at EL1 (CPACR_EL1.ZEN = 0x%x)",
+          cpacr, index);
+      return 0;
+    }
+  } else if (el == AARCH64_EL2) {
+    /* Read CPTR_EL2 it controls SVE access at EL2*/
+    cptr_el2 = val_pe_reg_read(CPTR_EL2);
+    hcr = val_pe_reg_read(HCR_EL2);
+    is_host = VAL_EXTRACT_BITS(hcr, 34, 34);
+
+    if (is_host == 0)
+    {
+      /* If TZ == 1 trap SVE access */
+      if (VAL_EXTRACT_BITS(cptr_el2, 8, 8) == 1) {
+        val_print_primary_pe(DEBUG, "\n       SVE trapped at EL2 (CPTR_EL2.TZ = 0x%x)",
+            VAL_EXTRACT_BITS(cptr_el2, 8, 8), index);
+        return 0;
+      }
+    } else {
+      /* If ZEN = 00 or 10 (LSB == 0), SVE access is trapped */
+      if ((VAL_EXTRACT_BITS(cptr_el2, 16, 17) & 0x1) == 0) {
+        val_print_primary_pe(DEBUG, "\n       SVE disabled at EL2 (CPTR_EL2.ZEN = 0x%x)",
+            VAL_EXTRACT_BITS(cptr_el2, 16, 17), index);
+        return 0;
+      }
+    }
+  }
+
+  /*Request maximum SVE vector length by setting LEN field to max
+   *Read back effective value and Restore original ZCR_EL1 to avoid
+   *modifying system state.
+   */
+  original_zcr = val_pe_reg_read(ZCR_EL1);
+  programmed_zcr = (original_zcr & ~ZCR_EL1_LEN_MASK) | ZCR_EL1_LEN_MASK;
+  val_pe_reg_write(ZCR_EL1, programmed_zcr);
+  isb();
+
+  effective_zcr = val_pe_reg_read(ZCR_EL1);
+  val_pe_reg_write(ZCR_EL1, original_zcr);
+  isb();
+
+  vl = (uint16_t)((VAL_EXTRACT_BITS(effective_zcr, 0, 3) + 1) * 128);
+
+  return vl;
+}
 
 static
 void
@@ -35,6 +102,7 @@ payload()
 {
   uint32_t pe_family;
   uint64_t data;
+  uint64_t sve_present;
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
   sve_reg_details *tmp_reg_data;
   uint64_t buffer_ptr, addr;
@@ -42,6 +110,12 @@ payload()
   val_get_test_data(index, &addr, &buffer_ptr);
   tmp_reg_data = (sve_reg_details *)buffer_ptr;
   tmp_reg_data = tmp_reg_data + index;
+  tmp_reg_data->vector_len_bits = 0;
+
+  /* Read ID_AA64PFR0_EL1.SVE[35:32] == 1 for SVE support */
+  sve_present = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64PFR0_EL1), 32, 35);
+  if (sve_present != 0)
+    tmp_reg_data->vector_len_bits = pe_get_max_sve_vector_length();
 
  /* Read ID_AA64ZFR0_EL1 for SVE2 support */
   data = val_pe_reg_read(ID_AA64ZFR0_EL1);
@@ -53,31 +127,32 @@ payload()
   /* If PE implements SVE2, it's a pass. No need to check architecture family, as
    * BSA mandates SVE2 from v9 */
   if (VAL_EXTRACT_BITS(data, 0, 3) > 0) {
-    val_set_status(index, RESULT_PASS);
     tmp_reg_data->status = ACS_STATUS_PASS;
+    val_set_status(index, RESULT_PASS);
+  } else {
+
+    /* Get PE family for each PE index*/
+    pe_family = val_get_pe_architecture(index);
+
+    /* SVE2 not implemented, SMBIOS info missing, cannot confirm if PE is v9. Skipping the test */
+    if (pe_family == ACS_STATUS_ERR) {
+      val_set_status(index, RESULT_SKIP(2));
+      tmp_reg_data->status = ACS_STATUS_ERR;
+      return;
+    }
+
+    /* SVE2 not implemented, SMBIOS does not report Armv9, skipping the test */
+    if (pe_family != PROCESSOR_FAMILY_ARMV9) {
+      val_set_status(index, RESULT_SKIP(3));
+      tmp_reg_data->status = ACS_STATUS_SKIP;
+      return;
+    }
+
+    /* SVE2 not implemented, SMBIOS reports Armv9, failing the test */
+    val_set_status(index, RESULT_FAIL(1));
+    tmp_reg_data->status = ACS_STATUS_FAIL;
     return;
   }
-
-  /* Get PE family for each PE index*/
-  pe_family = val_get_pe_architecture(index);
-
-  /* SVE2 not implemented, SMBIOS info missing, cannot confirm if PE is v9. Skipping the test */
-  if (pe_family == ACS_STATUS_ERR) {
-    val_set_status(index, RESULT_SKIP(2));
-    tmp_reg_data->status = ACS_STATUS_ERR;
-    return;
-  }
-
-  /* SVE2 not implemented, SMBIOS does not report Armv9, skipping the test */
-  if (pe_family != PROCESSOR_FAMILY_ARMV9) {
-    val_set_status(index, RESULT_SKIP(3));
-    tmp_reg_data->status = ACS_STATUS_SKIP;
-    return;
-  }
-
-  /* SVE2 not implemented, SMBIOS reports Armv9, failing the test */
-  val_set_status(index, RESULT_FAIL(1));
-  tmp_reg_data->status = ACS_STATUS_FAIL;
 }
 
 uint32_t
@@ -86,6 +161,10 @@ pe016_entry(uint32_t num_pe)
 
   uint32_t status = ACS_STATUS_FAIL;  //default value
   uint32_t i, smbios_slots, index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint16_t ref_vector_len = 0;
+  bool vector_len_set = 0;
+  bool vector_len_mismatch = 0;
+  uint32_t sve_pe_count = 0;
   sve_reg_details *reg_buffer;
 
   val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
@@ -123,8 +202,29 @@ pe016_entry(uint32_t num_pe)
       else if (reg_buffer->status == ACS_STATUS_FAIL) {
         val_print(DEBUG, "\n       Processor is v9 and FEAT_SVE2 is not implemented.");
         val_print(DEBUG, " ID_AA64ZFR0_EL1.SVEver 0x%llx  FAIL", reg_buffer->data);
-      } else
+      } else {
         val_print(DEBUG, "\n       ID_AA64ZFR0_EL1.SVEver 0x%llx PASS", reg_buffer->data);
+        if (reg_buffer->vector_len_bits)
+          val_print(INFO, "\n       PE[%d] VL = %u bits", i, reg_buffer->vector_len_bits);
+        else
+          val_print(DEBUG, "\n       PE[%d] VL probe skipped or not accessible", i);
+      }
+
+      /* Only PEs that implement SVE and return a valid VL are considered.
+       * PEs without SVE or inaccessible VL are ignored. */
+      if ((reg_buffer->status == ACS_STATUS_PASS) && reg_buffer->vector_len_bits) {
+        sve_pe_count++;
+        if (!vector_len_set) {
+          ref_vector_len = reg_buffer->vector_len_bits;
+          vector_len_set = 1;
+        } else if (reg_buffer->vector_len_bits != ref_vector_len) {
+          vector_len_mismatch = 1;
+        }
+      }
+    }
+
+    if (vector_len_mismatch && sve_pe_count > 1) {
+      val_print(INFO, "\n       PEs report differing maximum SVE vector lengths across PEs");
     }
 
     val_memory_free((void *) g_sve_reg_info);

--- a/val/include/acs_pe.h
+++ b/val/include/acs_pe.h
@@ -80,6 +80,9 @@
 #define BSA_TCR_PS_SHIFT   16
 #define BSA_TCR_PS_MASK    (0x7ull << BSA_TCR_PS_SHIFT)
 
+#define ZCR_EL1_LEN_SHIFT 0
+#define ZCR_EL1_LEN_MASK   (0xFULL << ZCR_EL1_LEN_SHIFT)
+
 /* MPIDR macros */
 #define PAL_MPIDR_AFFLVL_MASK    0xffull
 #define PAL_MPIDR_AFFINITY_BITS  8
@@ -195,7 +198,10 @@ typedef enum {
   TRCIDR4,
   TRCIDR5,
   HCR_EL2,
-  VTCR_EL2
+  VTCR_EL2,
+  CPTR_EL2,
+  CPACR_EL1,
+  ZCR_EL1,
 } BSA_ACS_PE_REGS;
 
 uint64_t AA64WriteSp(uint64_t write_data);

--- a/val/include/val_sysreg_pe.h
+++ b/val/include/val_sysreg_pe.h
@@ -56,6 +56,7 @@ SYSREG_READ_FUNC(pmsidr_el1)
 SYSREG_READ_FUNC(lorid_el1)
 
 SYSREG_RW_FUNCS(mdcr_el2)
+SYSREG_RW_FUNCS(zcr_el1)
 
 SYSREG_RW_FUNCS(pmcr_el0)
 SYSREG_RW_FUNCS(pmovsclr_el0)

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -220,14 +220,20 @@ val_pe_reg_read(uint32_t reg_id)
           return read_trbidr_el1();
       case TRCIDR0:
           return read_trcidr0();
-       case TRCIDR4:
+      case TRCIDR4:
           return read_trcidr4();
-       case TRCIDR5:
+      case TRCIDR5:
           return read_trcidr5();
-       case HCR_EL2:
+      case HCR_EL2:
           return read_hcr_el2();
-       case VTCR_EL2:
+      case VTCR_EL2:
           return read_vtcr_el2();
+      case ZCR_EL1:
+          return read_zcr_el1();
+      case CPTR_EL2:
+          return read_cptr_el2();
+      case CPACR_EL1:
+          return read_cpacr_el1();
       default:
            val_report_status(val_pe_get_index_mpid(val_pe_get_mpid()),
                                                  RESULT_FAIL(0xFF), NULL);
@@ -267,6 +273,15 @@ val_pe_reg_write(uint32_t reg_id, uint64_t write_data)
           break;
       case PMINTENCLR_EL1:
           write_pmintenclr_el1(write_data);
+          break;
+      case CPTR_EL2:
+          write_cptr_el2(write_data);
+          break;
+      case CPACR_EL1:
+          write_cpacr_el1(write_data);
+          break;
+      case ZCR_EL1:
+          write_zcr_el1(write_data);
           break;
       case MDCR_EL2:
           write_mdcr_el2(write_data);


### PR DESCRIPTION
- Add maximum SVE vector length probing using ZCR_EL1
- Check SVE accessibility via CPACR_EL1 and CPTR_EL2 to avoid traps
- Capture and report per-PE SVE vector length
- Detect mismatched SVE vector lengths across PE
- Extend PE register access APIs with CPTR_EL2, CPACR_EL1 and ZCR_EL1

Fixes #365

Change-Id: Ia3eb96982ea2562e0e54860c6569400e0f4b9998
Signed-off-by: Shanmuga Priya L <[shanmuga.priyal@arm.com](mailto:shanmuga.priyal@arm.com)>