### PR TITLE
fix(test): Skip P2P checks when ECAM is absent.

### DIFF
--- a/test_pool/cxl/cxl003.c
+++ b/test_pool/cxl/cxl003.c
@@ -49,8 +49,8 @@ payload(void)
 
   if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(1));
-
-  val_set_status(pe_index, RESULT_PASS);
+  else
+      val_set_status(pe_index, RESULT_PASS);
 }
 
 uint32_t

--- a/test_pool/drtm/interface004.c
+++ b/test_pool/drtm/interface004.c
@@ -47,6 +47,7 @@ payload(uint32_t num_pe)
   } else {
     val_print(ERROR, "\n       TCB hash feature value not available in return value");
     val_set_status(index, RESULT_FAIL(3));
+    return;
   }
 
   val_set_status(index, RESULT_PASS);

--- a/test_pool/drtm/interface006.c
+++ b/test_pool/drtm/interface006.c
@@ -49,6 +49,7 @@ payload(uint32_t num_pe)
     val_print(ERROR,
               "\n       TPM feature value not available in return value");
     val_set_status(index, RESULT_FAIL(3));
+    return;
   }
 
   val_set_status(index, RESULT_PASS);

--- a/test_pool/drtm/interface007.c
+++ b/test_pool/drtm/interface007.c
@@ -47,6 +47,7 @@ payload(uint32_t num_pe)
     val_print(ERROR,
               "\n       Min memory requirement feature value not available in return value");
     val_set_status(index, RESULT_FAIL(2));
+    return;
   }
   val_set_status(index, RESULT_PASS);
 }

--- a/test_pool/drtm/interface013.c
+++ b/test_pool/drtm/interface013.c
@@ -79,6 +79,7 @@ payload(uint32_t num_pe)
   if (!num_hashes) {
     val_print(ERROR, "\n       Max Hashes can be recorded with DRTM_SET_TCB_HASH is 0");
     val_set_status(index, RESULT_SKIP(2));
+    return;
   }
 
   /* Max number of hashes can be recorded plus one */

--- a/test_pool/drtm/interface014.c
+++ b/test_pool/drtm/interface014.c
@@ -76,6 +76,7 @@ payload(uint32_t num_pe)
   if (!num_hashes) {
     val_print(ERROR, "\n       Max Hashes can be recorded with DRTM_SET_TCB_HASH is 0");
     val_set_status(index, RESULT_SKIP(2));
+    return;
   }
 
   drtm_hash_table = (DRTM_TCB_HASH_TABLE *)val_memory_alloc(sizeof(DRTM_TCB_HASH_TABLE_HDR) +

--- a/test_pool/drtm/interface015.c
+++ b/test_pool/drtm/interface015.c
@@ -49,6 +49,7 @@ payload(uint32_t num_pe)
     val_print(ERROR,
         "\n       DLME Image Authentication feature value not available in return value");
     val_set_status(index, RESULT_FAIL(2));
+    return;
   }
 
   val_set_status(index, RESULT_PASS);

--- a/test_pool/exerciser/e001.c
+++ b/test_pool/exerciser/e001.c
@@ -223,21 +223,34 @@ payload(void)
   uint32_t test_skip;
   uint64_t bar_base;
   uint32_t curr_bdf_failed = 0;
+  uint32_t p2p_status;
   pcie_device_bdf_table *bdf_tbl_ptr;
-  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
-
   fail_cnt = 0;
   test_skip = 1;
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
 
-  uint32_t acsctrl_default[bdf_tbl_ptr->num_entries][1];
-
-  /* Check If PCIe Hierarchy supports P2P. */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(2));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
+
+  /* Check If PCIe Hierarchy supports P2P. */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  uint32_t acsctrl_default[bdf_tbl_ptr->num_entries][1];
 
   /* Store ACS Control reg bits in an array for every Exerciser and reset them
      to default at the end. */
@@ -314,7 +327,7 @@ payload(void)
   val_pcie_write_acsctrl(acsctrl_default);
 
   if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(1));
+      val_set_status(pe_index, RESULT_SKIP(3));
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(fail_cnt));
   else

--- a/test_pool/exerciser/e002.c
+++ b/test_pool/exerciser/e002.c
@@ -345,6 +345,7 @@ payload(void)
   uint32_t tgt_e_bus_num;
   uint32_t tgt_e_dev_num;
   uint32_t tgt_e_func_num;
+  uint32_t p2p_status;
 
   fail_cnt = 0;
   test_skip = 1;
@@ -353,14 +354,28 @@ payload(void)
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   tbl_index = 0;
-  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
-  uint32_t acsctrl_default[bdf_tbl_ptr->num_entries][1];
 
