### PR TITLE
ras: Add RAS error status clear into common VAL helper

### DIFF
--- a/test_pool/ras/ras005.c
+++ b/test_pool/ras/ras005.c
@@ -30,6 +30,8 @@
 
 static uint64_t int_id;
 static uint32_t intr_pending = 1;
+static uint32_t intr_node_index;
+static uint8_t intr_is_pfg_check;
 
 static
 void
@@ -37,9 +39,10 @@ intr_handler(void)
 {
   intr_pending = 0;
 
-  /* Clear the interrupt pending state */
+  /* Clear the RAS source before the common IRQ wrapper EOIs the interrupt. */
+  val_ras_clear_error_status(intr_node_index, intr_is_pfg_check);
 
-  val_print(TRACE, "\n       Received interrupt %x       ");
+  val_print(TRACE, "\n       Received interrupt 0x%x", int_id);
   val_gic_end_of_interrupt(int_id);
   return;
 }
@@ -121,6 +124,8 @@ payload()
       err_in_params.node_index = node_index;
       err_in_params.ras_error_type = ERR_CE;
       err_in_params.is_pfg_check = 0;
+      intr_node_index = node_index;
+      intr_is_pfg_check = err_in_params.is_pfg_check;
 
       /* Install handler for interrupt */
       val_gic_install_isr(int_id, intr_handler);

--- a/val/include/acs_ras.h
+++ b/val/include/acs_ras.h
@@ -112,6 +112,7 @@ uint32_t val_ras_check_plat_poison_support(void);
 
 uint64_t val_ras_reg_read(uint32_t node_index, uint32_t reg, uint32_t err_rec_idx);
 void val_ras_reg_write(uint32_t node_index, uint32_t reg, uint64_t write_data);
+void val_ras_clear_error_status(uint32_t node_index, uint8_t is_pfg_check);
 
 uint32_t ras001_entry(uint32_t num_pe);
 uint32_t ras002_entry(uint32_t num_pe);

--- a/val/src/acs_ras.c
+++ b/val/src/acs_ras.c
@@ -574,6 +574,26 @@ val_ras_reg_write(uint32_t node_index, uint32_t reg, uint64_t write_data)
 }
 
 /**
+  @brief  Function to clear the RAS error status after an error interrupt.
+
+  @param  node_index     RAS Node index in the info table.
+  @param  is_pfg_check  Pseudo fault check indicator.
+
+  @return None
+**/
+void
+val_ras_clear_error_status(uint32_t node_index, uint8_t is_pfg_check)
+{
+  if (is_pfg_check)
+    val_ras_reg_write(node_index, RAS_ERR_PFGCTL, 0);
+
+  val_ras_reg_write(node_index, RAS_ERR_STATUS, ERR_STATUS_CLEAR);
+
+  /* Read back to make sure the clear write has completed before EOI. */
+  (void)val_ras_reg_read(node_index, RAS_ERR_STATUS, 0);
+}
+
+/**
   @brief  Function for setting up the Error Environment
 
   @param  in_param  - Error Input Parameters.


### PR DESCRIPTION
  Add val_ras_clear_error_status() in the common RAS VAL layer to clear
  ERR<n>STATUS and optionally clear ERR<n>PFGCTL for pseudo fault checks.

  Update ras005 interrupt handling to use the common helper before EOI
  instead of keeping RAS clear logic in the test.


Change-Id: I0c5a27ba2b3cd57fe01d5b42a5c6700b3c1e1792