### PR TITLE
ras: PAL select common PFG error flow

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -1000,17 +1000,22 @@ typedef enum {
     ERR_CRITICAL          /* Critical Error */
 } RAS_ERROR_TYPE;
 
+#define RAS_INTR_TYPE_FHI   0x0  /* Fault Handling Interrupt */
+#define RAS_INTR_TYPE_ERI   0x1  /* Error Recovery Interrupt */
+#define RAS_INTR_TYPE_NONE  0xFF /* No ERI/FHI selected */
+
 typedef struct {
    RAS_ERROR_TYPE ras_error_type;   /* Error Type */
    uint64_t error_pa;                 /* Error Phy Address */
    uint32_t rec_index;                /* Error Record Index */
    uint32_t node_index;               /* Error Node Index in Info table */
-   uint8_t is_pfg_check;              /* Pseudo Fault Check or not */
+   uint32_t intr_type;                /* Interrupt type used for common PFG setup */
 } RAS_ERR_IN_t;
 
 typedef struct {
    uint32_t intr_id;        /* Interrupt ID */
    uint32_t error_record;   /* Error Record Number */
+   uint8_t is_pfg_check;    /* Pseudo Fault Check or not */
 } RAS_ERR_OUT_t;
 
 void pal_ras_create_info_table(RAS_INFO_TABLE *ras_info_table);

--- a/pal/baremetal/target/RDN2/src/pal_sbsa.c
+++ b/pal/baremetal/target/RDN2/src/pal_sbsa.c
@@ -162,7 +162,9 @@ pal_ras_setup_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
   /* Platform Defined way of setting up the Error Environment */
 
   (void) in_param;
-  (void) out_param;
+
+  if (out_param)
+    out_param->is_pfg_check = 0;
 
   pal_warn_not_implemented(__func__);
   return PAL_STATUS_NOT_IMPLEMENTED;

--- a/pal/baremetal/target/RDV3/src/pal_sbsa.c
+++ b/pal/baremetal/target/RDV3/src/pal_sbsa.c
@@ -163,7 +163,9 @@ pal_ras_setup_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
   /* Platform Defined way of setting up the Error Environment */
 
   (void) in_param;
-  (void) out_param;
+
+  if (out_param)
+    out_param->is_pfg_check = 0;
 
   pal_warn_not_implemented(__func__);
   return PAL_STATUS_NOT_IMPLEMENTED;

--- a/pal/baremetal/target/RDV3CFG1/src/pal_sbsa.c
+++ b/pal/baremetal/target/RDV3CFG1/src/pal_sbsa.c
@@ -163,7 +163,9 @@ pal_ras_setup_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
   /* Platform Defined way of setting up the Error Environment */
 
   (void) in_param;
-  (void) out_param;
+
+  if (out_param)
+    out_param->is_pfg_check = 0;
 
   pal_warn_not_implemented(__func__);
   return PAL_STATUS_NOT_IMPLEMENTED;

--- a/pal/uefi_acpi/include/pal_uefi.h
+++ b/pal/uefi_acpi/include/pal_uefi.h
@@ -894,17 +894,22 @@ typedef enum {
     ERR_CONTAINABLE       /* Containable Error */
 } RAS_ERROR_TYPE;
 
+#define RAS_INTR_TYPE_FHI   0x0  /* Fault Handling Interrupt */
+#define RAS_INTR_TYPE_ERI   0x1  /* Error Recovery Interrupt */
+#define RAS_INTR_TYPE_NONE  0xFF /* No ERI/FHI selected */
+
 typedef struct {
    RAS_ERROR_TYPE ras_error_type;   /* Error Type */
    UINT64 error_pa;                 /* Error Phy Address */
    UINT32 rec_index;                /* Error Record Index */
    UINT32 node_index;               /* Error Node Index in Info table */
-   UINT8 is_pfg_check;              /* Pseudo Fault Check or not */
+   UINT32 intr_type;                /* Interrupt type used for common PFG setup */
 } RAS_ERR_IN_t;
 
 typedef struct {
    UINT32 intr_id;        /* Interrupt ID */
    UINT32 error_record;   /* Error Record Number */
+   UINT8 is_pfg_check;    /* Pseudo Fault Check or not */
 } RAS_ERR_OUT_t;
 
 void pal_ras_create_info_table(RAS_INFO_TABLE *ras_info_table);

--- a/pal/uefi_acpi/src/pal_ras.c
+++ b/pal/uefi_acpi/src/pal_ras.c
@@ -61,6 +61,8 @@ pal_ras_setup_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
   if (out_param == NULL)
     return PAL_STATUS_INVALID_PARAM;
 