-  /* Check If PCIe Hierarchy supports P2P. */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(2));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
+
+  /* Check If PCIe Hierarchy supports P2P. */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
+
+  bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+  uint32_t acsctrl_default[bdf_tbl_ptr->num_entries][1];
 
   /* Store ACS Control reg bits in an array for every BDF and reset them to default at the end. */
   val_pcie_read_acsctrl(acsctrl_default);
@@ -470,7 +485,7 @@ payload(void)
   val_pcie_write_acsctrl(acsctrl_default);
 
   if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(1));
+      val_set_status(pe_index, RESULT_SKIP(3));
   else if (fail_cnt)
       val_set_status(pe_index, RESULT_FAIL(fail_cnt));
   else

--- a/test_pool/exerciser/e014.c
+++ b/test_pool/exerciser/e014.c
@@ -119,17 +119,30 @@ payload(void)
   uint32_t tgt_rp_bdf;
   uint32_t instance;
   uint32_t test_skip;
+  uint32_t p2p_status;
   uint64_t bar_base;
 
   test_skip = 1;
   index = val_pe_get_index_mpid(val_pe_get_mpid());
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
 
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(index, RESULT_SKIP(1));
+    return;
+  }
+
   /* Check If PCIe Hierarchy supports P2P. */
-  if (!val_pcie_p2p_support())
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status == ACS_STATUS_PASS)
   {
     val_print(DEBUG, "\n       P2P is supported, Skipping Test");
-    val_set_status(index, RESULT_SKIP(1));
+    val_set_status(index, RESULT_SKIP(2));
     return;
   }
 
@@ -169,7 +182,7 @@ payload(void)
     }
 
     if (test_skip) {
-        val_set_status(index, RESULT_SKIP(2));
+        val_set_status(index, RESULT_SKIP(3));
         return;
     }
 

--- a/test_pool/exerciser/e025.c
+++ b/test_pool/exerciser/e025.c
@@ -355,9 +355,16 @@ payload(void)
   uint32_t p2p_status;
   uint32_t test_status = 0;
 
+  pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+      val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+      val_set_status(pe_index, RESULT_SKIP(1));
+      return;
+  }
+
   do
   {
-      pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
       req_instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
 
       // Initialize the DMA source buffer with 8 bytes, as this is the maximum transfer size

--- a/test_pool/exerciser/e026.c
+++ b/test_pool/exerciser/e026.c
@@ -222,15 +222,18 @@ disable_ro:
       }
   }
 
+  if (test_skip) {
+      val_set_status(pe_index, RESULT_SKIP(01));
+      goto test_clean;
+  }
+
 test_pass:
   val_set_status(pe_index, RESULT_PASS);
   goto test_clean;
 
-  if (test_skip)
-      val_set_status(pe_index, RESULT_SKIP(01));
-
 test_fail:
   val_set_status(pe_index, RESULT_FAIL(03));
+
 test_clean:
   val_memory_free_aligned(pgt_base_array);
   val_memory_free_aligned(pgt_base);

--- a/test_pool/exerciser/e030.c
+++ b/test_pool/exerciser/e030.c
@@ -177,6 +177,11 @@ payload(void)
 
   }
 
+  if (test_skip == 1) {
+      val_set_status(pe_index, RESULT_SKIP(01));
+      goto test_clean;
+  }
+
   val_set_status(pe_index, RESULT_PASS);
   goto test_clean;
 
@@ -184,10 +189,6 @@ test_fail:
   val_set_status(pe_index, RESULT_FAIL(02));
 
 test_clean:
-
-  if (test_skip == 1)
-      val_set_status(pe_index, RESULT_SKIP(01));
-
   /* Remove all address mappings for each exerciser */
   for (instance = 0; instance < num_exercisers; ++instance)
   {

--- a/test_pool/gic/its001.c
+++ b/test_pool/gic/its001.c
@@ -51,7 +51,6 @@ payload()
       if (!num_blocks) {
           val_print(ERROR, "\n       No valid ITS Blocks found in group %d  ", i);
           val_set_status(index, RESULT_FAIL(2));
-          val_set_status(index, RESULT_FAIL(3));
           return;
       }
       val_print(DEBUG, "\n       Number of ITS Blocks = %d        "

--- a/test_pool/gic/its002.c
+++ b/test_pool/gic/its002.c
@@ -37,7 +37,6 @@ payload()
   }
   if (!num_group) {
       val_print(DEBUG, "\n       No ITS group found            ");
-      val_set_status(index, RESULT_FAIL(1));
       val_set_status(index, RESULT_SKIP(1));
       return;
   }
@@ -48,13 +47,13 @@ payload()
       status = val_iovirt_get_its_info(ITS_GROUP_NUM_BLOCKS, i, 0, &num_blocks);
       if (status) {
           val_print(ERROR, "\n       ITS get number of blocks failed        ");
-          val_set_status(index, RESULT_FAIL(2));
+          val_set_status(index, RESULT_FAIL(1));
           return;
       }
 
       if (!num_blocks) {
           val_print(ERROR, "\n       No valid ITS Blocks found in group %d  ", i);
-          val_set_status(index, RESULT_FAIL(3));
+          val_set_status(index, RESULT_FAIL(2));
           return;
       }
       val_print(DEBUG, "\n       ITS group index      = %d", i);
@@ -64,7 +63,7 @@ payload()
           status = val_iovirt_get_its_info(ITS_GET_ID_FOR_BLK_INDEX, i, j, &its_id);
           if (status) {
               val_print(ERROR, "\n       ITS get id failed        ");
-              val_set_status(index, RESULT_FAIL(4));
+              val_set_status(index, RESULT_FAIL(3));
               return;
           }
 
@@ -76,7 +75,7 @@ payload()
               if (status != ACS_INVALID_INDEX) {
                   val_print(ERROR, "\n       ITS ID (%d) repeated in multiple groups",
                             its_id);
-                  val_set_status(index, RESULT_FAIL(5));
+                  val_set_status(index, RESULT_FAIL(4));
                   return;
               }
           }

