### PR TITLE
Feat : Modify the status of exerciser tests from skip to warn

### DIFF
--- a/test_pool/exerciser/e001.c
+++ b/test_pool/exerciser/e001.c
@@ -235,7 +235,7 @@ payload(void)
 
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+    val_set_status(pe_index, RESULT_WARNING(2));
     return;
   }
 
@@ -335,7 +335,7 @@ e001_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e002.c
+++ b/test_pool/exerciser/e002.c
@@ -358,7 +358,7 @@ payload(void)
 
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+    val_set_status(pe_index, RESULT_WARNING(2));
     return;
   }
 
@@ -491,7 +491,7 @@ e002_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e003.c
+++ b/test_pool/exerciser/e003.c
@@ -372,7 +372,7 @@ payload(void)
   barspace_transactions_order_check();
 
   if (warn_cnt)
-    val_set_status(pe_index, RESULT_WARNING(1));
+    val_set_status(pe_index, RESULT_WARNING(2));
   else if (!run_flag)
     val_set_status(pe_index, RESULT_SKIP(2));
   else if (fail_cnt)
@@ -394,7 +394,7 @@ e003_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e004.c
+++ b/test_pool/exerciser/e004.c
@@ -181,7 +181,7 @@ e004_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e006.c
+++ b/test_pool/exerciser/e006.c
@@ -186,7 +186,7 @@ payload (void)
   if (test_fail)
       val_set_status(pe_index, RESULT_FAIL(03));
   else if (warn_cnt)
-      val_set_status(pe_index, RESULT_WARNING(01));
+      val_set_status(pe_index, RESULT_WARNING(02));
   else if (test_skip)
       val_set_status(pe_index, RESULT_SKIP(01));
   else
