### PR TITLE
feat(drtm): Add secure interrupts test

### DIFF
--- a/apps/uefi/Drtm.inf
+++ b/apps/uefi/Drtm.inf
@@ -69,6 +69,7 @@
   ../../test_pool/drtm/dl016.c
   ../../test_pool/drtm/dl017.c
   ../../test_pool/drtm/dl018.c
+  ../../test_pool/drtm/dl019.c
 
 [Packages]
   StdLib/StdLib.dec

--- a/test_pool/drtm/dl013.c
+++ b/test_pool/drtm/dl013.c
@@ -36,6 +36,7 @@ payload(uint32_t num_pe)
   uint32_t pcr18_events[256];
   uint32_t pcr18_count = 0;
   uint32_t event_idx = 0;
+  uint32_t secure_int_disabled = 0;
 
   DRTM_PARAMETERS      *drtm_params;
   DRTM_EVENT_LOG_STATE event_log;
@@ -65,8 +66,11 @@ payload(uint32_t num_pe)
     goto free_drtm_params;
   }
 
-  /* TODO - Enable below line after implementing DRTM_ENABLE_SECURE_INTERRUPTS function */
-  /* drtm_params->launch_features |= DRTM_LAUNCH_FEAT_SECURE_INT_DISABLE; */
+  /* Request secure interrupt disable during dynamic launch when supported. */
+  if (g_drtm_features.enable_secure_interrupts == DRTM_ACS_SUCCESS) {
+    drtm_params->launch_features |= DRTM_LAUNCH_FEAT_SECURE_INT_DISABLE;
+    secure_int_disabled = 1;
+  }
 
   /* Invoke DRTM Dynamic Launch, This will return only in case of error */
   status = val_drtm_dynamic_launch(drtm_params);
@@ -77,25 +81,35 @@ payload(uint32_t num_pe)
     goto free_dlme_region;
   }
 
+  /* Re-enable secure interrupts after a successful dynamic launch. */
+  if (secure_int_disabled) {
+    status = val_drtm_enable_secure_interrupts();
+    if (status != DRTM_ACS_SUCCESS) {
+      val_print(ERROR, "\n       DRTM Enable Secure Interrupts failed err=%d", status);
+      val_set_status(index, RESULT_FAIL(4));
+      goto unprotect_memory;
+    }
+  }
+
   /* Call DRTM Unprotect Memory */
   status = val_drtm_unprotect_memory();
   if (status < DRTM_ACS_SUCCESS) {
     val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(4));