--- a/test_pool/pcie/p011.c
+++ b/test_pool/pcie/p011.c
@@ -134,7 +134,7 @@ payload(void)
       val_print(DEBUG, "\n       No RP/iEP_RP type device found. Skipping test");
       val_set_status(pe_index, RESULT_SKIP(1));
   }
-  if (test_fail)
+  else if (test_fail)
       val_set_status(pe_index, RESULT_FAIL(1));
   else
       val_set_status(pe_index, RESULT_PASS);

--- a/test_pool/pcie/p017.c
+++ b/test_pool/pcie/p017.c
@@ -43,17 +43,31 @@ payload(void)
   uint32_t rc_ats_supp;
   uint32_t data;
   uint32_t status;
+  uint32_t p2p_status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check If PCIe Hierarchy supports P2P */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
 
   test_fails = 0;
 
@@ -62,7 +76,7 @@ payload(void)
   /* Get the number of Root Complex in the system */
   if (!num_pcie_rc) {
      val_print(DEBUG, "\n       Skip because no PCIe RC detected  ");
-     val_set_status(pe_index, RESULT_SKIP(1));
+     val_set_status(pe_index, RESULT_SKIP(3));
      return;
   }
 
@@ -128,7 +142,7 @@ payload(void)
   if (test_skip == 1) {
       val_print(DEBUG,
            "\n       No RP type device found with P2P and ATS Support. Skipping test");
-      val_set_status(pe_index, RESULT_SKIP(2));
+      val_set_status(pe_index, RESULT_SKIP(4));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pcie/p018.c
+++ b/test_pool/pcie/p018.c
@@ -37,17 +37,31 @@ payload(void)
   uint32_t test_fails;
   uint32_t test_skip = 1;
   uint32_t status;
+  uint32_t p2p_status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check If PCIe Hierarchy supports P2P */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(3));
+    return;
+  }
   test_fails = 0;
 
   /* Check for all the function present in bdf table */

--- a/test_pool/pcie/p019.c
+++ b/test_pool/pcie/p019.c
@@ -38,17 +38,31 @@ payload(void)
   uint32_t acs_data;
   uint32_t data;
   uint32_t curr_bdf_failed = 0;
+  uint32_t p2p_status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check If PCIe Hierarchy supports P2P */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
   test_fails = 0;
 
   /* Check for all the function present in bdf table */
@@ -121,7 +135,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(DEBUG, "\n       No RP type device found. Skipping device");
-      val_set_status(pe_index, RESULT_SKIP(2));
+      val_set_status(pe_index, RESULT_SKIP(3));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pcie/p081.c
+++ b/test_pool/pcie/p081.c
@@ -42,17 +42,31 @@ payload(void)
   uint32_t status;
   uint32_t iep_rp_bdf;
   uint32_t curr_bdf_failed = 0;
+  uint32_t p2p_status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(01));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check If PCIe Hierarchy supports P2P */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
   test_fails = 0;
 
   /* Check for all the function present in bdf table */
@@ -68,7 +82,7 @@ payload(void)
           /* Check If iEP_EP supports P2P with others. */
           status = val_pcie_dev_p2p_support(bdf);
           if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-              val_set_status(pe_index, RESULT_WARNING(01));
+              val_set_status(pe_index, RESULT_WARNING(2));
               return;
           }
           if (status)
