### PR TITLE
fix(gpu): initialize PCIe and IOVIRT tables for BM GPU

### DIFF
--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -65,12 +65,14 @@ freeAcsMeM(void)
 
     if (acs_is_module_enabled(PCIE)        ||
         acs_is_module_enabled(GIC)         ||
+        acs_is_module_enabled(GPU)         ||
         acs_is_module_enabled(SMMU))
        val_pcie_free_info_table();
 
    if (acs_is_module_enabled(SMMU)         ||
        acs_is_module_enabled(GIC)          ||
        acs_is_module_enabled(MEM_MAP)      ||
+       acs_is_module_enabled(GPU)          ||
        acs_is_module_enabled(PCIE))
        val_iovirt_free_info_table();
 
@@ -254,12 +256,14 @@ ShellAppMainsbsa()
 
     if (acs_is_module_enabled(PCIE)       ||
         acs_is_module_enabled(GIC)        ||
+        acs_is_module_enabled(GPU)        ||
         acs_is_module_enabled(SMMU))
         createPcieInfoTable();
 
     if (acs_is_module_enabled(GIC)        ||
         acs_is_module_enabled(PCIE)       ||
         acs_is_module_enabled(MEM_MAP)    ||
+        acs_is_module_enabled(GPU)        ||
         acs_is_module_enabled(SMMU))
         createIoVirtInfoTable();
 


### PR DESCRIPTION
- Include GPU in the baremetal SBSA init checks that create the PCIe and IOVIRT info tables.
- Ensure GPU rules that depend on PCIe RC or SMMU discovery have the required platform tables when the GPU module is run directly.


Change-Id: I12cdaa3320acfd67e26a11de0284c079364da890