### PR TITLE
fix: unmap device memory on exception return

### DIFF
--- a/test_pool/pcie/p045.c
+++ b/test_pool/pcie/p045.c
@@ -247,6 +247,7 @@ next_bdf:
           *(uint32_t *)(baseptr) = old_data;
 
 exception_return_device:
+          val_memory_unmap(baseptr);
           if (IS_TEST_FAIL(val_get_status(index))) {
               val_print(ERROR, "\n       Device memory access failed for Bdf: 0x%x", bdf);
               /* Setting the status to Pass to enable test for next BDF.


### PR DESCRIPTION
Ensure 'p045' unmaps the mapped BAR pointer when returning via the exception path. Adds 'val_memory_unmap(baseptr)' before evaluating test status so device memory is released for each BDF even after an access failure, preventing leaks across iterations.


Change-Id: I8a13aebd39742647ef734e5596a71bdec310b051