### PR TITLE
Fix(doc): Modify Baremetal checklist of S_L7ENT_1

### DIFF
--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -2624,7 +2624,7 @@ The checklist provides information about:
       <td>1301</td>
       <td>NIST Statistical Test Suite</td>
       <td>Yes</td>
-      <td>Yes</td>
+      <td>No</td>
       <td>No</td>
       <td></td>
     </tr>


### PR DESCRIPTION
	- Currently S_L7ENT_1 is not supported in baremetal, Modified the checklist as per current
ACS


Change-Id: Ib8a7b95704b5d996bef3b9ed3b7fe59d4bcbc8d0