### PR TITLE
impov(pre-si): reduce MPIDR reads on primary PE

### DIFF
--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -39,7 +39,7 @@ PE_INFO_TABLE *g_pe_info_table;
 ARM_SMC_ARGS g_smc_args;
 
 /* global variable to store primary PE index */
-uint32_t g_primary_pe_index = 0;
+uint32_t g_primary_pe_index = ACS_INVALID_INDEX;
 
 /**
   @brief   This API will call PAL layer to fill in the PE information
@@ -95,7 +95,12 @@ val_print(INFO, " Primary PE: MIDR_EL1                 :    0x%llx \n",
 
   /* store primary PE index for debug message printing purposes on
      multi PE tests */
-  g_primary_pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  if (g_primary_pe_index == ACS_INVALID_INDEX) {
+      if (g_primary_mpidr == PAL_INVALID_MPID)
+          g_primary_mpidr = val_pe_get_mpid();
+
+      g_primary_pe_index = val_pe_get_index_mpid(g_primary_mpidr);
+  }
   val_print(DEBUG, " PE_INFO: Primary PE index       : %4d\n",
             g_primary_pe_index);
 
@@ -154,7 +159,7 @@ val_pe_get_mpid()
   #ifdef TARGET_LINUX
     data = 0;
   #else
-    data = val_pe_reg_read(MPIDR_EL1);
+      data = val_pe_reg_read(MPIDR_EL1);
   #endif
   /* Return the Affinity bits */
   data = data & MPIDR_AFF_MASK;
@@ -382,7 +387,7 @@ val_pe_initialize_default_exception_handler(void (*esr)(uint64_t, void *))
 void
 val_pe_default_esr(uint64_t interrupt_type, void *context)
 {
-    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+    uint32_t index = val_pe_get_primary_index();
     val_print(WARN, "\n        Unexpected exception of type %d occurred", interrupt_type);
 
 #ifndef TARGET_LINUX
@@ -490,7 +495,7 @@ val_pe_cache_invalidate_range(uint64_t start_addr, uint64_t length)
   @param   None
   @return  Primary PE index.
 **/
-uint32_t
+inline __attribute__((always_inline)) uint32_t
 val_pe_get_primary_index(void)
 {
   return g_primary_pe_index;

--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -398,7 +398,7 @@ val_initialize_test(uint32_t test_num, char8_t *desc, uint32_t num_pe)
 {
 
   uint32_t i;
-  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t index = val_pe_get_primary_index();
 
   g_override_skip = 0;
 
@@ -636,7 +636,7 @@ void
 val_run_test_payload(uint32_t test_num, uint32_t num_pe, void (*payload)(void), uint64_t test_input)
 {
 
-  uint32_t my_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t my_index = val_pe_get_primary_index();
   uint32_t i;
 
   payload();  //this is test run separately on present PE
@@ -692,7 +692,7 @@ val_check_for_error(uint32_t test_num, uint32_t num_pe, char8_t *ruleid)
   uint32_t i;
   uint32_t status = 0;
   uint32_t error_flag = 0;
-  uint32_t my_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t my_index = val_pe_get_primary_index();
   (void) test_num;
 
   /* this special case is needed when the Main PE is not the first entry
@@ -746,7 +746,7 @@ val_check_for_error(uint32_t test_num, uint32_t num_pe, char8_t *ruleid)
   uint32_t i, checkpoint;
   uint32_t overall_status;
   uint32_t status = RESULT_FAIL(0);
-  uint32_t my_index = val_pe_get_index_mpid(val_pe_get_mpid());
+  uint32_t my_index = val_pe_get_primary_index();
 
   if (num_pe == 1) {
       status = val_get_status(my_index);


### PR DESCRIPTION
  - Cache the primary PE index/MPIDR once and reuse it for single-PE paths.
  - Avoid repeated MPIDR_EL1 reads on the primary, cutting instruction count in simulation.


Change-Id: Ib2e7ad38b8c330558d3c893d12893b77cb815d35