### PR TITLE
Initialise PCIe and IOVIRT tables for BM GPU and update ACS version to 8.0.2

### DIFF
--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -65,12 +65,14 @@ freeAcsMeM(void)
 
     if (acs_is_module_enabled(PCIE)        ||
         acs_is_module_enabled(GIC)         ||
+        acs_is_module_enabled(GPU)         ||
         acs_is_module_enabled(SMMU))
        val_pcie_free_info_table();
 
    if (acs_is_module_enabled(SMMU)         ||
        acs_is_module_enabled(GIC)          ||
        acs_is_module_enabled(MEM_MAP)      ||
+       acs_is_module_enabled(GPU)          ||
        acs_is_module_enabled(PCIE))
        val_iovirt_free_info_table();
 
@@ -254,12 +256,14 @@ ShellAppMainsbsa()
 
     if (acs_is_module_enabled(PCIE)       ||
         acs_is_module_enabled(GIC)        ||
+        acs_is_module_enabled(GPU)        ||
         acs_is_module_enabled(SMMU))
         createPcieInfoTable();
 
     if (acs_is_module_enabled(GIC)        ||
         acs_is_module_enabled(PCIE)       ||
         acs_is_module_enabled(MEM_MAP)    ||
+        acs_is_module_enabled(GPU)        ||
         acs_is_module_enabled(SMMU))
         createIoVirtInfoTable();
 

--- a/docs/sbsa/README.md
+++ b/docs/sbsa/README.md
@@ -38,7 +38,7 @@ The tests can also be executed in a Bare-metal environment. The initialization o
 
 ## Release details
 - **Code quality:** BETA
-- **Latest release version:** v8.0.1
+- **Latest release version:** v8.0.2
 - **Release tag:** `v26.03_SBSA_8.0.1`
 - **Specification coverage:** SBSA v8.0
 - **Execution levels:** Pre-Silicon and Silicon.
@@ -56,6 +56,7 @@ The tests can also be executed in a Bare-metal environment. The initialization o
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 |   SBSA Spec Version   |   ACS Coverage Mapping   |   SBSA ACS Version   |        SBSA Tag ID         |   BSA ACS Version   |          BSA Tag ID         |    Pre-Si Support    |
 |-----------------------|:------------------------:|:--------------------:|:--------------------------:|:-------------------:|:---------------------------:|:--------------------:|
+|       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.2          |   v26.06_SBSA_8.0.2        |        v1.2.1       |       v26.03_BSA_1.2.1      |       Yes            |
 |       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.1          |   v26.03_SBSA_8.0.1        |        v1.2.1       |       v26.03_BSA_1.2.1      |       Yes            |
 |       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.0          |   v25.12_SBSA_8.0.0        |        v1.2.0       |       v25.12_BSA_1.2.0      |       Yes            |
 |       SBSA v7.2       |    BSA ACS + SBSA ACS    |      v7.2.2          |   v25.03_REL7.2.2          |        v1.1.0       |       v25.03_REL1.1.0       |       Yes            |

--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -1,6 +1,6 @@
 ## SBSA ACS Testcase checklist
 
-The SBSA ACS test checklist is based on **SBSA 8.0 specification** and **SBSA ACS 8.0.1** tag.
+The SBSA ACS test checklist is based on **SBSA 8.0 specification** and **SBSA ACS 8.0.2** tag.
 
 The checklist provides information about:
 
@@ -3674,7 +3674,7 @@ The checklist provides information about:
   </tbody>
 </table>
 
-## Latest Checklist Changes
+### v26.06_SBSA_8.0.2
 - Updated PCI_MM_02 coverage with test 907.
 - Updated S_L5SM_04, S_L6PE_08, S_L6SM_04
 - Added rule S_L5PE_03

--- a/val/include/acs_app_versions.h
+++ b/val/include/acs_app_versions.h
@@ -26,7 +26,7 @@
 /* SBSA Release versions */
 #define SBSA_ACS_MAJOR_VER         8
 #define SBSA_ACS_MINOR_VER         0
-#define SBSA_ACS_SUBMINOR_VER      1
+#define SBSA_ACS_SUBMINOR_VER      2
 
 /* PC BSA Release versions */
 #define PC_BSA_ACS_MAJOR_VER       1


### PR DESCRIPTION
sbsa: update ACS release version to 8.0.2
- Update SBSA ACS version metadata from 8.0.1 to 8.0.2 and refresh
  the corresponding release tag references to v26.06_SBSA_8.0.2.
- Keep the previous 8.0.1 entry in the top-level release table while
  adding 8.0.2 as the latest release.

fix(gpu): initialise PCIe and IOVIRT tables for BM GPU
- Include GPU in the baremetal SBSA init checks that create the PCIe and
  IOVIRT info tables.
- Ensure GPU rules that depend on PCIe RC or SMMU discovery have the
  required platform tables when the GPU module is run directly.