@@ -209,7 +209,7 @@ e006_entry(uint32_t num_pe)
   status = val_initialize_test (TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload (TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e007.c
+++ b/test_pool/exerciser/e007.c
@@ -237,7 +237,7 @@ e007_entry(uint32_t num_pe)
   status = val_initialize_test (TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-        return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload (TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e008.c
+++ b/test_pool/exerciser/e008.c
@@ -254,7 +254,7 @@ e008_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[0].test_num, test_entries[0].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(test_entries[0].rule);
       val_run_test_configurable_payload(&data, payload);
   }
 
@@ -278,7 +278,7 @@ e038_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[1].test_num, test_entries[1].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(test_entries[1].rule);
       val_run_test_configurable_payload(&data, payload);
   }
 

--- a/test_pool/exerciser/e010.c
+++ b/test_pool/exerciser/e010.c
@@ -115,7 +115,7 @@ e010_entry(uint32_t num_pe)
   status = val_initialize_test (TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload (TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e011.c
+++ b/test_pool/exerciser/e011.c
@@ -116,7 +116,7 @@ e011_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e012.c
+++ b/test_pool/exerciser/e012.c
@@ -191,7 +191,7 @@ e012_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e013.c
+++ b/test_pool/exerciser/e013.c
@@ -229,7 +229,7 @@ e013_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e014.c
+++ b/test_pool/exerciser/e014.c
@@ -189,7 +189,7 @@ e014_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e015.c
+++ b/test_pool/exerciser/e015.c
@@ -212,7 +212,7 @@ e015_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e016.c
+++ b/test_pool/exerciser/e016.c
@@ -140,7 +140,7 @@ return;
 
 test_warn_unimplemented:
   val_memory_unmap(baseptr);
-  val_set_status(pe_index, RESULT_WARNING(01));
+  val_set_status(pe_index, RESULT_WARNING(02));
   return;
 
 test_fail:
@@ -160,7 +160,7 @@ e016_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e017.c
+++ b/test_pool/exerciser/e017.c
@@ -238,7 +238,7 @@ e017_entry(uint32_t num_pe)
   status = val_initialize_test(data.test_num, test_entries[0].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(test_entries[0].rule);
       val_run_test_configurable_payload(&data, payload);
   }
 
@@ -263,7 +263,7 @@ e034_entry(uint32_t num_pe)
   status = val_initialize_test(data.test_num, test_entries[1].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(test_entries[1].rule);
       val_run_test_configurable_payload(&data, payload);
   }
 

--- a/test_pool/exerciser/e019.c
+++ b/test_pool/exerciser/e019.c
@@ -334,7 +334,7 @@ e019_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e020.c
+++ b/test_pool/exerciser/e020.c
@@ -397,7 +397,7 @@ e020_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e021.c
+++ b/test_pool/exerciser/e021.c
@@ -436,7 +436,7 @@ payload(void)
   barspace_transactions_order_check();
 
   if (warn_cnt) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+    val_set_status(pe_index, RESULT_WARNING(2));
     return;
   } else if (!run_flag) {
       val_set_status(pe_index, RESULT_SKIP(01));
@@ -460,7 +460,7 @@ e021_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e022.c
+++ b/test_pool/exerciser/e022.c
@@ -229,7 +229,7 @@ e022_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e023.c
+++ b/test_pool/exerciser/e023.c
@@ -444,7 +444,7 @@ e023_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e024.c
+++ b/test_pool/exerciser/e024.c
@@ -428,7 +428,7 @@ e024_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e025.c
+++ b/test_pool/exerciser/e025.c
@@ -174,7 +174,7 @@ payload(void)
 
   /* Check If PCIe Hierarchy supports P2P. */
   if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(01));
+    val_set_status(pe_index, RESULT_WARNING(02));
     return;
   }
 
@@ -249,7 +249,7 @@ e025_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e026.c
+++ b/test_pool/exerciser/e026.c
@@ -250,7 +250,7 @@ e026_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[0].test_num, test_entries[0].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(test_entries[0].rule);
       val_run_test_configurable_payload(&data, payload);
   }
 
@@ -275,7 +275,7 @@ e032_entry(uint32_t num_pe)
   status = val_initialize_test(test_entries[1].test_num, test_entries[1].desc, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(test_entries[1].rule);
       val_run_test_configurable_payload(&data, payload);
   }
 

--- a/test_pool/exerciser/e027.c
+++ b/test_pool/exerciser/e027.c
@@ -390,7 +390,7 @@ e027_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
      if (val_exerciser_test_init() != ACS_STATUS_PASS)
-            return RESULT_SKIP(0);
+         return val_exerciser_get_init_result(TEST_RULE);
      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e028.c
+++ b/test_pool/exerciser/e028.c
@@ -191,7 +191,7 @@ e028_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e029.c
+++ b/test_pool/exerciser/e029.c
@@ -212,7 +212,7 @@ e029_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e030.c
+++ b/test_pool/exerciser/e030.c
@@ -225,7 +225,7 @@ e030_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-        return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e033.c
+++ b/test_pool/exerciser/e033.c
@@ -179,7 +179,7 @@ e033_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e035.c
+++ b/test_pool/exerciser/e035.c
@@ -199,8 +199,8 @@ e035_entry(uint32_t num_pe)
   val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
-     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-         return RESULT_SKIP(1);
+    if (val_exerciser_test_init() != ACS_STATUS_PASS)
+         return val_exerciser_get_init_result(TEST_RULE);
      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e036.c
+++ b/test_pool/exerciser/e036.c
@@ -420,7 +420,7 @@ e036_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-          return RESULT_SKIP(1);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e039.c
+++ b/test_pool/exerciser/e039.c
@@ -148,7 +148,7 @@ payload(void)
 test_warn_unimplemented:
   if (baseptr != NULL)
       val_memory_unmap(baseptr);
-  val_set_status(pe_index, RESULT_WARNING(01));
+  val_set_status(pe_index, RESULT_WARNING(02));
   return;
 
 test_fail:
@@ -170,8 +170,8 @@ e039_entry(uint32_t num_pe)
   val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
-     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-         return RESULT_SKIP(0);
+    if (val_exerciser_test_init() != ACS_STATUS_PASS)
+         return val_exerciser_get_init_result(TEST_RULE);
      val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e040.c
+++ b/test_pool/exerciser/e040.c
@@ -278,7 +278,7 @@ payload(void)
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   if (val_exerciser_test_init() != ACS_STATUS_PASS) {
-    val_set_status(pe_index, RESULT_SKIP(01));
+    val_set_status(pe_index, val_exerciser_get_init_result(TEST_RULE));
     return;
   }
 
@@ -328,7 +328,7 @@ e040_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-        return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e041.c
+++ b/test_pool/exerciser/e041.c
@@ -234,7 +234,7 @@ e041_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-      return RESULT_SKIP(0);
+      return val_exerciser_get_init_result(TEST_RULE);
 
     val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }

