### PR TITLE
fix(exerciser): clear ATS TXN set after ATS is done

### DIFF
--- a/pal/baremetal/base/include/pal_common_support.h
+++ b/pal/baremetal/base/include/pal_common_support.h
@@ -764,7 +764,8 @@ typedef enum {
     START_TXN_MONITOR    = 0xb,
     STOP_TXN_MONITOR     = 0xc,
     ATS_TXN_REQ          = 0xd,
-    INJECT_ERROR         = 0xe
+    ATS_TXN_CLEAR        = 0xe,
+    INJECT_ERROR         = 0xf
 } EXERCISER_OPS;
 /**
   @brief  Instance of system pmu info

--- a/pal/baremetal/target/RDN2/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDN2/include/pal_exerciser.h
@@ -137,7 +137,8 @@ typedef enum {
     START_TXN_MONITOR    = 0xb,
     STOP_TXN_MONITOR     = 0xc,
     ATS_TXN_REQ          = 0xd,
-    INJECT_ERROR         = 0xe
+    ATS_TXN_CLEAR        = 0xe,
+    INJECT_ERROR         = 0xf
 } EXERCISER_OPS;
 
 typedef enum {

--- a/pal/baremetal/target/RDN2/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDN2/include/platform_override_fvp.h
@@ -887,8 +887,9 @@
 #define RID_VALID_MASK (1ul << 31)
 #define RID_VALID      1
 #define RID_NOT_VALID  0
-#define ATS_TRIGGER    1
-#define ATS_STATUS     (1ul << 7)
+#define ATS_TRIGGER        1
+#define ATS_TXN_CLEAR_BIT  (1ul << 5)
+#define ATS_STATUS         (1ul << 7)
 #define TXN_INVALID    0xFFFFFFFF
 #define TXN_START      1
 #define TXN_STOP       0

--- a/pal/baremetal/target/RDN2/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDN2/src/pal_exerciser.c
@@ -624,9 +624,14 @@ uint32_t pal_exerciser_ops(EXERCISER_OPS Ops, uint64_t Param, uint32_t Bdf)
         pal_mmio_write(Base + ATSCTL, ATS_TRIGGER);
         return !(pal_mmio_read(Base + ATSCTL) & ATS_STATUS);
 
+    case ATS_TXN_CLEAR:
+        pal_mmio_write(Base + ATSCTL, ATS_TXN_CLEAR_BIT);
+        return 0;
+
     case START_TXN_MONITOR:
         pal_mmio_write(Base + TXN_CTRL_BASE, TXN_START);
         return 0;
+
     case STOP_TXN_MONITOR:
         pal_mmio_write(Base + TXN_CTRL_BASE, TXN_STOP);
         return 0;

--- a/pal/baremetal/target/RDV3/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3/include/pal_exerciser.h
@@ -151,7 +151,8 @@ typedef enum {
     START_TXN_MONITOR    = 0xB,
     STOP_TXN_MONITOR     = 0xC,
     ATS_TXN_REQ          = 0xD,
-    INJECT_ERROR         = 0xE
+    ATS_TXN_CLEAR        = 0xE,
+    INJECT_ERROR         = 0xF
 } EXERCISER_OPS;
 
 typedef enum {

--- a/pal/baremetal/target/RDV3/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3/include/platform_override_fvp.h
@@ -823,6 +823,7 @@
 #define RID_VALUE_MASK         0xFFFF
 #define RID_VALID_MASK         (1ul << 31)
 #define ATS_TRIGGER            1
+#define ATS_TXN_CLEAR_BIT      (1ul << 5)
 #define ATS_STATUS             (1ul << 7)
 
 /* Memory config */

--- a/pal/baremetal/target/RDV3/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3/src/pal_exerciser.c
@@ -622,9 +622,14 @@ uint32_t pal_exerciser_ops(EXERCISER_OPS Ops, uint64_t Param, uint32_t Bdf)
         pal_mmio_write(Base + ATSCTL, ATS_TRIGGER);
         return !(pal_mmio_read(Base + ATSCTL) & ATS_STATUS);
 
+  case ATS_TXN_CLEAR:
+        pal_mmio_write(Base + ATSCTL, ATS_TXN_CLEAR_BIT);
+        return 0;
+
   case START_TXN_MONITOR:
         pal_mmio_write(Base + TXN_CTRL_BASE, TXN_START);
         return 0;
+
   case STOP_TXN_MONITOR:
         pal_mmio_write(Base + TXN_CTRL_BASE, TXN_STOP);
         return 0;

