### PR TITLE
Fix(power_wakeup): disable system timer on wakeup test skip path

### DIFF
--- a/test_pool/power_wakeup/u005.c
+++ b/test_pool/power_wakeup/u005.c
@@ -156,6 +156,7 @@ payload5()
           */
           wakeup_clear_failsafe();
           if (!(g_timer_int_rcvd || g_failsafe_int_rcvd)) {
+              val_timer_disable_system_timer((addr_t)cnt_base_n);
               intid = val_timer_get_info(TIMER_INFO_SYS_INTID, timer_num);
               val_gic_clear_interrupt(intid);
               val_set_status(index, RESULT_SKIP(4));


### PR DESCRIPTION
u005 (B_WAK_03/B_WAK_07, Wake from System Timer Int) cleared the GIC pending bits when the wake interrupt was not received, but never disabled the memory-mapped system timer (CNTP_CTL). Since the interrupt is level-triggered, the timer kept re-asserting the line, leaving it stuck armed after the test returned. This hung subsequent tests that install their own exception/interrupt handlers.

Mirrors the disable-on-skip pattern already used by u001-u004 for their respective timer/watchdog sources.