### PR TITLE
ras: defer PFG countdown enable until injection

### DIFF
--- a/test_pool/ras/ras005.c
+++ b/test_pool/ras/ras005.c
@@ -28,10 +28,10 @@
 
 #define IS_NOT_SPI_PPI(int_id) ((int_id < 16) || (int_id > 1019))
 
-static uint64_t int_id;
-static uint32_t intr_pending = 1;
-static uint32_t intr_node_index;
-static uint8_t intr_is_pfg_check;
+static volatile uint64_t int_id;
+static volatile uint32_t intr_pending = 1;
+static volatile uint32_t intr_node_index;
+static volatile uint8_t intr_is_pfg_check;
 
 static
 void

--- a/val/include/acs_ras.h
+++ b/val/include/acs_ras.h
@@ -53,7 +53,7 @@
 #define ERR_PFGCTL_CE_NON_ENABLE  (0x1ull << 6)
 #define ERR_PFGCTL_CI_ENABLE      (0x1ull << 8)
 #define ERR_PFGCTL_CDNEN_ENABLE   (0x1ull << 31)
-#define ERR_PFGCTL_TRIGGER_ALL    0xC0001FFFULL  /* Trigger all supported PFG classes */
+#define ERR_PFGCTL_TRIGGER_ALL    0x40001FFFULL  /* Trigger all supported PFG classes */
 
 #define ERR_FR_OFFSET           0x000
 #define ERR_CTLR_OFFSET         0x008


### PR DESCRIPTION
  Avoid setting ERR<n>PFGCTL.CDNEN during RAS PFG setup by removing the
  CDNEN bit from ERR_PFGCTL_TRIGGER_ALL. This keeps setup from starting
  the pseudo-fault countdown before ras005 records the PAL-selected PFG
  cleanup mode.

  The countdown is now started only from val_ras_inject_error(), where
  ERR_PFGCTL_CDNEN_ENABLE is ORed into the existing PFGCTL value after
  ras005 has saved err_out_params.is_pfg_check for interrupt cleanup.

  Mark ras005 ISR-shared state as volatile.


Change-Id: I60ac6b769e50085129c882ebda806a366d5b5276