### PR TITLE
feat(pe): add PE069 test for FEAT_TRF support

### DIFF
--- a/apps/uefi/Bsa.inf
+++ b/apps/uefi/Bsa.inf
@@ -194,6 +194,7 @@
   ../../test_pool/pe/pe062.c
   ../../test_pool/pe/pe068.c
   ../../test_pool/pe/pe065.c
+  ../../test_pool/pe/pe069.c
   ../../test_pool/gic/g012.c
   ../../test_pool/gic/g013.c
   ../../test_pool/gic/g014.c

--- a/apps/uefi/Sbsa.inf
+++ b/apps/uefi/Sbsa.inf
@@ -194,6 +194,7 @@
   ../../test_pool/pe/pe060.c
   ../../test_pool/pe/pe061.c
   ../../test_pool/pe/pe062.c
+  ../../test_pool/pe/pe069.c
   ../../test_pool/pe/pe068.c
   ../../test_pool/pe/pe065.c
   ../../test_pool/gic/g012.c

--- a/apps/uefi/SbsaNist.inf
+++ b/apps/uefi/SbsaNist.inf
@@ -75,6 +75,7 @@
   ../../test_pool/pe/pe061.c
   ../../test_pool/pe/pe062.c
   ../../test_pool/pe/pe065.c
+  ../../test_pool/pe/pe069.c
   ../../test_pool/gic/g012.c
   ../../test_pool/gic/g013.c
   ../../test_pool/gic/g014.c

--- a/apps/uefi/Vbsa.inf
+++ b/apps/uefi/Vbsa.inf
@@ -197,6 +197,7 @@
   ../../test_pool/pe/pe065.c
   ../../test_pool/pe/pe066.c
   ../../test_pool/pe/pe068.c
+  ../../test_pool/pe/pe069.c
   ../../test_pool/gic/g012.c
   ../../test_pool/gic/g013.c
   ../../test_pool/gic/g014.c

--- a/apps/uefi/pc_bsa.inf
+++ b/apps/uefi/pc_bsa.inf
@@ -195,6 +195,7 @@
   ../../test_pool/pe/pe062.c
   ../../test_pool/pe/pe068.c
   ../../test_pool/pe/pe065.c
+  ../../test_pool/pe/pe069.c
   ../../test_pool/gic/g012.c
   ../../test_pool/gic/g013.c
   ../../test_pool/gic/g014.c

--- a/apps/uefi/xbsa_acpi.inf
+++ b/apps/uefi/xbsa_acpi.inf
@@ -189,6 +189,7 @@
   ../../test_pool/pe/pe062.c
   ../../test_pool/pe/pe068.c
   ../../test_pool/pe/pe065.c
+  ../../test_pool/pe/pe069.c
   ../../test_pool/gic/g012.c
   ../../test_pool/gic/g013.c
   ../../test_pool/gic/g014.c

--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -344,11 +344,11 @@ The checklist provides information about:
       <td>L5</td>
       <td>S_L5PE_03</td>
       <td>S_L5PE_03</td>
-      <td>Not Covered</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+      <td>69</td>
+      <td>Check FEAT_TRF support for CS-BSA C</td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>No</td>
       <td></td>
     </tr>
     <tr>
@@ -3677,6 +3677,7 @@ The checklist provides information about:
 ## Latest Checklist Changes
 - Updated PCI_MM_02 coverage with test 907.
 - Updated S_L5SM_04, S_L6PE_08, S_L6SM_04
+- Added rule S_L5PE_03
 
 ### v26.03_SBSA_8.0.1
 - **FR Added:** LVQBC, KBRZG

