### PR TITLE
Baremetal: expose build target macro and print banner target

### DIFF
--- a/apps/baremetal/bsa_main.c
+++ b/apps/baremetal/bsa_main.c
@@ -148,6 +148,7 @@ ShellAppMainbsa()
     val_print(INFO, "\n          Version %d.", BSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", BSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", BSA_ACS_SUBMINOR_VER);
+    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 BSA_LEVEL_FR), ctx->level_value);

--- a/apps/baremetal/pc_bsa_main.c
+++ b/apps/baremetal/pc_bsa_main.c
@@ -175,6 +175,7 @@ ShellAppMainpcbsa(void)
     val_print(INFO, "\n          Version %d.", PC_BSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", PC_BSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", PC_BSA_ACS_SUBMINOR_VER);
+    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 PCBSA_LEVEL_FR), ctx->level_value);

--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -195,6 +195,7 @@ ShellAppMainsbsa()
     val_print(INFO, "    Version %d.", SBSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", SBSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", SBSA_ACS_SUBMINOR_VER);
+    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
 
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,

--- a/tools/cmake/toolchain/gnuarm.cmake
+++ b/tools/cmake/toolchain/gnuarm.cmake
@@ -34,6 +34,9 @@ endif()
 
 message(STATUS "[ACS] : TARGET_SWITCH is set to ${TARGET_SWITCH}")
 
+# Expose the selected target as a string macro for binaries to report.
+add_compile_definitions(ACS_TARGET="${TARGET}")
+
 if(${ENABLE_PIE})
     set(COMPILE_PIE_SWITCH "-fpie")
     add_definitions(-DENABLE_PIE)


### PR DESCRIPTION
  - Add ACS_TARGET compile definition from selected TARGET in gnuarm toolchain.
  - Show resolved build target in BSA/SBSA/PC_BSA app banners for clarity.


Change-Id: I3321432aa491ce863e6dd2fdf45cfa9757525a40