### PR TITLE
add CNTP_CVAL_EL02/CNTV_CVAL_EL02 support and reorder system timer 

### DIFF
--- a/test_pool/timer/t005.c
+++ b/test_pool/timer/t005.c
@@ -101,8 +101,6 @@ payload()
       return;
   }
 
-  val_timer_set_system_timer((addr_t)cnt_base_n, sys_timer_ticks);
-
   irq_received = 0;
 
   intid = val_timer_get_info(TIMER_INFO_SYS_INTID, timer_num);
@@ -111,6 +109,9 @@ payload()
   intid_phy = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);
   val_gic_install_isr(intid_phy, isr_phy_el1);
 
+  /* Start system timer */
+  val_timer_set_system_timer((addr_t)cnt_base_n, sys_timer_ticks);
+  
   /* Start EL1 PHY timer */
   val_timer_set_phy_el1(pe_timer_ticks);
 

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -237,7 +237,10 @@ ArmArchTimerWriteReg (
       break;
 
     case CntpCval:
-      write_cntp_cval_el0(*data_buf);
+      if (effective_e2h)
+        write_cntp_cval_el02(*data_buf);
+      else
+        write_cntp_cval_el0(*data_buf);
       break;
 
     case CntvCval:


### PR DESCRIPTION
1.add CNTP_CVAL_EL02/CNTV_CVAL_EL02 support for ArmArchTimerWriteReg
2.reorder system timer in test_pool/timer/t005.c
Signed-off-by: xayahion <xayahion@sina.com>