--- a/test_pool/exerciser/e043.c
+++ b/test_pool/exerciser/e043.c
@@ -184,7 +184,7 @@ e043_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
       if (val_exerciser_test_init() != ACS_STATUS_PASS)
-        return RESULT_SKIP(0);
+          return val_exerciser_get_init_result(TEST_RULE);
       val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e044.c
+++ b/test_pool/exerciser/e044.c
@@ -151,7 +151,7 @@ e044_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-      return RESULT_SKIP(0);
+      return val_exerciser_get_init_result(TEST_RULE);
     val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/test_pool/exerciser/e045.c
+++ b/test_pool/exerciser/e045.c
@@ -85,7 +85,7 @@ payload(void)
 
   status = val_exerciser_check_firmware_handle_support();
   if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+    val_set_status(pe_index, RESULT_WARNING(2));
     return;
   }
 
@@ -152,7 +152,7 @@ e045_entry(uint32_t num_pe)
   status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
   if (status != ACS_STATUS_SKIP) {
     if (val_exerciser_test_init() != ACS_STATUS_PASS)
-      return RESULT_SKIP(0);
+      return val_exerciser_get_init_result(TEST_RULE);
     val_run_test_payload(TEST_NUM, num_pe, payload, 0);
   }
 

--- a/val/include/acs_exerciser.h
+++ b/val/include/acs_exerciser.h
@@ -127,6 +127,7 @@ uint32_t val_exerciser_get_pcie_ras_compliant_err_node(uint32_t bdf, uint32_t rp
 uint64_t val_exerciser_get_ras_status(uint32_t ras_node, uint32_t e_bdf, uint32_t erp_bdf);
 uint32_t val_exerciser_set_bar_response(uint32_t bdf);
 uint32_t val_exerciser_test_init(void);
+uint32_t val_exerciser_get_init_result(const char8_t *rule_id);
 uint32_t val_exerciser_check_firmware_handle_support(void);
 
 uint32_t e001_entry(uint32_t num_pe);

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -26,6 +26,9 @@ EXERCISER_INFO_TABLE g_exerciser_info_table;
 
 extern uint32_t pcie_bdf_table_list_flag;
 
+/* Cached result from the last exerciser init attempt, encoded as RESULT_* */
+static uint32_t g_exerciser_init_result = RESULT_PASS;
+
 /**
   @brief   Return a string representing the vendor name for a given vendor ID
 **/
@@ -379,6 +382,8 @@ val_exerciser_check_firmware_handle_support(void)
   Builds the PCIe BDF table, validates platform hierarchy, discovers Exerciser
   instances, initializes and disables SMMU contexts, and configures ITS once.
   Subsequent calls return the cached status from the first invocation.
+  The encoded outcome for the last attempt can be queried via
+  val_exerciser_get_init_result() to surface WARN vs SKIP to rule-based flows.
 
   @return ACS_STATUS_PASS on success
   @return ACS_STATUS_SKIP if prerequisites are not met (no ECAM/BDF/Exerciser,
@@ -388,6 +393,7 @@ uint32_t val_exerciser_test_init(void)
 {
 /* For non-rule based build the init is done by val_*bsa_exerciser_execute_tests */
 #ifndef COMPILE_RB_EXE
+    g_exerciser_init_result = RESULT_PASS;
     return ACS_STATUS_PASS;
 #endif
     static uint32_t status = ACS_STATUS_UNKNOWN;
@@ -400,11 +406,14 @@ uint32_t val_exerciser_test_init(void)
         return status;
     }
 
+    g_exerciser_init_result = RESULT_PASS;
+
     /* Build BDF table for all PCIe devices */
     if (val_pcie_create_device_bdf_table()) {
         val_print(WARN,
                   "\n     Create BDF Table Failed, Skipping Exerciser tests...\n");
         status = ACS_STATUS_SKIP;
+        g_exerciser_init_result = RESULT_SKIP(0);
         return status;
     }
 
@@ -413,6 +422,7 @@ uint32_t val_exerciser_test_init(void)
                   "\n     *** Created device list with valid bdf doesn't match with the"
                   " platform pcie device hierarchy, Skipping exerciser tests ***\n");
         status = ACS_STATUS_SKIP;
+        g_exerciser_init_result = RESULT_SKIP(0);
         return status;
     }
 