+    val_set_status(index, RESULT_FAIL(5));
     goto free_dlme_region;
   }
 
   status = val_drtm_event_log_init(drtm_params, &event_log);
   if (status != ACS_STATUS_PASS) {
     val_print(ERROR, "\n       Event log initialization failed", 0);
-    val_set_status(index, RESULT_FAIL(5));
+    val_set_status(index, RESULT_FAIL(6));
     goto free_dlme_region;
   }
 
   while ((status = val_drtm_event_log_next(&event_log, &entry)) != DRTM_ACS_NOT_FOUND) {
     if (status != ACS_STATUS_PASS) {
       val_print(ERROR, "\n       Event log parsing failed");
-      val_set_status(index, RESULT_FAIL(6));
+      val_set_status(index, RESULT_FAIL(7));
       goto free_dlme_region;
     }
 
@@ -111,14 +125,14 @@ payload(uint32_t num_pe)
   /* DCE Image required*/
   if ((event_idx >= pcr17_count) || (pcr17_events[event_idx] != DRTM_EVTYPE_ARM_DCE)) {
     val_print(ERROR, "\n       PCR[17] DCE event not found or out of order");
-    val_set_status(index, RESULT_FAIL(7));
+    val_set_status(index, RESULT_FAIL(8));
     goto free_dlme_region;
   }
   event_idx++;
   /* PCR_SCHEMA required */
   if (event_idx >= pcr17_count || pcr17_events[event_idx] != DRTM_EVTYPE_ARM_PCR_SCHEMA) {
     val_print(ERROR, "\n       PCR[17] PCR_SCHEMA not found or out of order");
-    val_set_status(index, RESULT_FAIL(8));
+    val_set_status(index, RESULT_FAIL(9));
     goto free_dlme_region;
   }
   event_idx++;
@@ -129,14 +143,23 @@ payload(uint32_t num_pe)
   while (event_idx < pcr17_count && pcr17_events[event_idx] == DRTM_EVTYPE_ARM_DCE_SECONDARY)
     event_idx++;
 
-  /* SECURE_INT_DISABLE optional */
-  /* TODO - Change this to required after enabling DRTM_EVTYPE_ARM_SECURE_INT_DISABLE */
-  if (event_idx < pcr17_count && pcr17_events[event_idx] == DRTM_EVTYPE_ARM_SECURE_INT_DISABLE)
+  /* SECURE_INT_DISABLE event is required when secure interrupts were disabled. */
+  if (secure_int_disabled) {
+    if (event_idx >= pcr17_count ||
+        pcr17_events[event_idx] != DRTM_EVTYPE_ARM_SECURE_INT_DISABLE) {
+      val_print(ERROR, "\n       PCR[17] SECURE_INT_DISABLE not found or out of order");
+      val_set_status(index, RESULT_FAIL(10));
+      goto free_dlme_region;
+    }
     event_idx++;
+  } else if (event_idx < pcr17_count &&
+             pcr17_events[event_idx] == DRTM_EVTYPE_ARM_SECURE_INT_DISABLE) {
+    event_idx++;
+  }
   /* SEPARATOR required */
   if (event_idx >= pcr17_count || pcr17_events[event_idx] != DRTM_EVTYPE_ARM_SEPARATOR) {
     val_print(ERROR, "\n       PCR[17] SEPARATOR not found or out of order");
-    val_set_status(index, RESULT_FAIL(9));
+    val_set_status(index, RESULT_FAIL(11));
     goto free_dlme_region;
   }
   event_idx++;
@@ -144,7 +167,7 @@ payload(uint32_t num_pe)
 
   if (event_idx != pcr17_count) {
     val_print(ERROR, "\n       PCR[17] extra events after SEPARATOR");
-    val_set_status(index, RESULT_FAIL(10));
+    val_set_status(index, RESULT_FAIL(12));
     goto free_dlme_region;
   }
 
@@ -153,7 +176,7 @@ payload(uint32_t num_pe)
   /* PCR_SCHEMA required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_PCR_SCHEMA) {
     val_print(ERROR, "\n       PCR[18] PCR_SCHEMA not found or out of order");
-    val_set_status(index, RESULT_FAIL(11));
+    val_set_status(index, RESULT_FAIL(13));
     goto free_dlme_region;
   }
   event_idx++;
@@ -163,46 +186,53 @@ payload(uint32_t num_pe)
   /* DLME required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_DLME) {
     val_print(ERROR, "\n       PCR[18] DLME not found or out of order");
-    val_set_status(index, RESULT_FAIL(12));
+    val_set_status(index, RESULT_FAIL(14));
     goto free_dlme_region;
   }
   event_idx++;
   /* DLME_ENTRY_POINT required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_DLME_ENTRY_POINT) {
     val_print(ERROR, "\n       PCR[18] DLME_ENTRY_POINT not found or out of order");
-    val_set_status(index, RESULT_FAIL(13));
+    val_set_status(index, RESULT_FAIL(15));
     goto free_dlme_region;
   }
   event_idx++;
   /* DEBUG_CONFIG required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_DEBUG_CONFIG) {
     val_print(ERROR, "\n       PCR[18] DEBUG_CONFIG not found or out of order");
-    val_set_status(index, RESULT_FAIL(14));
+    val_set_status(index, RESULT_FAIL(16));
     goto free_dlme_region;
   }
   event_idx++;
   /* NONSECURE_CONFIG required */
-  if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_NONSECURE_CONFIG) {
+  if (event_idx >= pcr18_count ||
+      pcr18_events[event_idx] != DRTM_EVTYPE_ARM_NONSECURE_CONFIG) {
     val_print(ERROR, "\n       PCR[18] NONSECURE_CONFIG not found or out of order");
-    val_set_status(index, RESULT_FAIL(15));
+    val_set_status(index, RESULT_FAIL(17));
     goto free_dlme_region;
   }
   event_idx++;
   /* SEPARATOR required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_SEPARATOR) {
     val_print(ERROR, "\n       PCR[18] SEPARATOR not found or out of order");
-    val_set_status(index, RESULT_FAIL(16));
+    val_set_status(index, RESULT_FAIL(18));
     goto free_dlme_region;
   }
   event_idx++;
   /* No more events */
   if (event_idx != pcr18_count) {
     val_print(ERROR, "\n       PCR[18] extra events after SEPARATOR");
-    val_set_status(index, RESULT_FAIL(17));
+    val_set_status(index, RESULT_FAIL(19));
     goto free_dlme_region;
   }
 
   val_set_status(index, RESULT_PASS);
+  goto free_dlme_region;
+
+unprotect_memory:
+  status = val_drtm_unprotect_memory();
+  if (status < DRTM_ACS_SUCCESS)
+    val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
 
 free_dlme_region:
   if (drtm_params->dlme_region_address)

--- a/test_pool/drtm/dl015.c
+++ b/test_pool/drtm/dl015.c
@@ -37,6 +37,7 @@ payload(uint32_t num_pe)
   uint32_t pcr18_events[256];
   uint32_t pcr18_count = 0;
   uint32_t event_idx = 0;
+  uint32_t secure_int_disabled = 0;
 
   DRTM_PARAMETERS      *drtm_params;
   DRTM_EVENT_LOG_STATE event_log;
@@ -79,8 +80,11 @@ payload(uint32_t num_pe)
   drtm_params->launch_features |= (DRTM_LAUNCH_FEAT_REQ_DLME_IMG_AUTH <<
                     DRTM_LAUNCH_FEAT_SHIFT_DLME_IMG_AUTH);
 
-  /* TODO - Enable below line after implementing DRTM_ENABLE_SECURE_INTERRUPTS function */
-  /* drtm_params->launch_features |= DRTM_LAUNCH_FEAT_SECURE_INT_DISABLE; */
+  /* Request secure interrupt disable during dynamic launch when supported. */
+  if (g_drtm_features.enable_secure_interrupts == DRTM_ACS_SUCCESS) {
+    drtm_params->launch_features |= DRTM_LAUNCH_FEAT_SECURE_INT_DISABLE;
+    secure_int_disabled = 1;
+  }
 
   /* Invoke DRTM Dynamic Launch, This will return only in case of error */
   status = val_drtm_dynamic_launch(drtm_params);
@@ -91,18 +95,28 @@ payload(uint32_t num_pe)
     goto free_dlme_region;
   }
 