+  out_param->is_pfg_check = 0;
+
   pal_warn_not_implemented(__func__);
   return PAL_STATUS_NOT_IMPLEMENTED;
 }

--- a/test_pool/ras/ras005.c
+++ b/test_pool/ras/ras005.c
@@ -42,7 +42,7 @@ intr_handler(void)
   /* Clear the RAS source before the common IRQ wrapper EOIs the interrupt. */
   val_ras_clear_error_status(intr_node_index, intr_is_pfg_check);
 
-  val_print(TRACE, "\n       Received interrupt 0x%x", int_id);
+  val_print(TRACE, "\n       Received interrupt 0x%lx", int_id);
   val_gic_end_of_interrupt(int_id);
   return;
 }
@@ -123,9 +123,9 @@ payload()
       err_in_params.rec_index = rec_index;
       err_in_params.node_index = node_index;
       err_in_params.ras_error_type = ERR_CE;
-      err_in_params.is_pfg_check = 0;
+      /* Pass the selected interrupt type so common RAS setup can enable FHI or ERI. */
+      err_in_params.intr_type = (fhi_id) ? RAS_INTR_TYPE_FHI : RAS_INTR_TYPE_ERI;
       intr_node_index = node_index;
-      intr_is_pfg_check = err_in_params.is_pfg_check;
 
       /* Install handler for interrupt */
       val_gic_install_isr(int_id, intr_handler);
@@ -140,6 +140,8 @@ payload()
         fail_cnt++;
         break;
       }
+      /* Preserve PAL/VAL-selected PFG mode for interrupt-source cleanup. */
+      intr_is_pfg_check = err_out_params.is_pfg_check;
 
       /* Inject error in an implementation defined way */
       status = val_ras_inject_error(err_in_params, &err_out_params);

--- a/test_pool/ras/ras006.c
+++ b/test_pool/ras/ras006.c
@@ -145,7 +145,7 @@ payload()
           err_in_params.ras_error_type = ERR_CE; /* correctable error */
           err_in_params.error_pa = err_inj_addr; /* address of the location where error
                                                     needs to be injected */
-          err_in_params.is_pfg_check = 0;        /* not a pseudo fault check */
+          err_in_params.intr_type = RAS_INTR_TYPE_NONE;
 
           /* Setup error in an implementation defined way */
           status = val_ras_setup_error(err_in_params, &err_out_params);

--- a/test_pool/ras/ras009.c
+++ b/test_pool/ras/ras009.c
@@ -154,7 +154,7 @@ payload()
     err_in_params.ras_error_type = ERR_CONTAINABLE; /* containable error */
     err_in_params.error_pa = err_inj_addr; /* address of the location where error
                                               needs to be injected */
-    err_in_params.is_pfg_check = 0;        /* not a pseudo fault check */
+    err_in_params.intr_type = RAS_INTR_TYPE_NONE;
 
     /* Setup error in an implementation defined way */
     status = val_ras_setup_error(err_in_params, &err_out_params);

--- a/test_pool/ras/ras011.c
+++ b/test_pool/ras/ras011.c
@@ -145,7 +145,7 @@ payload_poison_supported()
     err_in_params.rec_index = rec_index;
     err_in_params.node_index = node_index;
     err_in_params.ras_error_type = ERR_CE;
-    err_in_params.is_pfg_check = 0;
+    err_in_params.intr_type = RAS_INTR_TYPE_ERI;
 
     /* Get Interrupt details for this node */
     status = val_ras_get_info(RAS_INFO_ERI_ID, node_index, &int_id);
@@ -346,7 +346,7 @@ payload_poison_unsupported()
     err_in_params.rec_index = rec_index;
     err_in_params.node_index = node_index;
     err_in_params.ras_error_type = ERR_CE;
-    err_in_params.is_pfg_check = 0;
+    err_in_params.intr_type = RAS_INTR_TYPE_ERI;
 
     /* Get Interrupt details for this node */
     status = val_ras_get_info(RAS_INFO_ERI_ID, node_index, &int_id);

--- a/test_pool/ras/ras018.c
+++ b/test_pool/ras/ras018.c
@@ -134,7 +134,7 @@ payload()
         err_in_params.ras_error_type = ERR_CONTAINABLE; /* containable error */
         err_in_params.error_pa = dev_addr;              /* address of the location where error
                                                                needs to be injected */
-        err_in_params.is_pfg_check = 0;                 /* not a pseudo fault check */
+        err_in_params.intr_type = RAS_INTR_TYPE_NONE;
 
         /* Setup error in an implementation defined way */
         status = val_ras_setup_error(err_in_params, &err_out_params);

