### PR TITLE
docs(baremetal): align ARM arch defaults with baremetal build

### DIFF
--- a/docs/baremetal/README.md
+++ b/docs/baremetal/README.md
@@ -60,8 +60,8 @@ Run the command
 
 ```
 CMake Command Line Options:
- `-DARM_ARCH_MAJOR` = Arch major version. Default value is 9.
- `-DARM_ARCH_MINOR` = Arch minor version. Default value is 0.
+ `-DARM_ARCH_MAJOR` = Arch major version. Default value is 8.
+ `-DARM_ARCH_MINOR` = Arch minor version. Default value is 6.
  `-DCROSS_COMPILE`  = Cross compiler path
  `-DTARGET`         = Target platform. Should be same as folder under baremetal/target/
  `-DACS`            = To compile <bsa/sbsa/pc_bsa> ACS

--- a/pal/baremetal/README.md
+++ b/pal/baremetal/README.md
@@ -57,8 +57,8 @@ Run the command
 
 ```
 CMake Command Line Options:
- `-DARM_ARCH_MAJOR` = Arch major version. Default value is 9.
- `-DARM_ARCH_MINOR` = Arch minor version. Default value is 0.
+ `-DARM_ARCH_MAJOR` = Arch major version. Default value is 8.
+ `-DARM_ARCH_MINOR` = Arch minor version. Default value is 6.
  `-DCROSS_COMPILE`  = Cross compiler path
  `-DTARGET`         = Target platform. Should be same as folder under baremetal/target/
  `-DACS`            = To compile <bsa/sbsa/pc_bsa> ACS


### PR DESCRIPTION
- Update the baremetal README files to document the actual default ARM_ARCH_MAJOR and ARM_ARCH_MINOR values used by the build.


Change-Id: Ia8f5a435fb5002b575e2d00fdd2bc4a3850f4bd9