### PR TITLE
fix(baremetal): Initialize WD info when runing TIMER module

### DIFF
--- a/apps/baremetal/bsa_main.c
+++ b/apps/baremetal/bsa_main.c
@@ -42,6 +42,7 @@ freeAcsMeM(void)
         acs_is_module_enabled(POWER_WAKEUP))
             val_timer_free_info_table();
     if (acs_is_module_enabled(WATCHDOG)     ||
+        acs_is_module_enabled(TIMER)        ||
         acs_is_module_enabled(POWER_WAKEUP))
             val_wd_free_info_table();
     if (acs_is_module_enabled(PCIE)         ||
@@ -204,6 +205,7 @@ ShellAppMainbsa()
             createTimerInfoTable();
 
     if (acs_is_module_enabled(WATCHDOG)    ||
+        acs_is_module_enabled(TIMER)       ||
         acs_is_module_enabled(POWER_WAKEUP))
             createWatchdogInfoTable();
 

--- a/apps/baremetal/pc_bsa_main.c
+++ b/apps/baremetal/pc_bsa_main.c
@@ -44,6 +44,7 @@ freeAcsMem(void)
        val_timer_free_info_table();
 
     if (acs_is_module_enabled(WATCHDOG)    ||
+        acs_is_module_enabled(TIMER)       ||
         acs_is_module_enabled(POWER_WAKEUP))
        val_wd_free_info_table();
 
@@ -218,6 +219,7 @@ ShellAppMainpcbsa(void)
         createTimerInfoTable();
 
     if (acs_is_module_enabled(WATCHDOG)    ||
+        acs_is_module_enabled(TIMER)       ||
         acs_is_module_enabled(POWER_WAKEUP))
         createWatchdogInfoTable();
 

--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -51,6 +51,7 @@ freeAcsMeM(void)
        val_timer_free_info_table();
 
     if (acs_is_module_enabled(WATCHDOG)    ||
+        acs_is_module_enabled(TIMER)       ||
         acs_is_module_enabled(POWER_WAKEUP))
        val_wd_free_info_table();
 
@@ -242,6 +243,7 @@ ShellAppMainsbsa()
         createTimerInfoTable();
 
     if (acs_is_module_enabled(WATCHDOG)   ||
+        acs_is_module_enabled(TIMER)      ||
         acs_is_module_enabled(POWER_WAKEUP))
         createWatchdogInfoTable();
 


### PR DESCRIPTION
    Certain timer tests like B_TIME_05 refer to watchdog info, hence its required to initialize WD info

Change-Id: Icc307239c540a44f434d57e9f41b2d53964d649c