--- a/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
+++ b/pal/baremetal/target/RDV3CFG1/include/pal_exerciser.h
@@ -151,7 +151,8 @@ typedef enum {
     START_TXN_MONITOR    = 0xb,
     STOP_TXN_MONITOR     = 0xc,
     ATS_TXN_REQ          = 0xd,
-    INJECT_ERROR         = 0xe
+    ATS_TXN_CLEAR        = 0xe,
+    INJECT_ERROR         = 0xf
 } EXERCISER_OPS;
 
 typedef enum {

--- a/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
+++ b/pal/baremetal/target/RDV3CFG1/include/platform_override_fvp.h
@@ -759,6 +759,7 @@
 #define RID_VALUE_MASK         0xFFFF
 #define RID_VALID_MASK         (1ul << 31)
 #define ATS_TRIGGER            1
+#define ATS_TXN_CLEAR_BIT      (1ul << 5)
 #define ATS_STATUS             (1ul << 7)
 
 /* Memory config */

--- a/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
@@ -622,9 +622,14 @@ uint32_t pal_exerciser_ops(EXERCISER_OPS Ops, uint64_t Param, uint32_t Bdf)
         pal_mmio_write(Base + ATSCTL, ATS_TRIGGER);
         return !(pal_mmio_read(Base + ATSCTL) & ATS_STATUS);
 
+  case ATS_TXN_CLEAR:
+        pal_mmio_write(Base + ATSCTL, ATS_TXN_CLEAR_BIT);
+        return 0;
+
   case START_TXN_MONITOR:
         pal_mmio_write(Base + TXN_CTRL_BASE, TXN_START);
         return 0;
+
   case STOP_TXN_MONITOR:
         pal_mmio_write(Base + TXN_CTRL_BASE, TXN_STOP);
         return 0;

--- a/test_pool/exerciser/e020.c
+++ b/test_pool/exerciser/e020.c
@@ -369,6 +369,8 @@ test_clean:
       val_pgt_destroy(pgt_desc);
     }
 
+    val_exerciser_ops(ATS_TXN_CLEAR, 0, instance);
+
     if (val_pcie_find_capability(e_bdf, PCIE_ECAP, ECID_ATS, &cap_base) == PCIE_SUCCESS)
     {
         val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);

--- a/test_pool/exerciser/e040.c
+++ b/test_pool/exerciser/e040.c
@@ -71,6 +71,7 @@ run_cxl_path_ats_dma(uint32_t e_bdf)
   uint64_t ttbr;
   uint32_t device_id;
   uint32_t its_id;
+  uint32_t test_status = ACS_STATUS_FAIL;
   void *dram_buf_virt = NULL;
   void *dram_buf_out_virt;
   uint64_t dram_buf_phys;
@@ -222,26 +223,13 @@ run_cxl_path_ats_dma(uint32_t e_bdf)
     goto test_fail;
   }
 
-  if (smmu_mapped)
-    val_smmu_unmap(master);
-
-  if (smmu_enabled)
-    val_smmu_disable(master.smmu_index);
-
-  if (pgt_desc.pgt_base)
-    val_pgt_destroy(pgt_desc);
-
-  if (ats_enabled) {
-    val_pcie_read_cfg(e_bdf, cap_base + ATS_CTRL, &reg_value);
-    reg_value &= ATS_CACHING_DIS;
-    val_pcie_write_cfg(e_bdf, cap_base + ATS_CTRL, reg_value);
-  }
-
-  if (dram_buf_virt)
-    val_memory_free_pages(dram_buf_virt, TEST_DATA_NUM_PAGES);
-  return ACS_STATUS_PASS;
+  test_status = ACS_STATUS_PASS;
+  goto test_clean;
 
 test_fail:
+  test_status = ACS_STATUS_FAIL;
+
+test_clean:
   if (smmu_mapped)
     val_smmu_unmap(master);
 
@@ -257,9 +245,10 @@ test_fail:
     val_pcie_write_cfg(e_bdf, cap_base + ATS_CTRL, reg_value);
   }
 
+  val_exerciser_ops(ATS_TXN_CLEAR, 0, instance);
   if (dram_buf_virt)
     val_memory_free_pages(dram_buf_virt, TEST_DATA_NUM_PAGES);
-  return ACS_STATUS_FAIL;
+  return test_status;
 }
 
 static

--- a/val/include/pal_interface.h
+++ b/val/include/pal_interface.h
@@ -924,7 +924,8 @@ typedef enum {
     START_TXN_MONITOR    = 0xb,
     STOP_TXN_MONITOR     = 0xc,
     ATS_TXN_REQ          = 0xd,
-    INJECT_ERROR         = 0xe
+    ATS_TXN_CLEAR        = 0xe,
+    INJECT_ERROR         = 0xf
 } EXERCISER_OPS;
 
 typedef enum {


### PR DESCRIPTION
- Add an exerciser operation to invalidate the ATS entry and call it in e020 and e040 test. This prevents repeated runs from reusing the previous cached ATS translation.
- Define ATS_TXN_CLEAR before INJECT_ERROR
- Refactor e040 cleanup flow to avoid duplicated pass/fail cleanup code.

Signed-off-by: Sujana M <sujana.murali@arm.com>
Change-Id: Idf519cb67a14875da4e2f1dbafc178751fca94fc