@@ -421,9 +431,8 @@ uint32_t val_exerciser_test_init(void)
     val_exerciser_create_info_table();
     num_instances = val_exerciser_get_info(EXERCISER_NUM_CARDS);
     if (num_instances == 0) {
-        val_print(WARN,
-                  "\n     No Exerciser Devices Found, Skipping Exerciser tests...\n");
         status = ACS_STATUS_SKIP;
+        g_exerciser_init_result = RESULT_WARNING(1);
         return status;
     }
 
@@ -432,6 +441,7 @@ uint32_t val_exerciser_test_init(void)
     if (val_smmu_init() == ACS_STATUS_ERR) {
         val_print(ERROR, "\n     val_smmu_init() failed \n");
         status = ACS_STATUS_SKIP;
+        g_exerciser_init_result = RESULT_SKIP(0);
         return status;
     }
 
@@ -446,6 +456,7 @@ uint32_t val_exerciser_test_init(void)
         if (val_gic_its_configure() == ACS_STATUS_ERR) {
             val_print(ERROR, "\n     val_gic_its_configure() failed \n");
             status = ACS_STATUS_SKIP;
+            g_exerciser_init_result = RESULT_SKIP(0);
             return status;
         }
         g_its_init = 1;
@@ -453,4 +464,65 @@ uint32_t val_exerciser_test_init(void)
 
     status = ACS_STATUS_PASS;
     return status;
+}
+
+#ifdef COMPILE_RB_EXE
+static bool
+rule_is_conditional(const char8_t *rule_id)
+{
+    uint32_t i;
+    const char8_t *curr;
+    uint32_t len_rule;
+    uint32_t len_curr;
+    /* Extend this list with conditional rules that should SKIP when exerciser is absent. */
+    static const char8_t *conditional_rules[] = {
+        "RI_SMU_1",
+        "PCI_ER_10",
+        "B_PCIe_10",
+        "RI_SMU_3",
+        "CXL_09",
+        "CXL_06",
+    };
+
+    if (rule_id == NULL) {
+        return STATUS_ERROR;
+    }
+
+    len_rule = (uint32_t)val_strlen((char *)rule_id);
+
+    for (i = 0; i < (sizeof(conditional_rules) / sizeof(conditional_rules[0])); i++) {
+        curr = conditional_rules[i];
+        len_curr = (uint32_t)val_strlen((char *)curr);
+        if (len_rule != len_curr) {
+            continue;
+        }
+        /* Compare including terminator to ensure full-string match */
+        if (val_strncmp((char8_t *)rule_id, (char8_t *)curr, len_rule + 1) == 0) {
+            return STATUS_ERROR;
+        }
+    }
+    return STATUS_SUCCESS;
+}
+#endif
+
+uint32_t
+val_exerciser_get_init_result(const char8_t *rule_id)
+{
+#ifndef COMPILE_RB_EXE
+    return RESULT_PASS;
+#else
+    /* Surface the cached warning for each caller when no exerciser is present. */
+    if (GET_STATE(g_exerciser_init_result) == TEST_WARNING) {
+        if (rule_is_conditional(rule_id)) {
+            return RESULT_SKIP(0);
+        }
+        val_print(WARN,
+                  "\n     This test requires PCIe exerciser.");
+        val_print(WARN,
+                  "\n     Please rerun with a supported exerciser device");
+        val_print(WARN,
+                  "\n     or conduct manual review.");
+    }
+    return g_exerciser_init_result;
+#endif
 }


### PR DESCRIPTION
	Modify the status of exerciser tests from skip to warn
when no exercisers are found. Also added a warning print to notify the users


Change-Id: I5edb422eff756592d4c97f3b6d5976914ce6b7a5