--- a/test_pool/pe/pe069.c
+++ b/test_pool/pe/pe069.c
@@ -1,0 +1,119 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+#include "acs_val.h"
+#include "acs_pe.h"
+#include "val_interface.h"
+
+#define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  69)
+#define TEST_RULE  "S_L5PE_03"
+#define TEST_DESC  "Check FEAT_TRF support per CS-BSA C  "
+
+static void payload(void)
+{
+    uint32_t pe_family;
+    uint64_t dfr0, pfr0, isar0, isar1, mmfr2;
+    uint64_t ete, trbe;
+    uint64_t dit, flagm, ids, lrcpc, at, trace_filt;
+    uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+
+    pe_family = val_get_pe_architecture(index);
+    if (pe_family == PROCESSOR_FAMILY_ARMV9) {
+        val_print_primary_pe(DEBUG, "\n       Armv9 PE detected; skipping the test", 0, index);
+        dfr0 = val_pe_reg_read(ID_AA64DFR0_EL1);
+
+        /* ID_AA64DFR0_EL1.TraceVer[7:4] != 0 indicates FEAT_ETE support */
+        ete = VAL_EXTRACT_BITS(dfr0, 4, 7);
+        if (ete)
+            val_print_primary_pe(DEBUG, "\n       FEAT_ETE SUPPORTED", 0, index);
+        else
+            val_print_primary_pe(DEBUG, "\n       FEAT_ETE NOT SUPPORTED", 0, index);
+        val_print_primary_pe(DEBUG, " (TraceVer[7:4]=0x%llx)", ete, index);
+
+        /* ID_AA64DFR0_EL1.TraceBuffer[47:44] != 0 indicates FEAT_TRBE support */
+        trbe = VAL_EXTRACT_BITS(dfr0, 44, 47);
+        if (trbe)
+            val_print_primary_pe(DEBUG, "\n       FEAT_TRBE SUPPORTED", 0, index);
+        else
+            val_print_primary_pe(DEBUG, "\n       FEAT_TRBE NOT SUPPORTED", 0, index);
+        val_print_primary_pe(DEBUG, " (TraceBuffer[47:44]=0x%llx)", trbe, index);
+        val_set_status(index, RESULT_SKIP(1));
+        return;
+    } else if (pe_family == ACS_STATUS_ERR) {
+        val_print_primary_pe(WARN, "\n       SMBIOS info missing, unable to determine if PE is v9",
+                    0, index);
+    }
+
+    /* Approximate Armv8.4+ using mandatory features:
+     * DIT>=1, TS>=1 (FlagM), LRCPC>=2, IDS>=1, AT>=1
+     */
+    pfr0 = val_pe_reg_read(ID_AA64PFR0_EL1);
+    isar0 = val_pe_reg_read(ID_AA64ISAR0_EL1);
+    isar1 = val_pe_reg_read(ID_AA64ISAR1_EL1);
+    mmfr2 = val_pe_reg_read(ID_AA64MMFR2_EL1);
+
+    dit   = VAL_EXTRACT_BITS(pfr0, 48, 51);
+    flagm = VAL_EXTRACT_BITS(isar0, 52, 55);
+    lrcpc = VAL_EXTRACT_BITS(isar1, 20, 23);
+    ids   = VAL_EXTRACT_BITS(mmfr2, 36, 39);
+    at    = VAL_EXTRACT_BITS(mmfr2, 32, 35);
+
+    val_print_primary_pe(DEBUG, "\n       ID_AA64PFR0_EL1.DIT 0x%llx", dit, index);
+    val_print_primary_pe(DEBUG, "\n       ID_AA64ISAR0_EL1.TS 0x%llx", flagm, index);
+    val_print_primary_pe(DEBUG, "\n       ID_AA64MMFR2_EL1.IDS 0x%llx", ids, index);
+    val_print_primary_pe(DEBUG, "\n       ID_AA64ISAR1_EL1.LRCPC 0x%llx", lrcpc, index);
+    val_print_primary_pe(DEBUG, "\n       ID_AA64MMFR2_EL1.AT 0x%llx", at, index);
+
+    if ((dit < 1) || (flagm < 1) || (ids < 1) || (lrcpc < 2) ||
+        (at < 1)) {
+        val_print_primary_pe(DEBUG, "\n       Skipping: PE does not meet Armv8.4 feature baseline",
+                    0, index);
+        val_set_status(index, RESULT_SKIP(2));
+        return;
+    }
+
+    /* ID_AA64DFR0_EL1.TraceFilt[43:40] == 0b0001 indicates FEAT_TRF support */
+    trace_filt = VAL_EXTRACT_BITS(val_pe_reg_read(ID_AA64DFR0_EL1), 40, 43);
+
+    if (trace_filt != 0x1) {
+        val_print_primary_pe(ERROR, "\n       FEAT_TRF not implemented (TraceFilt[43:40]=0x%llx)",
+                trace_filt, index);
+        val_set_status(index, RESULT_FAIL(1));
+        return;
+    }
+
+    val_print_primary_pe(INFO,
+            "\n       FEAT_TRF supported; manual verification required for CS-BSA combination C",
+            0, index);
+    val_set_status(index, RESULT_PARTIAL_COVERED);
+}
+
+uint32_t pe069_entry(uint32_t num_pe)
+{
+    uint32_t status = ACS_STATUS_FAIL;
+
+    val_log_context((char8_t *)__FILE__, (char8_t *)__func__, __LINE__);
+    status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+    /* This check is when user is forcing us to skip this test */
+    if (status != ACS_STATUS_SKIP)
+        val_run_test_payload(TEST_NUM, num_pe, payload, 0);
+
+    /* get the result from all PE and check for failure */
+    status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+    val_report_status(0, ACS_END(TEST_NUM), TEST_RULE);
+
+    return status;
+}