@@ -156,7 +170,7 @@ payload(void)
   if (test_skip == 1) {
       val_print(DEBUG,
            "\n       No iEP_EP type device found with P2P support. Skipping test");
-      val_set_status(pe_index, RESULT_SKIP(01));
+      val_set_status(pe_index, RESULT_SKIP(3));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pcie/p082.c
+++ b/test_pool/pcie/p082.c
@@ -72,19 +72,33 @@ payload(void *arg)
   uint32_t acs_data;
   uint32_t data;
   uint32_t status;
+  uint32_t p2p_status;
   uint8_t p2p_support_flag = 0;
   pcie_device_bdf_table *bdf_tbl_ptr;
   test_data_t *test_data = (test_data_t *)arg;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(01));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check If PCIe Hierarchy supports P2P */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(01));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
 
   test_fails = 0;
 
@@ -106,7 +120,7 @@ payload(void *arg)
           /* Check If Endpoint supports P2P with other Functions. */
           status = val_pcie_dev_p2p_support(bdf);
           if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-              val_set_status(pe_index, RESULT_WARNING(01));
+              val_set_status(pe_index, RESULT_WARNING(02));
               return;
           }
           if (status)
@@ -170,7 +184,7 @@ payload(void *arg)
   if (test_skip == 1) {
       val_print(DEBUG,
       "\n       No target device type with Multifunction and P2P support.Skipping test");
-      val_set_status(pe_index, RESULT_SKIP(01));
+      val_set_status(pe_index, RESULT_SKIP(3));
   }
   else if (test_fails + aer_cap_fail)
       val_set_status(pe_index, RESULT_FAIL(test_fails));
@@ -235,9 +249,9 @@ p016_entry(uint32_t num_pe)
 
   if (status != ACS_STATUS_SKIP) {
       if (g_aer_cap_status == ACS_STATUS_SKIP)
-          val_set_status(pe_index, RESULT_SKIP(01));
+          val_set_status(pe_index, RESULT_SKIP(4));
       else if (g_aer_cap_status == ACS_STATUS_FAIL)
-          val_set_status(pe_index, RESULT_FAIL(01));
+          val_set_status(pe_index, RESULT_FAIL(1));
       else
           val_set_status(pe_index, RESULT_PASS);
   }

--- a/test_pool/pcie/p093.c
+++ b/test_pool/pcie/p093.c
@@ -39,17 +39,31 @@ payload(void)
   uint32_t acs_data;
   uint32_t data;
   uint32_t curr_bdf_failed = 0;
+  uint32_t p2p_status;
   pcie_device_bdf_table *bdf_tbl_ptr;
 
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
-  /* Check If PCIe Hierarchy supports P2P */
-  if (val_pcie_p2p_support() == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
-    val_set_status(pe_index, RESULT_WARNING(1));
+  if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
+    val_print(DEBUG, "\n       No ECAM region found. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(1));
     return;
   }
 
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
+
+  /* Check If PCIe Hierarchy supports P2P */
+  p2p_status = val_pcie_p2p_support();
+  if (p2p_status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+    val_set_status(pe_index, RESULT_WARNING(1));
+    return;
+  }
+
+  if (p2p_status != 0) {
+    val_print(DEBUG, "\n       P2P not supported. Skipping test");
+    val_set_status(pe_index, RESULT_SKIP(2));
+    return;
+  }
   test_fails = 0;
 
   /* Check for all the function present in bdf table */
@@ -134,7 +148,7 @@ payload(void)
 
   if (test_skip == 1) {
       val_print(DEBUG, "\n       No Downstream Port of Switch found. Skipping device");
-      val_set_status(pe_index, RESULT_SKIP(1));
+      val_set_status(pe_index, RESULT_SKIP(3));
   }
   else if (test_fails)
       val_set_status(pe_index, RESULT_FAIL(test_fails));

--- a/test_pool/pe/pe037.c
+++ b/test_pool/pe/pe037.c
@@ -50,7 +50,7 @@ void payload(void)
     if (data == 0)
         /* SPE Not Implemented Skip the test */
         val_set_status(index, RESULT_SKIP(03));
-    if (data == 1)
+    else if (data == 1)
         /* SPE Implemented but SPEv1p1 not implemented. Fail the test*/
         val_set_status(index, RESULT_FAIL(01));
     else


### PR DESCRIPTION
- PCIe P2P-related tests queried platform P2P capability before checking whether any ECAM region was present. On platforms without ECAM, this could report WARNING from PAL-not-implemented paths instead of treating the test as not applicable.
- Treat platforms without P2P support as not skip.
- Correct test status flow so skip and fail outcomes are not overwritten by later status updates. Add explicit control flow for skip/fail paths and make final pass reporting conditional on no prior terminal result.
- This prevents tests from incorrectly reporting PASS/SKIP after an earlier failure or skip condition was detected.


Change-Id: Ie62b130b03aecb31d6725566e51b04696b0951a9