+  /* Re-enable secure interrupts after a successful dynamic launch. */
+  if (secure_int_disabled) {
+    status = val_drtm_enable_secure_interrupts();
+    if (status != DRTM_ACS_SUCCESS) {
+      val_print(ERROR, "\n       DRTM Enable Secure Interrupts failed err=%d", status);
+      val_set_status(index, RESULT_FAIL(4));
+      goto unprotect_memory;
+    }
+  }
+
   /* Call DRTM Unprotect Memory */
   status = val_drtm_unprotect_memory();
   if (status < DRTM_ACS_SUCCESS) {
     val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
-    val_set_status(index, RESULT_FAIL(4));
+    val_set_status(index, RESULT_FAIL(5));
     goto free_dlme_region;
   }
 
   status = val_drtm_event_log_init(drtm_params, &event_log);
   if (status != ACS_STATUS_PASS) {
     val_print(ERROR, "\n       Event log initialization failed");
-    val_set_status(index, RESULT_FAIL(5));
+    val_set_status(index, RESULT_FAIL(6));
     goto free_dlme_region;
   }
 
@@ -110,7 +124,7 @@ payload(uint32_t num_pe)
   while ((status = val_drtm_event_log_next(&event_log, &entry)) != DRTM_ACS_NOT_FOUND) {
     if (status != ACS_STATUS_PASS) {
       val_print(ERROR, "\n       Event log parsing failed");
-      val_set_status(index, RESULT_FAIL(6));
+      val_set_status(index, RESULT_FAIL(7));
       goto free_dlme_region;
     }
 
@@ -126,7 +140,7 @@ payload(uint32_t num_pe)
   /* DCE Image required*/
   if ((event_idx >= pcr17_count) || (pcr17_events[event_idx] != DRTM_EVTYPE_ARM_DCE)) {
     val_print(ERROR, "\n       PCR[17] DCE event not found or out of order");
-    val_set_status(index, RESULT_FAIL(7));
+    val_set_status(index, RESULT_FAIL(8));
     goto free_dlme_region;
   }
   event_idx++;
@@ -134,7 +148,7 @@ payload(uint32_t num_pe)
   /* PCR_SCHEMA required */
   if (event_idx >= pcr17_count || pcr17_events[event_idx] != DRTM_EVTYPE_ARM_PCR_SCHEMA) {
     val_print(ERROR, "\n       PCR[17] PCR_SCHEMA not found or out of order");
-    val_set_status(index, RESULT_FAIL(8));
+    val_set_status(index, RESULT_FAIL(9));
     goto free_dlme_region;
   }
   event_idx++;
@@ -147,15 +161,24 @@ payload(uint32_t num_pe)
   while (event_idx < pcr17_count && pcr17_events[event_idx] == DRTM_EVTYPE_ARM_DCE_SECONDARY)
     event_idx++;
 
-  /* SECURE_INT_DISABLE optional */
-  /* TODO - Change this to required after enabling DRTM_EVTYPE_ARM_SECURE_INT_DISABLE */
-  if (event_idx < pcr17_count && pcr17_events[event_idx] == DRTM_EVTYPE_ARM_SECURE_INT_DISABLE)
+  /* SECURE_INT_DISABLE event is required when secure interrupts were disabled. */
+  if (secure_int_disabled) {
+    if (event_idx >= pcr17_count ||
+        pcr17_events[event_idx] != DRTM_EVTYPE_ARM_SECURE_INT_DISABLE) {
+      val_print(ERROR, "\n       PCR[17] SECURE_INT_DISABLE not found or out of order");
+      val_set_status(index, RESULT_FAIL(10));
+      goto free_dlme_region;
+    }
     event_idx++;
+  } else if (event_idx < pcr17_count &&
+             pcr17_events[event_idx] == DRTM_EVTYPE_ARM_SECURE_INT_DISABLE) {
+    event_idx++;
+  }
 
   /* SEPARATOR required */
   if (event_idx >= pcr17_count || pcr17_events[event_idx] != DRTM_EVTYPE_ARM_SEPARATOR) {
     val_print(ERROR, "\n       PCR[17] SEPARATOR not found or out of order");
-    val_set_status(index, RESULT_FAIL(9));
+    val_set_status(index, RESULT_FAIL(11));
     goto free_dlme_region;
   }
   event_idx++;
@@ -163,7 +186,7 @@ payload(uint32_t num_pe)
   /* No more events */
   if (event_idx != pcr17_count) {
     val_print(ERROR, "\n       PCR[17] extra events after SEPARATOR");
-    val_set_status(index, RESULT_FAIL(10));
+    val_set_status(index, RESULT_FAIL(12));
     goto free_dlme_region;
   }
 
@@ -172,7 +195,7 @@ payload(uint32_t num_pe)
   /* PCR_SCHEMA required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_PCR_SCHEMA) {
     val_print(ERROR, "\n       PCR[18] PCR_SCHEMA not found or out of order");
-    val_set_status(index, RESULT_FAIL(11));
+    val_set_status(index, RESULT_FAIL(13));
     goto free_dlme_region;
   }
   event_idx++;
@@ -184,7 +207,7 @@ payload(uint32_t num_pe)
   /* DLME_PUBKEY required if auth succeeds */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_DLME_PUBKEY) {
     val_print(ERROR, "\n       PCR[18] DLME_PUBKEY not found or out of order");
-    val_set_status(index, RESULT_FAIL(12));
+    val_set_status(index, RESULT_FAIL(14));
     goto free_dlme_region;
   }
   event_idx++;