--- a/tools/cmake/infra/sbsa_test.txt
+++ b/tools/cmake/infra/sbsa_test.txt
@@ -36,6 +36,7 @@ pe060.c
 pe061.c
 pe062.c
 pe065.c
+pe069.c
 g012.c
 g013.c
 g014.c

--- a/val/include/acs_pe.h
+++ b/val/include/acs_pe.h
@@ -291,5 +291,6 @@ uint32_t pe065_entry(uint32_t num_pe);
 uint32_t pe066_entry(uint32_t num_pe);
 uint32_t pe067_entry(uint32_t num_pe);
 uint32_t pe068_entry(uint32_t num_pe);
+uint32_t pe069_entry(uint32_t num_pe);
 
 #endif

--- a/val/include/rule_based_execution_enum.h
+++ b/val/include/rule_based_execution_enum.h
@@ -653,6 +653,7 @@ typedef enum {
     PE062_ENTRY,
     PE067_ENTRY,
     PE068_ENTRY,
+    PE069_ENTRY,
     V_L1PE_02_ENTRY,
     PE065_ENTRY,
     G001_ENTRY,

--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -561,7 +561,13 @@ val_get_pe_architecture(uint32_t index)
 {
   PE_SMBIOS_TYPE4_INFO *type4_entry;
   uint32_t cur_pe_count = 0;
-  uint32_t num_slots = g_smbios_info_table->slot_count;
+  uint32_t num_slots;
+
+  if (g_smbios_info_table == NULL) {
+    return ACS_STATUS_ERR;
+  }
+
+  num_slots = g_smbios_info_table->slot_count;
 
   if (num_slots == 0) {
     return ACS_STATUS_ERR;

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -370,6 +370,14 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_PE_TEST_NUM_BASE  +  32,
         },
+        [S_L5PE_03] = {
+            .test_entry_id    = PE069_ENTRY,
+            .module_id        = PE,
+            .rule_desc        = "Check FEAT_TRF support per CS-BSA C",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = BASE_RULE,
+            .test_num         = ACS_PE_TEST_NUM_BASE  +  69,
+        },
         [S_L5PE_04] = {
             .test_entry_id    = PE033_ENTRY,
             .module_id        = PE,
@@ -3021,9 +3029,6 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
         [B_PE_16] = {
             .module_id        = PE,
         },
-        [S_L5PE_03] = {
-            .module_id        = PE,
-        },
         [S_L6PE_07] = {
             .module_id        = PE,
         },
@@ -3764,6 +3769,7 @@ test_entry_fn_t test_entry_func_table[TEST_ENTRY_SENTINEL] = {
     [PE066_ENTRY] = pe066_entry,
     [PE067_ENTRY] = pe067_entry,
     [PE068_ENTRY] = pe068_entry,
+    [PE069_ENTRY] = pe069_entry,
     [CXL001_ENTRY] = cxl001_entry,
     [CXL002_ENTRY] = cxl002_entry,
     [CXL003_ENTRY] = cxl003_entry,
@@ -4068,6 +4074,7 @@ test_entry_fn_t test_entry_func_table[TEST_ENTRY_SENTINEL] = {
     [PE040_ENTRY] = pe040_entry,
     [PE064_ENTRY] = pe064_entry,
     [PE065_ENTRY] = pe065_entry,
+    [PE069_ENTRY] = pe069_entry,
     [M005_ENTRY] = m005_entry,
     [M008_ENTRY] = m008_entry,
     [ETE008_ENTRY] = ete008_entry,

--- a/val/src/sbsa_execute_test.c
+++ b/val/src/sbsa_execute_test.c
@@ -84,6 +84,7 @@ val_sbsa_pe_execute_tests(uint32_t level, uint32_t num_pe)
 
   if (((level > 4)  && (g_sbsa_only_level == 0)) || (g_sbsa_only_level == 5)) {
       status |= pe031_entry(num_pe);
+      status |= pe069_entry(num_pe);
       status |= pe032_entry(num_pe);
       status |= pe033_entry(num_pe);
       status |= pe034_entry(num_pe);


### PR DESCRIPTION
- Add PE069 to validate FEAT_TRF (TraceFilt) per CS-BSA C
- Add PE069 to INF files and CMake
- Updated SBSA testcase checklist

Fixes #326 

Change-Id: Ie167e3348f00853265bc404308276074c9bf4cac
Signed-off-by: Shanmuga Priya L <[shanmuga.priyal@arm.com](mailto:shanmuga.priyal@arm.com)>