### PR TITLE
feat(pcbsa): Add skip-dp-nic-ms CLI option

### DIFF
--- a/apps/uefi/pc_bsa_main.c
+++ b/apps/uefi/pc_bsa_main.c
@@ -41,6 +41,7 @@ CONST SHELL_PARAM_ITEM ParamList[] = {
     {L"-only", TypeValue},
     {L"-r", TypeValue},
     {L"-skip", TypeValue},
+    {L"-skip-dp-nic-ms", TypeFlag},
     {L"-skipmodule", TypeValue},
     {L"-timeout", TypeValue},
     {L"-v", TypeValue},
@@ -75,6 +76,8 @@ HelpMsg (VOID)
         "        Only run tests for rules at level <n> \n"
         "-skip   Rule ID(s) to be skipped (comma-separated, like -r)\n"
         "        Example: -skip B_PE_01,B_GIC_02\n"
+        "-skip-dp-nic-ms \n"
+        "        Skip PCIe tests for DisplayPort, Network, Mass Storage devices and Unclassified devices\n"
         "-skipmodule \n"
         "        Skip the specified modules (comma-separated names).\n"
         "        Example: -skipmodule PE,GIC,PCIE\n"


### PR DESCRIPTION
- Add the -skip-dp-nic-ms flag to PCBSA command-line parameters
- Allow skipping PCIe tests for DisplayPort, Network, Mass Storage, and Unclassified devices during test execution

related #433 

Signed-off-by: Shanmuga Priya L <[shanmuga.priyal@arm.com](mailto:shanmuga.priyal@arm.com)>
Change-Id: I19b185afae003138af6db1d26f34182e1fa26601