@@ -196,7 +219,7 @@ payload(uint32_t num_pe)
   /* DLME_ENTRY_POINT required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_DLME_ENTRY_POINT) {
     val_print(ERROR, "\n       PCR[18] DLME_ENTRY_POINT not found or out of order");
-    val_set_status(index, RESULT_FAIL(13));
+    val_set_status(index, RESULT_FAIL(15));
     goto free_dlme_region;
   }
   event_idx++;
@@ -204,15 +227,15 @@ payload(uint32_t num_pe)
   /* DEBUG_CONFIG required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_DEBUG_CONFIG) {
     val_print(ERROR, "\n       PCR[18] DEBUG_CONFIG not found or out of order");
-    val_set_status(index, RESULT_FAIL(14));
+    val_set_status(index, RESULT_FAIL(16));
     goto free_dlme_region;
   }
   event_idx++;
-
   /* NONSECURE_CONFIG required */
-  if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_NONSECURE_CONFIG) {
+  if (event_idx >= pcr18_count ||
+      pcr18_events[event_idx] != DRTM_EVTYPE_ARM_NONSECURE_CONFIG) {
     val_print(ERROR, "\n       PCR[18] NONSECURE_CONFIG not found or out of order");
-    val_set_status(index, RESULT_FAIL(15));
+    val_set_status(index, RESULT_FAIL(17));
     goto free_dlme_region;
   }
   event_idx++;
@@ -220,7 +243,7 @@ payload(uint32_t num_pe)
   /* SEPARATOR required */
   if (event_idx >= pcr18_count || pcr18_events[event_idx] != DRTM_EVTYPE_ARM_SEPARATOR) {
     val_print(ERROR, "\n       PCR[18] SEPARATOR not found or out of order");
-    val_set_status(index, RESULT_FAIL(16));
+    val_set_status(index, RESULT_FAIL(18));
     goto free_dlme_region;
   }
   event_idx++;
@@ -228,11 +251,17 @@ payload(uint32_t num_pe)
   /* No more events */
   if (event_idx != pcr18_count) {
     val_print(ERROR, "\n       PCR[18] extra events after SEPARATOR");
-    val_set_status(index, RESULT_FAIL(17));
+    val_set_status(index, RESULT_FAIL(19));
     goto free_dlme_region;
   }
 
   val_set_status(index, RESULT_PASS);
+  goto free_dlme_region;
+
+unprotect_memory:
+  status = val_drtm_unprotect_memory();
+  if (status < DRTM_ACS_SUCCESS)
+    val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%d", status);
 
 free_dlme_region:
   if (drtm_params->dlme_region_address)

--- a/test_pool/drtm/dl019.c
+++ b/test_pool/drtm/dl019.c
@@ -1,0 +1,131 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+#include "val/include/acs_val.h"
+#include "val/include/acs_memory.h"
+#include "val/include/val_interface.h"
+
+#define TEST_NUM   (ACS_DRTM_DL_TEST_NUM_BASE  +  19)
+#define TEST_RULE  ""
+#define TEST_DESC  "Check Enable Secure Interrupts cmd    "
+
+static
+void
+payload(uint32_t num_pe)
+{
+  uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
+  int64_t  status;
+
+  DRTM_PARAMETERS *drtm_params;
+  uint64_t drtm_params_size = DRTM_SIZE_4K;
+
+  if (g_drtm_features.enable_secure_interrupts != DRTM_ACS_SUCCESS) {
+    val_print(ERROR,
+              "\n       DRTM_ENABLE_SECURE_INTERRUPTS function not supported err=%d",
+              g_drtm_features.enable_secure_interrupts);
+    val_set_status(index, RESULT_SKIP(1));
+    return;
+  }
+
+  /* Allocate Memory For DRTM Parameters 4KB Aligned */
+  drtm_params = (DRTM_PARAMETERS *)((uint64_t)val_aligned_alloc(DRTM_SIZE_4K,
+                                                                drtm_params_size));
+  if (!drtm_params) {
+    val_print(ERROR, "\n    Failed to allocate memory for DRTM Params");
+    val_set_status(index, RESULT_FAIL(1));
+    return;
+  }
+
+  status = val_drtm_init_drtm_params(drtm_params);
+  if (status != ACS_STATUS_PASS) {
+    val_print(ERROR, "\n       DRTM Init Params failed err=%ld", status);
+    val_set_status(index, RESULT_FAIL(2));
+    goto free_drtm_params;
+  }
+
+  drtm_params->launch_features |= DRTM_LAUNCH_FEAT_SECURE_INT_DISABLE;
+
+  /* Invoke DRTM Dynamic Launch, This will return only in case of error */
+  status = val_drtm_dynamic_launch(drtm_params);
+  /* This will return only in fail*/
+  if (status < DRTM_ACS_SUCCESS) {
+    val_print(ERROR, "\n       DRTM Dynamic Launch failed err=%ld", status);
+    val_set_status(index, RESULT_FAIL(3));
+    goto free_dlme_region;
+  }
+
+  /* The first enable request must succeed after secure interrupts are disabled. */
+  status = val_drtm_enable_secure_interrupts();
+  if (status != DRTM_ACS_SUCCESS) {
+    val_print(ERROR, "\n       DRTM Enable Secure Interrupts failed err=%ld", status);
+    val_print(ERROR, " Expected %d,", DRTM_ACS_SUCCESS);
+    val_set_status(index, RESULT_FAIL(4));
+    goto unprotect_memory;
+  }
+
+  /* A repeated enable request must be denied after interrupts are already enabled. */
+  status = val_drtm_enable_secure_interrupts();
+  if (status != DRTM_ACS_DENIED) {
+    val_print(ERROR, "\n       Unexpected Status for second enable secure interrupts %ld", status);
+    val_print(ERROR, " Expected %d,", DRTM_ACS_DENIED);
+    val_set_status(index, RESULT_FAIL(5));
+    goto unprotect_memory;
+  }
+
+  /* Unprotect memory after dynamic launch. */
+  status = val_drtm_unprotect_memory();
+  if (status < DRTM_ACS_SUCCESS) {
+    val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%ld", status);
+    val_set_status(index, RESULT_FAIL(6));
+    goto free_dlme_region;
+  }
+
+  val_set_status(index, RESULT_PASS);
+  goto free_dlme_region;
+
+unprotect_memory:
+  status = val_drtm_unprotect_memory();
+  if (status < DRTM_ACS_SUCCESS)
+    val_print(ERROR, "\n       DRTM Unprotect Memory failed err=%ld", status);
+
+free_dlme_region:
+  val_memory_free_aligned((void *)drtm_params->dlme_region_address);
+free_drtm_params:
+  val_memory_free_aligned((void *)drtm_params);
+
+  return;
+}
+
+uint32_t
+dl019_entry(uint32_t num_pe)
+{
+
+  uint32_t status = ACS_STATUS_FAIL;
+  num_pe = 1;
+  status = val_initialize_test(TEST_NUM, TEST_DESC, num_pe);
+
+  if (status != ACS_STATUS_SKIP)
+  /* execute payload, which will execute relevant functions on Boot PE */
+      payload(num_pe);
+
+  /* get the result from all PE and check for failure */
+  status = val_check_for_error(TEST_NUM, num_pe, TEST_RULE);
+
+  val_report_status(0, ACS_END(TEST_NUM), NULL);
+
+  return status;
+}

--- a/val/include/acs_drtm.h
+++ b/val/include/acs_drtm.h
@@ -46,6 +46,7 @@
 #define DRTM_1_0_FN_DRTM_SET_ERROR          DRTM_1_0_FN(0x07)
 #define DRTM_1_0_FN_DRTM_SET_TCB_HASH       DRTM_1_0_FN(0x08)
 #define DRTM_1_0_FN_DRTM_LOCK_TCB_HASH      DRTM_1_0_FN(0x09)
+#define DRTM_1_0_FN_DRTM_ENABLE_SECURE_INTERRUPTS DRTM_1_0_FN(0x0A)
 
 #define DRTM_1_0_FEAT_ID_BIT                ((uint64_t)0x1 << 63)
 #define DRTM_1_0_FEAT_ID(n)                 (DRTM_1_0_FEAT_ID_BIT | (n))
@@ -219,6 +220,7 @@ typedef struct {
     int64_t               set_error;
     int64_t               set_tcb_hash;
     int64_t               lock_tcb_hashes;
+    int64_t               enable_secure_interrupts;
 } DRTM_ACS_FEATURES;
 
 extern DRTM_ACS_FEATURES g_drtm_features;
@@ -386,6 +388,7 @@ int64_t val_drtm_unprotect_memory(void);
 int64_t val_drtm_get_error(uint64_t *feat1);
 int64_t val_drtm_set_tcb_hash(uint64_t tcb_hash_table_addr);
 int64_t val_drtm_lock_tcb_hashes(void);
+int64_t val_drtm_enable_secure_interrupts(void);
 uint32_t val_drtm_reserved_bits_check_is_zero(uint32_t reserved_bits);
 uint32_t val_drtm_get_psci_ver(void);
 uint32_t val_drtm_get_smccc_ver(void);
@@ -440,6 +443,7 @@ uint32_t dl015_entry(uint32_t num_pe);
 uint32_t dl016_entry(uint32_t num_pe);
 uint32_t dl017_entry(uint32_t num_pe);
 uint32_t dl018_entry(uint32_t num_pe);
+uint32_t dl019_entry(uint32_t num_pe);
 
 
 #endif /* __VAL_SPECIFICATION_H */

--- a/val/src/acs_interface.c
+++ b/val/src/acs_interface.c
@@ -281,6 +281,17 @@ int64_t val_drtm_lock_tcb_hashes(void)
 }
 
 /**
+ *  @brief   Calls DRTM Enable Secure Interrupts function
+ *
+ *  @return  status
+ */
+int64_t val_drtm_enable_secure_interrupts(void)
+{
+    return val_invoke_drtm_fn(DRTM_1_0_FN_DRTM_ENABLE_SECURE_INTERRUPTS, 0, 0, 0, 0, 0,
+                              NULL, NULL, NULL);
+}
+
+/**
   @brief   This function checks if reserved_bits received are zero
   @param   reserved_bits reserved bits value received
   @return  status
@@ -607,6 +618,8 @@ uint32_t val_drtm_create_info_table(void)
         val_drtm_features(DRTM_1_0_FN_DRTM_SET_TCB_HASH, &feat1, &feat2);
     g_drtm_features.lock_tcb_hashes  =
         val_drtm_features(DRTM_1_0_FN_DRTM_LOCK_TCB_HASH, &feat1, &feat2);
+    g_drtm_features.enable_secure_interrupts =
+        val_drtm_features(DRTM_1_0_FN_DRTM_ENABLE_SECURE_INTERRUPTS, &feat1, &feat2);
 
     return 0;
 }

--- a/val/src/drtm_execute_test.c
+++ b/val/src/drtm_execute_test.c
@@ -153,6 +153,7 @@ val_drtm_execute_dl_tests(uint32_t num_pe)
   status |= dl016_entry(num_pe);
   status |= dl017_entry(num_pe);
   status |= dl018_entry(num_pe);
+  status |= dl019_entry(num_pe);
 
   val_print_test_end(status, "Dynamic Launch");
 


### PR DESCRIPTION
* Add DRTM_ENABLE_SECURE_INTERRUPTS interface support and feature discovery.
* Enable secure interrupt disable launch feature when supported.
* Validate SECURE_INT_DISABLE event ordering in PCR[17].
* Add DL019 to verify secure interrupts can be enabled once and reject repeated enable requests.


Change-Id: If9ff80f816be1abe30f28f1cd4ea229f3f00418c