### PR TITLE
Enhancement: Added new Makefile parameter CHIP_ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,15 @@ if(DEFINED ACS_ENABLE_MMU)
     add_compile_definitions(ACS_ENABLE_MMU=${ACS_ENABLE_MMU})
 endif()
 
+if(NOT DEFINED CHIP_ID)
+    set(CHIP_ID 0 CACHE STRING "Default CHIP_ID value" FORCE)
+    message(STATUS "[ACS] : Defaulting CHIP_ID to ${CHIP_ID}")
+else()
+    set(CHIP_ID "${CHIP_ID}" CACHE STRING "CHIP_ID is set to ${CHIP_ID}" FORCE)
+    message(STATUS "[ACS] : CHIP_ID is set to ${CHIP_ID}")
+endif()
+add_compile_definitions(CHIP_ID=${CHIP_ID})
+
 # Propagate ACS_VERBOSE_LEVEL into compiler definitions for all sources
 if(DEFINED ACS_VERBOSE_LEVEL)
     message(STATUS "[ACS] : ACS_VERBOSE_LEVEL (compile defs) = ${ACS_VERBOSE_LEVEL}")
@@ -147,6 +156,9 @@ if(DEFINED ACS_ENABLE_MMU)
     message(STATUS "[ACS] : ACS_ENABLE_MMU (compile defs) = ${ACS_ENABLE_MMU}")
     list(APPEND DEFAULT_OVERRIDE_ARGS -DACS_ENABLE_MMU=${ACS_ENABLE_MMU})
 endif()
+
+#   cmake -DCHIP_ID=0
+list(APPEND DEFAULT_OVERRIDE_ARGS -DCHIP_ID=${CHIP_ID})
 
 #   cmake -DACS_VERBOSE_LEVEL=1 ...
 if(DEFINED ACS_VERBOSE_LEVEL)

--- a/patches/edk2_sbsa_nist.patch
+++ b/patches/edk2_sbsa_nist.patch
@@ -32,26 +32,6 @@ index 7e985f8280..ae19e5b070 100644
 +       *_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES
 +!endif
 +!include edk2-libc/StdLib/StdLib.inc
-diff --git a/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c b/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c
-index e3b595e..cc12b38 100644
---- a/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c
-+++ b/edk2-libc/StdLib/LibC/Main/Arm/flt_rounds.c
-@@ -38,13 +38,14 @@ __RCSID("$NetBSD: flt_rounds.c,v 1.3 2006/02/25 00:58:35 wiz Exp $");
- 
- #include <sys/types.h>
- //#include <ieeefp.h>
--
-+#if 0
- static const int map[] = {
-   1,  /* round to nearest */
-   2,  /* round to positive infinity */
-   3,  /* round to negative infinity */
-   0   /* round to zero */
- };
-+#endif
- 
- /*
-  * Return the current FP rounding mode
 diff --git a/edk2-libc/StdLib/LibC/Main/Main.c b/edk2-libc/StdLib/LibC/Main/Main.c
 index b203d15..8c9618e 100644
 --- a/edk2-libc/StdLib/LibC/Main/Main.c


### PR DESCRIPTION
    This is useful in PAL layer,
     if the Base Addresses change with respect to CHIP_IDs

Change-Id: I895cf7c3710d00b61552164f3d59e56c85811082