### PR TITLE
fix(test): Fix MPIDR_EL1 truncation during register read

### DIFF
--- a/test_pool/gic/g005.c
+++ b/test_pool/gic/g005.c
@@ -39,8 +39,8 @@ payload()
   uint32_t enable_grp1ns;
   uint32_t data;
   uint32_t are_ns = val_gic_get_info(GIC_INFO_AFFINITY_NS);
-  uint32_t index, mpid;
-  uint64_t pe_rdbase;
+  uint32_t index;
+  uint64_t pe_rdbase, mpid;
 
   mpid = val_pe_get_mpid();
   val_print(DEBUG, "\n       PE MPIDR 0x%x", mpid);


### PR DESCRIPTION
   Store the 64-bit MPIDR_EL1 value in a 64-bit variable to avoid losing
    the upper 32 bits.

Change-Id: If354e2f5ad4420e18ee1b36447e5365a7f36ab89