### PR TITLE
pcie(infra): scope shared RI rules by parent alias

### DIFF
--- a/test_pool/exerciser/e019.c
+++ b/test_pool/exerciser/e019.c
@@ -73,6 +73,7 @@ payload(void)
   uint32_t e_bdf;
   uint32_t bdf;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t test_skip = 1;
   void *dram_buf_in_virt;
   void *dram_buf_out_virt;
@@ -156,16 +157,18 @@ payload(void)
   for (instance = 0; instance < num_smmus; ++instance)
      val_smmu_enable(instance);
 
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
+
   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
   {
     bdf = bdf_tbl_ptr->device[tbl_index].bdf;
     dp_type = val_pcie_device_port_type(bdf);
-    if ((dp_type != RCiEP) && (dp_type != iEP_EP) && (dp_type != iEP_RP)) {
-        val_print(DEBUG, "\n       BDF - 0x%x not an RCiEP/iEP device", bdf);
+    if (!(rule_dp_type & dp_type)) {
+        val_print(DEBUG, "\n       BDF - 0x%x is not of type 0x%x", bdf, rule_dp_type);
         continue;
     }
 
-    val_print(DEBUG, "\n      RCiEP/iEP BDF - 0x%x ", bdf);
+    val_print(DEBUG, "\n      BDF - 0x%x ", bdf);
 
     /* Get rc index of RCiEP/iEP in IOVIRT mapping*/
     rc_index = val_iovirt_get_rc_index(PCIE_EXTRACT_BDF_SEG(bdf));

--- a/test_pool/exerciser/e020.c
+++ b/test_pool/exerciser/e020.c
@@ -70,6 +70,7 @@ payload(void)
   uint32_t dma_len;
   uint32_t instance;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t e_bdf;
   uint32_t bdf;
   uint32_t rc_index;
@@ -152,11 +153,13 @@ payload(void)
      val_smmu_enable(instance);
 
 
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
+
   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
   {
     bdf = bdf_tbl_ptr->device[tbl_index].bdf;
     dp_type = val_pcie_device_port_type(bdf);
-    if ((dp_type != RCiEP) && (dp_type != iEP_EP) && (dp_type != iEP_RP)) {
+    if (!(rule_dp_type & dp_type)) {
         val_print(DEBUG, "\n       BDF - 0x%x not an RCiEP/iEP device", bdf);
         continue;
     }

--- a/test_pool/exerciser/e021.c
+++ b/test_pool/exerciser/e021.c
@@ -277,11 +277,13 @@ cfgspace_transactions_order_check(void)
   uint32_t bdf;
   char *baseptr;
   uint32_t cid_offset, dp_type;
+  uint32_t rule_dp_type;
   uint64_t bdf_addr;
   uint32_t status;
 
   /* Read the number of excerciser cards */
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
 
   while (instance-- != 0) {
 
@@ -293,8 +295,8 @@ cfgspace_transactions_order_check(void)
     bdf = val_exerciser_get_bdf(instance);
     dp_type = val_pcie_device_port_type(bdf);
 
-    /* Check entry is RCiEP/ iEP. Else move to next BDF. */
-    if ((dp_type != RCiEP) && (dp_type != iEP_EP))
+    /* Check entry is RCiEP or iEP endpoint in the current alias scope. */
+    if (!(rule_dp_type & dp_type))
         continue;
 
     val_print(DEBUG, "\n       Exerciser BDF - 0x%x", bdf);
@@ -354,9 +356,11 @@ barspace_transactions_order_check(void)
   char *baseptr;
   uint32_t status;
   uint32_t bdf, dp_type;
+  uint32_t rule_dp_type;
 
   /* Read the number of excerciser cards */
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_EP);
 
   while (instance-- != 0) {
 
@@ -368,8 +372,8 @@ barspace_transactions_order_check(void)
     bdf = val_exerciser_get_bdf(instance);
     dp_type = val_pcie_device_port_type(bdf);
 
-    /* Check entry is RCiEP/ iEP. Else move to next BDF. */
-    if ((dp_type != RCiEP) && (dp_type != iEP_EP))
+    /* Check entry is RCiEP or iEP endpoint in the current alias scope. */
+    if (!(rule_dp_type & dp_type))
         continue;
 
     /* Get BAR 0 details for this instance */

--- a/test_pool/exerciser/e036.c
+++ b/test_pool/exerciser/e036.c
@@ -96,6 +96,7 @@ payload(void)
   uint32_t device_id, its_id;
   uint32_t page_size;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t test_data_blk_size;
 
   memory_region_descriptor_t mem_desc_array[2], *mem_desc;
@@ -160,6 +161,7 @@ payload(void)
     goto test_fail;
 
   instance = val_exerciser_get_info(EXERCISER_NUM_CARDS);
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_EP);
 
   while (instance-- != 0) {
     clear_dram_buf(dram_buf_base_virt, test_data_blk_size * 2);
@@ -173,7 +175,7 @@ payload(void)
 
     dp_type = val_pcie_device_port_type(e_bdf);
 
-    if ((dp_type != RCiEP) && (dp_type != iEP_EP))
+    if (!(rule_dp_type & dp_type))
         continue;
 
     val_print(DEBUG, "\n       Exerciser BDF - 0x%x", e_bdf);

--- a/test_pool/pcie/p062.c
+++ b/test_pool/pcie/p062.c
@@ -38,6 +38,7 @@ payload(void)
   uint32_t addr_type;
   uint32_t bar_index;
   uint32_t  dp_type;
+  uint32_t rule_dp_type;
   uint32_t test_fails;
   uint32_t test_skip = 1;
   pcie_device_bdf_table *bdf_tbl_ptr;
@@ -47,6 +48,7 @@ payload(void)
 
   tbl_index = 0;
   test_fails = 0;
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
 
   /* Check for all the function present in bdf table */
   while (tbl_index < bdf_tbl_ptr->num_entries)
@@ -54,8 +56,8 @@ payload(void)
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
 
-      /* Check for RCiEP, iEP_EP and iEP_RP type devices */
-      if (dp_type == RCiEP || dp_type == iEP_EP || dp_type == iEP_RP)
+      /* Check for RI rule devices in the current alias scope */
+      if ((rule_dp_type & dp_type))
       {
           val_print(DEBUG, "\n       BDF - 0x%x ", bdf);
           /* Extract Hdr Type */

--- a/test_pool/pcie/p063.c
+++ b/test_pool/pcie/p063.c
@@ -62,6 +62,7 @@ payload(void)
   uint32_t tbl_index;
   uint32_t reg_value;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t cap_base;
   uint32_t flr_cap;
   uint32_t base_cc;
@@ -82,6 +83,7 @@ payload(void)
 
   tbl_index = 0;
   test_fails = 0;
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_EP);
 
   /* Check for all the function present in bdf table */
   while (tbl_index < bdf_tbl_ptr->num_entries)
@@ -105,8 +107,8 @@ payload(void)
           continue;
       }
 
-      /* Check entry is  RCiEP or iEP endpoint */
-      if ((dp_type == RCiEP) || (dp_type == iEP_EP))
+      /* Check entry is RCiEP or iEP endpoint in the current alias scope */
+      if ((rule_dp_type & dp_type))
       {
           /* Read FLR capability bit value */
           val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cap_base);

--- a/test_pool/pcie/p069.c
+++ b/test_pool/pcie/p069.c
@@ -34,6 +34,7 @@ payload(void)
   uint32_t pe_index;
   uint32_t tbl_index;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t cap_base;
   uint32_t test_fails;
   bool     test_skip = 1;
@@ -45,6 +46,7 @@ payload(void)
   bdf_tbl_ptr = val_pcie_bdf_table_ptr();
 
   test_fails = 0;
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
 
   /* Check for all the function present in bdf table */
   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
@@ -56,8 +58,8 @@ payload(void)
       if (val_pcie_is_host_bridge(bdf))
         continue;
 
-      /* Check entry is iEP pair or RCiEP based on the rule the test covers */
-      if ((dp_type == RCiEP) || (dp_type == iEP_EP) || (dp_type == iEP_RP))
+      /* Check entry is iEP pair or RCiEP in the current alias scope */
+      if ((rule_dp_type & dp_type))
       {
          val_print(DEBUG, "\n       BDF - 0x%x", bdf);
 

--- a/test_pool/pcie/p070.c
+++ b/test_pool/pcie/p070.c
@@ -34,6 +34,7 @@ payload(void)
   uint32_t pe_index;
   uint32_t tbl_index;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t cap_base;
   uint32_t test_fails;
   bool     test_skip = 1;
@@ -44,14 +45,15 @@ payload(void)
 
   test_fails = 0;
 
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
   /* Check for all the function present in bdf table */
   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
   {
       bdf = bdf_tbl_ptr->device[tbl_index].bdf;
       dp_type = val_pcie_device_port_type(bdf);
 
-      /* Check entry is onchip peripherals */
-      if (dp_type == RCiEP || dp_type == iEP_EP || dp_type == iEP_RP)
+      /* Check entry is on-chip peripheral in the current alias scope */
+      if (rule_dp_type & dp_type)
       {
          val_print(DEBUG, "\n       BDF - 0x%x", bdf);
 

--- a/test_pool/pcie/p080.c
+++ b/test_pool/pcie/p080.c
@@ -34,6 +34,7 @@ payload(void)
   uint32_t pe_index;
   uint32_t tbl_index;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t cap_base;
   bool     test_skip;
   uint32_t warn_cnt;
@@ -47,6 +48,7 @@ payload(void)
   test_fails = 0;
   test_skip = 1;
   warn_cnt = 0;
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
 
   /* Check for all the function present in bdf table */
   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
@@ -58,8 +60,8 @@ payload(void)
       if (val_pcie_is_host_bridge(bdf))
         continue;
 
-      /* Check entry is integrated endpoint or rciep */
-      if ((dp_type == RCiEP) || (dp_type == iEP_EP) || (dp_type == iEP_RP))
+      /* Check entry is integrated endpoint or RCiEP in the current alias scope */
+      if ((rule_dp_type & dp_type))
       {
          val_print(DEBUG, "\n       BDF - 0x%x", bdf);
          /* Check if Address Translation Cache is Present in this device. */

--- a/test_pool/pcie/p083.c
+++ b/test_pool/pcie/p083.c
@@ -37,6 +37,7 @@ payload(void)
   uint32_t base_lower;
   uint32_t base_upper;
   uint32_t dp_type;
+  uint32_t rule_dp_type;
   uint32_t pe_index;
   uint32_t tbl_index;
   uint32_t fail_cnt;
@@ -51,12 +52,13 @@ payload(void)
 
   fail_cnt = 0;
   tbl_index = 0;
+  rule_dp_type = val_pcie_get_ri_device_scope(RI_SCOPE_RCIEP_IEP_PAIR);
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
   {
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
-      if (dp_type == RCiEP || dp_type == iEP_EP || dp_type == iEP_RP)
+      if ((rule_dp_type & dp_type))
       {
           /* If test runs for atleast an endpoint */
           test_skip = 0;

--- a/val/Makefile
+++ b/val/Makefile
@@ -37,8 +37,7 @@ ccflags-y = \
     -DTARGET_LINUX \
     -DSTATIC_ASSERT_CHECKS \
     -Wall \
-    -Werror \
-    -DCOMPILE_RB_EXE
+    -Werror
 
 ccflags-y += \
     -I$(PWD)/$(PAL_COMMON_INC)
@@ -51,6 +50,7 @@ ccflags-y += \
     -I$(PWD)/$(ACS_DIR)/driver/pcie
 
 ifeq ($(ACS), bsa)
+ccflags-y += -DCOMPILE_RB_EXE
 obj-m += bsa_acs_val.o
 bsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_peripherals.o $(VAL_SRC)/acs_dma.o  $(VAL_SRC)/acs_smmu.o \
@@ -68,6 +68,7 @@ bsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/rule_enum_string_map.o
 ccflags-y += -DBSA_LINUX_BUILD
 else ifeq ($(ACS), sbsa)
+ccflags-y += -DCOMPILE_RB_EXE
 obj-m += sbsa_acs_val.o
 sbsa_acs_val-objs += $(VAL_SRC)/acs_status.o      $(VAL_SRC)/acs_memory.o \
     $(VAL_SRC)/acs_peripherals.o  $(VAL_SRC)/acs_smmu.o $(VAL_SRC)/acs_dma.o \

--- a/val/include/acs_pcie.h
+++ b/val/include/acs_pcie.h
@@ -84,6 +84,10 @@
 /* Allows storage of 2048 valid BDFs */
 #define PCIE_DEVICE_BDF_TABLE_SZ 8192
 
+#define RI_SCOPE_RCIEP_IEP_EP   (RCiEP | iEP_EP)
+#define RI_SCOPE_RCIEP_IEP_PAIR (RCiEP | iEP_EP | iEP_RP)
+#define RI_SCOPE_RCIEP_IEP_RCEC (RCiEP | iEP_EP | iEP_RP | RCEC)
+
 typedef enum {
   HEADER = 0,
   PCIE_CAP = 1,
@@ -197,6 +201,7 @@ uint32_t val_is_transaction_pending_set(uint32_t bdf);
 uint32_t val_pcie_multifunction_support(uint32_t bdf);
 uint32_t val_pcie_get_rp_transaction_frwd_support(uint32_t bdf);
 uint32_t val_pcie_is_cache_present(uint32_t bdf);
+uint32_t val_pcie_get_ri_device_scope(uint32_t default_scope);
 uint32_t val_pcie_link_cap_support(uint32_t bdf);
 uint32_t val_pcie_scan_bridge_devices_and_check_memtype(uint32_t bdf);
 uint32_t val_pcie_get_atomicop_requester_capable(uint32_t bdf);

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -22,6 +22,9 @@
 #include "acs_pcie.h"
 #include "acs_memory.h"
 #include "pcie.h"
+#ifdef COMPILE_RB_EXE
+#include "rule_based_execution.h"
+#endif
 
 #define WARN_STR_LEN 7
 
@@ -894,6 +897,32 @@ uint32_t
 val_pcie_is_onchip_peripheral(uint32_t bdf)
 {
   return pal_pcie_is_onchip_peripheral(bdf);
+}
+
+/**
+  @brief  Return the effective RCiEP/iEP device scope for the current RI rule
+
+  Shared RI_* rules are referenced by both B_REP_1 and B_IEP_1. When rule-based
+  execution is active, use the current alias path to avoid reporting an RCiEP
+  failure under B_IEP_1, or an iEP failure under B_REP_1. Non-rule-based and
+  direct RI_* execution preserve the original broad scope.
+
+  @param  default_scope  Device-type mask for standalone execution of this RI rule
+  @return Device-type mask narrowed to the current alias path
+**/
+uint32_t
+val_pcie_get_ri_device_scope(uint32_t default_scope)
+{
+#ifdef COMPILE_RB_EXE
+  if (rule_reference_path_contains(B_REP_1))
+      return (default_scope & RCiEP);
+
+  if (rule_reference_path_contains(B_IEP_1)) {
+      return (default_scope & (iEP_EP | iEP_RP));
+  }
+#endif
+
+  return default_scope;
 }
 
 /**


### PR DESCRIPTION
- Add RI device scope masks for shared RCiEP/iEP rules.
- Derive the effective RI device scope from the current rule reference path.
- Limit shared RI rules under B_REP_1 to RCiEP devices only.
- Limit shared RI rules under B_IEP_1 to iEP devices only.
- Preserve full default device scope when RI rules are run directly.
- Update RI_BAR_1, RI_BAR_3, RI_INT_1, RI_PWR_1, RI_SMU_1, RI_RST_1, RI_ORD_1, and RI_SMU_3 test paths to use cached scope masks.


Change-Id: I813c81898d8f9556808bbe541d67e1ff4f31f7d3