--- a/val/include/acs_ras.h
+++ b/val/include/acs_ras.h
@@ -43,6 +43,8 @@
 
 #define ERR_CTLR_CLEAR_MASK     0x3FFD
 #define ERR_CTLR_ED_ENABLE      0x1
+#define ERR_CTLR_FHI_ENABLE     0x108ULL  /* Enable Fault Handling Interrupt */
+#define ERR_CTLR_ERI_ENABLE     0x4ULL    /* Enable Error Recovery Interrupt */
 
 #define ERR_ADDR_AI_SHIFT 61
 
@@ -51,6 +53,7 @@
 #define ERR_PFGCTL_CE_NON_ENABLE  (0x1ull << 6)
 #define ERR_PFGCTL_CI_ENABLE      (0x1ull << 8)
 #define ERR_PFGCTL_CDNEN_ENABLE   (0x1ull << 31)
+#define ERR_PFGCTL_TRIGGER_ALL    0xC0001FFFULL  /* Trigger all supported PFG classes */
 
 #define ERR_FR_OFFSET           0x000
 #define ERR_CTLR_OFFSET         0x008

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -1362,17 +1362,22 @@ typedef enum {
     ERR_CONTAINABLE  /* Containable Error */
 } RAS_ERROR_TYPE;
 
+#define RAS_INTR_TYPE_FHI   0x0  /* Fault Handling Interrupt */
+#define RAS_INTR_TYPE_ERI   0x1  /* Error Recovery Interrupt */
+#define RAS_INTR_TYPE_NONE  0xFF /* No ERI/FHI selected */
+
 typedef struct {
    RAS_ERROR_TYPE ras_error_type;   /* Error Type */
    uint64_t error_pa;                 /* Error Phy Address */
    uint32_t rec_index;                /* Error Record Index */
    uint32_t node_index;               /* Error Node Index in Info table */
-   uint8_t is_pfg_check;              /* Pseudo Fault Check or not */
+   uint32_t intr_type;                /* Interrupt type used for common PFG setup */
 } RAS_ERR_IN_t;
 
 typedef struct {
    uint32_t intr_id;        /* Interrupt ID */
    uint32_t error_record;   /* Error Record Number */
+   uint8_t is_pfg_check;    /* Pseudo Fault Check or not */
 } RAS_ERR_OUT_t;
 
 typedef enum {

--- a/val/src/acs_ras.c
+++ b/val/src/acs_ras.c
@@ -604,8 +604,14 @@ val_ras_clear_error_status(uint32_t node_index, uint8_t is_pfg_check)
 uint32_t
 val_ras_setup_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
 {
-  uint32_t status = ACS_STATUS_FAIL;
-  uint32_t pfgctl_value = 0;
+  uint32_t status;
+  uint64_t ctlr_value;
+  uint64_t ctlr_intr_enable;
+  uint64_t pfgctl_value;
+  uint8_t is_pfg_check = 0;
+
+  if (out_param)
+    out_param->is_pfg_check = 0;
 
   /* Clear the ERR_STATUS for any previous error */
   val_ras_reg_write(in_param.node_index, RAS_ERR_STATUS, ERR_STATUS_CLEAR);
@@ -616,36 +622,62 @@ val_ras_setup_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
   /* Enable fault injection: ERR<n>CTLR.ED=1 */
   val_ras_reg_write(in_param.node_index, RAS_ERR_CTLR, ERR_CTLR_ED_ENABLE);
 
+  /* PAL can request the common PFG setup path through out_param->is_pfg_check. */
+  status = pal_ras_setup_error(in_param, out_param);
+  if (status)
+    return status;
+
+  if (out_param)
+    is_pfg_check = out_param->is_pfg_check;
+
   /* Check if Pseudo Fault needs to test */
-  if (in_param.is_pfg_check)
+  if (is_pfg_check)
   {
+    /* Enable the interrupt selected by the test without clobbering PAL CTLR bits. */
+    switch (in_param.intr_type) {
+    case RAS_INTR_TYPE_FHI:
+      ctlr_intr_enable = ERR_CTLR_FHI_ENABLE;
+      break;
+    case RAS_INTR_TYPE_ERI:
+      ctlr_intr_enable = ERR_CTLR_ERI_ENABLE;
+      break;
+    default:
+      val_print(ERROR, "\n       RAS PFG setup: invalid interrupt type %d", in_param.intr_type);
+      return ACS_STATUS_FAIL;
+    }
+
+    ctlr_value = val_ras_reg_read(in_param.node_index, RAS_ERR_CTLR, in_param.rec_index);
+    if (ctlr_value == INVALID_RAS_REG_VAL) {
+        val_print(ERROR,
+                  "\n       Couldn't read ERR<%d>CTLR register for ",
+                  in_param.rec_index);
+        val_print(ERROR,
+                  "RAS node index: 0x%lx",
+                  in_param.node_index);
+        return ACS_STATUS_FAIL;
+    }
+    val_ras_reg_write(in_param.node_index, RAS_ERR_CTLR, (ctlr_value | ctlr_intr_enable));
+
     /* Write Counter in ERR<n>PFGCDN */
     val_ras_reg_write(in_param.node_index, RAS_ERR_PFGCDN, 0x5);
 
-    /* Write to ERR<n>PFGCTL.* To Enable Error */
-    switch (in_param.ras_error_type) {
-    case ERR_UC:
-                pfgctl_value = ERR_PFGCTL_UC_ENABLE;
-                break;
-    case ERR_DE:
-                pfgctl_value = ERR_PFGCTL_DE_ENABLE;
-                break;
-    case ERR_CE:
-                pfgctl_value = ERR_PFGCTL_CE_NON_ENABLE;
-                break;
-    case ERR_CRITICAL:
-                pfgctl_value = ERR_PFGCTL_CI_ENABLE;
-                break;
-    default:
-                break;
+    /* Trigger all supported PFG error classes while preserving current PFGCTL bits. */
+    pfgctl_value = val_ras_reg_read(in_param.node_index, RAS_ERR_PFGCTL, in_param.rec_index);
+    if (pfgctl_value == INVALID_RAS_REG_VAL) {
+        val_print(ERROR,
+                  "\n       Couldn't read ERR<%d>PFGCTL register for ",
+                  in_param.rec_index);
+        val_print(ERROR,
+                  "RAS node index: 0x%lx",
+                  in_param.node_index);
+        return ACS_STATUS_FAIL;
     }
-    val_ras_reg_write(in_param.node_index, RAS_ERR_PFGCTL, pfgctl_value);
+    val_ras_reg_write(in_param.node_index, RAS_ERR_PFGCTL,
+                                (pfgctl_value | ERR_PFGCTL_TRIGGER_ALL));
 
     return ACS_STATUS_PASS;
   }
 
-  /* Platform defined way of error setup */
-  status = pal_ras_setup_error(in_param, out_param);
   return status;
 }
 
@@ -692,11 +724,14 @@ ras_pfg_access_node(uint32_t node_index)
 uint32_t
 val_ras_inject_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
 {
-  uint32_t status = ACS_STATUS_FAIL;
   uint64_t reg_value;
+  uint8_t is_pfg_check = 0;
+
+  if (out_param)
+    is_pfg_check = out_param->is_pfg_check;
 
   /* Check if Pseudo Fault needs to test */
-  if (in_param.is_pfg_check)
+  if (is_pfg_check)
   {
     /* Write to ERR<n>PFGCTL.CDNEN */
     reg_value = val_ras_reg_read(in_param.node_index, RAS_ERR_PFGCTL, in_param.rec_index);
@@ -711,6 +746,7 @@ val_ras_inject_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
         return ACS_STATUS_FAIL;
     }
 
+    /* Start PFG countdown without disturbing the setup-time PFGCTL programming. */
     val_ras_reg_write(in_param.node_index, RAS_ERR_PFGCTL, reg_value | ERR_PFGCTL_CDNEN_ENABLE);
 
     /* Wait and Access to Node */
@@ -720,9 +756,7 @@ val_ras_inject_error(RAS_ERR_IN_t in_param, RAS_ERR_OUT_t *out_param)
   }
 
   /* Platform Defined Way of Error Injection */
-  status = pal_ras_inject_error(in_param, out_param);
-
-  return status;
+  return pal_ras_inject_error(in_param, out_param);
 }
 
 /**


### PR DESCRIPTION
  Move pseudo fault generation selection from RAS_ERR_IN_t to
  RAS_ERR_OUT_t so PAL setup can request the common VAL PFG path.

  Update VAL setup and injection to use out_param->is_pfg_check for
  PFG setup/injection, and update ras005 interrupt cleanup to use the
  PAL-selected mode. Remove stale test-side is_pfg_check initialization
  from RAS_ERR_IN_t users.

  Initialize the new output flag in PAL setup stubs and leave PAL inject
  from modifying the setup-selected state.


Change-Id: If594ddf1682e09fb112576e6e3357b0a338f2fc7