### PR TITLE
val: centralize log indentation handling

### DIFF
--- a/apps/baremetal/acs_runtime_init.c
+++ b/apps/baremetal/acs_runtime_init.c
@@ -73,7 +73,7 @@ acs_clamp_level_for_arch(uint32_t requested_level)
 
   if (requested_level < min_level || requested_level > max_level) {
       val_print(WARN,
-              "ACS Level (EL3 parameter) %d is not supported maxing it to level FR\n",
+              "\nACS Level (EL3 parameter) %d is not supported maxing it to level FR",
               requested_level);
 	  return max_level;
   }
@@ -262,7 +262,7 @@ acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 
   if (!g_el3_param_addr) {
     val_print(WARN,
-              "EL3 param magic set but param address is 0, ignoring\n");
+              "\nEL3 param magic set but param address is 0, ignoring");
     return;
   }
 
@@ -271,14 +271,14 @@ acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
   /* Optional: version check (kept minimal, versioned for future proofing) */
   if ((params->version < 0x1) || (params->version > ACS_EL3_PARAM_VERSION)) {
     val_print(WARN,
-              "Unsupported EL3 param version %ld, ignoring\n", params->version);
+              "\nUnsupported EL3 param version %ld, ignoring", params->version);
     return;
   }
 
-  val_print(DEBUG, "EL3 params: tests=0x%lx", params->rule_array_addr);
+  val_print(DEBUG, "\nEL3 params: tests=0x%lx", params->rule_array_addr);
   val_print(DEBUG, " (%ld),", params->rule_array_count);
   val_print(DEBUG, " modules=0x%lx", params->module_array_addr);
-  val_print(DEBUG, " (%ld)\n", params->module_array_count);
+  val_print(DEBUG, " (%ld)", params->module_array_count);
 
   /* Override tests if provided */
   if (params->rule_array_addr && params->rule_array_count) {
@@ -328,13 +328,13 @@ acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
       ctx->level_filter_mode = params->level_selection;
     else
       val_print(WARN,
-                "Override skipped for level filter mode  %d\n", params->level_selection);
+                "\nOverride skipped for level filter mode  %d", params->level_selection);
 
     if (params->verbose >= TRACE && params->verbose <= FATAL)
       policy->print_level = params->verbose;
     else
       val_print(WARN,
-                "Override skipped for verbose  %d\n", params->verbose);
+                "\nOverride skipped for verbose  %d", params->verbose);
 
     if (params->timeout >= TIMEOUT_THRESHOLD
        && params->timeout <= TIMEOUT_MAX_THRESHOLD)
@@ -346,7 +346,7 @@ acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
     }
     else
       val_print(WARN,
-                "Override skipped for timeout  %d\n", params->timeout);
+                "\nOverride skipped for timeout  %d", params->timeout);
   }
 }
 #else
@@ -364,7 +364,7 @@ acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 
   if (!g_el3_param_addr) {
     val_print(WARN,
-              "EL3 param magic set but param address is 0, ignoring\n");
+              "\nEL3 param magic set but param address is 0, ignoring");
     return;
   }
 
@@ -372,7 +372,7 @@ acs_apply_el3_params(acs_run_request_t *ctx, acs_execution_policy_t *policy)
 
   if ((params->version < 0x1) || (params->version > ACS_EL3_PARAM_VERSION)) {
     val_print(WARN,
-              "Unsupported EL3 param version %ld, ignoring\n", params->version);
+              "\nUnsupported EL3 param version %ld, ignoring", params->version);
     return;
   }
 

--- a/apps/baremetal/bsa_main.c
+++ b/apps/baremetal/bsa_main.c
@@ -146,10 +146,10 @@ ShellAppMainbsa()
     acs_apply_el3_params(ctx, policy);
 
     val_print(INFO, "\n\n BSA Architecture Compliance Suite\n");
-    val_print(INFO, "\n          Version %d.", BSA_ACS_MAJOR_VER);
+    val_print(INFO, "\n        Version %d.", BSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", BSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", BSA_ACS_SUBMINOR_VER);
-    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
+    val_print(INFO, "\nBuilt for target: %s", ACS_TARGET);
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 BSA_LEVEL_FR), ctx->level_value);
@@ -157,7 +157,7 @@ ShellAppMainbsa()
     val_print(INFO, "(Print level is %2d)\n\n", policy->print_level);
 
 #if ACS_ENABLE_MMU
-    val_print(INFO, " Enabling MMU\n");
+    val_print(INFO, "\nEnabling MMU");
 
     /* Create MMU page tables before enabling the MMU at EL2 */
     if (val_setup_mmu()) {
@@ -171,10 +171,10 @@ ShellAppMainbsa()
         return ACS_STATUS_FAIL;
     }
 #else
-    val_print(INFO, "Skipping MMU setup/enable (ACS_ENABLE_MMU=0)\n");
+    val_print(INFO, "\nSkipping MMU setup/enable (ACS_ENABLE_MMU=0)");
 #endif
 
-    val_print(INFO, " Creating Platform Information Tables\n");
+    val_print(INFO, "\nCreating Platform Information Tables");
 
     Status = createPeInfoTable();
     if (Status) {

--- a/apps/baremetal/mpam_main.c
+++ b/apps/baremetal/mpam_main.c
@@ -124,11 +124,11 @@ ShellAppMainmpam(void)
     val_print(INFO, "    Version %d.", MPAM_ACS_MAJOR_VER);
     val_print(INFO, "%d.", MPAM_ACS_MINOR_VER);
     val_print(INFO, "%d\n", MPAM_ACS_SUBMINOR_VER);
-    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
+    val_print(INFO, "\nBuilt for target: %s", ACS_TARGET);
     val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());
 
 #if ACS_ENABLE_MMU
-    val_print(INFO, " Enabling MMU\n");
+    val_print(INFO, "\nEnabling MMU");
 
     if (val_setup_mmu()) {
         status = ACS_STATUS_FAIL;
@@ -140,7 +140,7 @@ ShellAppMainmpam(void)
         goto exit_acs;
     }
 #else
-    val_print(INFO, "Skipping MMU setup/enable (ACS_ENABLE_MMU=0)\n");
+    val_print(INFO, "\nSkipping MMU setup/enable (ACS_ENABLE_MMU=0)");
 #endif
 
     if (!acs_is_module_enabled(ACS_MPAM_REGISTER_TEST_NUM_BASE) &&
@@ -152,7 +152,7 @@ ShellAppMainmpam(void)
         goto print_test_status;
     }
 
-    val_print(INFO, " Creating Platform Information Tables\n");
+    val_print(INFO, "\nCreating Platform Information Tables");
 
     status = createPeInfoTable();
     if (status)

--- a/apps/baremetal/pc_bsa_main.c
+++ b/apps/baremetal/pc_bsa_main.c
@@ -155,7 +155,7 @@ ShellAppMainpcbsa(void)
     acs_apply_el3_params(ctx, policy);
 
 #if ACS_ENABLE_MMU
-    val_print(INFO, " Enabling MMU\n");
+    val_print(INFO, "\nEnabling MMU");
 
     /* Create MMU page tables before enabling the MMU at EL2 */
     if (val_setup_mmu()) {
@@ -169,21 +169,21 @@ ShellAppMainpcbsa(void)
         return ACS_STATUS_FAIL;
     }
 #else
-    val_print(INFO, "Skipping MMU setup/enable (ACS_ENABLE_MMU=0)\n");
+    val_print(INFO, "\nSkipping MMU setup/enable (ACS_ENABLE_MMU=0)");
 #endif
 
     val_print(INFO, "\n\n PC BSA Architecture Compliance Suite\n");
-    val_print(INFO, "\n          Version %d.", PC_BSA_ACS_MAJOR_VER);
+    val_print(INFO, "\n        Version %d.", PC_BSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", PC_BSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", PC_BSA_ACS_SUBMINOR_VER);
-    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
+    val_print(INFO, "\nBuilt for target: %s", ACS_TARGET);
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
                 PCBSA_LEVEL_FR), ctx->level_value);
 
     val_print(INFO, "(Print level is %2d)\n\n", policy->print_level);
 
-    val_print(INFO, " Creating Platform Information Tables\n");
+    val_print(INFO, "\nCreating Platform Information Tables");
 
     Status = createPeInfoTable();
     if (Status) {

--- a/apps/baremetal/sbsa_main.c
+++ b/apps/baremetal/sbsa_main.c
@@ -190,7 +190,7 @@ ShellAppMainsbsa()
       return ACS_STATUS_FAIL;
   }
 #else
-  val_print(INFO, "Skipping MMU setup/enable (ACS_ENABLE_MMU=0)\n");
+  val_print(INFO, "\nSkipping MMU setup/enable (ACS_ENABLE_MMU=0)");
 #endif
     /* Apply any compile-time test/module overrides before we consume the run request. */
     acs_apply_compile_params(ctx, policy);
@@ -201,7 +201,7 @@ ShellAppMainsbsa()
     val_print(INFO, "    Version %d.", SBSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", SBSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", SBSA_ACS_SUBMINOR_VER);
-    val_print(INFO, " Built for target: %s\n", ACS_TARGET);
+    val_print(INFO, "\nBuilt for target: %s", ACS_TARGET);
 
 
     val_print(INFO, LEVEL_PRINT_FORMAT(ctx->level_value, ctx->level_filter_mode,
@@ -209,7 +209,7 @@ ShellAppMainsbsa()
 
     val_print(INFO, "(Print level is %2d)\n\n", policy->print_level);
 
-    val_print(INFO, " Creating Platform Information Tables\n");
+    val_print(INFO, "\nCreating Platform Information Tables");
 
     Status = createPeInfoTable();
     if (Status) {

--- a/apps/uefi/bsa_main.c
+++ b/apps/uefi/bsa_main.c
@@ -163,7 +163,7 @@ execute_tests()
     }
 
     val_print(INFO, "\n\n BSA Architecture Compliance Suite");
-    val_print(INFO, "\n          Version %d.", BSA_ACS_MAJOR_VER);
+    val_print(INFO, "\n        Version %d.", BSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", BSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", BSA_ACS_SUBMINOR_VER);
 

--- a/apps/uefi/drtm_main.c
+++ b/apps/uefi/drtm_main.c
@@ -305,7 +305,7 @@ execute_tests()
   UINT32             Status;
 
   val_print(INFO, "\n\n DRTM Architecture Compliance Suite");
-  val_print(INFO, "\n          Version %d.", DRTM_ACS_MAJOR_VER);
+  val_print(INFO, "\n        Version %d.", DRTM_ACS_MAJOR_VER);
   val_print(INFO, "%d\n", DRTM_ACS_MINOR_VER);
 
   val_print(INFO, "\n Starting tests with print level : %2d\n\n", acs_policy_get_print_level());

--- a/apps/uefi/mem_test_main.c
+++ b/apps/uefi/mem_test_main.c
@@ -577,8 +577,8 @@ command_init ()
 }
 
 #define BSA_LEVEL_PRINT_FORMAT(level, only) ((level > BSA_MAX_LEVEL_SUPPORTED) ? \
-    ((only) != 0 ? "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
-    ((only) != 0 ? "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
+    ((only) != 0 ? "\nStarting tests for only level FR " : "\nStarting tests for level FR ") : \
+    ((only) != 0 ? "\nStarting tests for only level %2d " : "\nStarting tests for level %2d "))
 
 VOID FlushImage (VOID)
 {
@@ -709,7 +709,7 @@ execute_tests()
   UINT32             Status;
 
   val_print(INFO, "\n\n BSA Architecture Compliance Suite");
-  val_print(INFO, "\n          Version %d.", BSA_ACS_MAJOR_VER);
+  val_print(INFO, "\n        Version %d.", BSA_ACS_MAJOR_VER);
   val_print(INFO, "%d.", BSA_ACS_MINOR_VER);
   val_print(INFO, "%d\n", BSA_ACS_SUBMINOR_VER);
 

--- a/apps/uefi/mpam_main.c
+++ b/apps/uefi/mpam_main.c
@@ -394,13 +394,13 @@ execute_tests()
     branch_label = &&print_test_status;
     val_pe_context_save(AA64ReadSp(), (uint64_t)branch_label);
 
-    Print(L"\n\n MPAM System Architecture Compliance Suite \n");
+    Print(L"\n\nMPAM System Architecture Compliance Suite \n");
     Print(L"    Version %d.%d.", MPAM_ACS_MAJOR_VER, MPAM_ACS_MINOR_VER);
     Print(L"%d  \n", MPAM_ACS_SUBMINOR_VER);
 
-    Print(L"\n Starting tests for Print level %2d\n\n", acs_policy_get_print_level());
+    Print(L"\nStarting tests for Print level %2d\n", acs_policy_get_print_level());
 
-    Print(L" Creating Platform Information Tables \n");
+    Print(L"\nCreating Platform Information Tables");
     Status = createPeInfoTable();
     if (Status)
         return Status;

--- a/apps/uefi/pc_bsa_main.c
+++ b/apps/uefi/pc_bsa_main.c
@@ -147,7 +147,7 @@ execute_tests()
     }
 
     val_print(INFO, "\n\n PC BSA Architecture Compliance Suite");
-    val_print(INFO, "\n          Version %d.", PC_BSA_ACS_MAJOR_VER);
+    val_print(INFO, "\n        Version %d.", PC_BSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", PC_BSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", PC_BSA_ACS_SUBMINOR_VER);
 

--- a/apps/uefi/pfdi_main.c
+++ b/apps/uefi/pfdi_main.c
@@ -104,7 +104,7 @@ execute_tests()
   }
 
   val_print(INFO, "\n\n PFDI Architecture Compliance Suite");
-  val_print(INFO, "\n          Version %d.", PFDI_ACS_MAJOR_VER);
+  val_print(INFO, "\n        Version %d.", PFDI_ACS_MAJOR_VER);
   val_print(INFO, "%d.", PFDI_ACS_MINOR_VER);
   val_print(INFO, "%d\n", PFDI_ACS_SUBMINOR_VER);
 

--- a/apps/uefi/sbsa_nist_main.c
+++ b/apps/uefi/sbsa_nist_main.c
@@ -50,8 +50,8 @@ SHELL_FILE_HANDLE g_acs_log_file_handle;
 UINT32  g_build_sbsa = TRUE;
 
 #define SBSA_LEVEL_PRINT_FORMAT(level, only) ((level > SBSA_MAX_LEVEL_SUPPORTED) ? \
-    ((only) != 0 ? "\n Starting tests for only level FR " : "\n Starting tests for level FR ") : \
-    ((only) != 0 ? "\n Starting tests for only level %2d " : "\n Starting tests for level %2d "))
+    ((only) != 0 ? "\nStarting tests for only level FR " : "\nStarting tests for level FR ") : \
+    ((only) != 0 ? "\nStarting tests for only level %2d " : "\nStarting tests for level %2d "))
 
 VOID FlushImage (VOID)
 {

--- a/apps/uefi/vbsa_main.c
+++ b/apps/uefi/vbsa_main.c
@@ -150,7 +150,7 @@ execute_tests()
     }
 
     val_print(INFO, "\n\n VBSA Architecture Compliance Suite");
-    val_print(INFO, "\n          Version %d.", VBSA_ACS_MAJOR_VER);
+    val_print(INFO, "\n        Version %d.", VBSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", VBSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", VBSA_ACS_SUBMINOR_VER);
 

--- a/apps/uefi/xbsa_main.c
+++ b/apps/uefi/xbsa_main.c
@@ -200,7 +200,7 @@ execute_tests()
 
     /* Print ACS header */
     val_print(INFO, "\n\nxBSA Architecture Compliance Suite");
-    val_print(INFO, "\n          Version %d.", XBSA_ACS_MAJOR_VER);
+    val_print(INFO, "\n        Version %d.", XBSA_ACS_MAJOR_VER);
     val_print(INFO, "%d.", XBSA_ACS_MINOR_VER);
     val_print(INFO, "%d\n", XBSA_ACS_SUBMINOR_VER);
     val_print(INFO, "(Print level is %2d)\n\n", acs_policy_get_print_level());

--- a/pal/baremetal/base/src/pal_cxl.c
+++ b/pal/baremetal/base/src/pal_cxl.c
@@ -31,7 +31,7 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
 
   if (CxlTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "Input CXL Table Pointer is NULL. Cannot create CXL INFO Table\n");
+                  "\n       Input CXL Table Pointer is NULL. Cannot create CXL INFO Table");
     return;
   }
 
@@ -39,7 +39,7 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
 
   if (platform_cxl_cfg.num_entries == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "Number of HB is 0. Cannot create CXL INFO\n");
+                  "\n       Number of HB is 0. Cannot create CXL INFO");
     return;
   }
 
@@ -58,7 +58,7 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
     if (window_count > max_windows) {
       window_count = max_windows;
       pal_print_msg(ACS_PRINT_WARN,
-                    "CFMWS count exceeds per-host capacity. Truncating\n");
+                    "\n       CFMWS count exceeds per-host capacity. Truncating");
     }
     CxlTable->device[i].cfmws_count = window_count;
 
@@ -88,7 +88,7 @@ pal_cxl_get_host_bridge_uid(uint32_t bdf, uint32_t *uid)
     *uid = 0;
   else
     pal_print_msg(ACS_PRINT_ERR,
-                  " %s UID pointer NULL ",
+                  "\n       %s UID pointer NULL",
                   __func__);
   return 1;
 }

--- a/pal/baremetal/base/src/pal_hmat.c
+++ b/pal/baremetal/base/src/pal_hmat.c
@@ -39,7 +39,7 @@ void pal_hmat_dump_info_table(HMAT_INFO_TABLE *HmatTable)
 
   curr_entry = HmatTable->bw_info;
   pal_print_msg(ACS_PRINT_INFO,
-                "\n*** HMAT info table entries ***\n");
+                "\n       *** HMAT info table entries ***");
   for (i = 0 ; i < HmatTable->num_of_mem_prox_domain ; i++) {
       pal_print_msg(ACS_PRINT_INFO,
                     "\nMemory Proximity domain  :   0x%llx",
@@ -48,7 +48,7 @@ void pal_hmat_dump_info_table(HMAT_INFO_TABLE *HmatTable)
                     "\n  Write bandwidth        :   0x%llx",
                     curr_entry->write_bw);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  Read  bandwidth        :   0x%llx\n",
+                    "\n       Read  bandwidth        :   0x%llx",
                     curr_entry->read_bw);
       curr_entry++;
   }
@@ -72,7 +72,7 @@ void pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
 
   if (HmatTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Unable to create HMAT info table, input pointer is NULL\n");
+                    "\n       Unable to create HMAT info table, input pointer is NULL");
       return;
   }
 

--- a/pal/baremetal/base/src/pal_iovirt.c
+++ b/pal/baremetal/base/src/pal_iovirt.c
@@ -92,7 +92,7 @@ pal_iovirt_get_rc_smmu_base (
    * is not behind any SMMU. Return NULL pointer
    */
   pal_print_msg(ACS_PRINT_DEBUG,
-                " No SMMU found behind the RootComplex with segment :%x",
+                "\n       No SMMU found behind the RootComplex with segment :%x",
                 RcSegmentNum);
   return 0;
 }
@@ -128,54 +128,52 @@ dump_block(IOVIRT_BLOCK *block) {
   switch(block->type) {
       case IOVIRT_NODE_ITS_GROUP:
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n ITS Group: Num ITS:%d\n",
+                    "\n       ITS Group: Num ITS:%d",
                     (*map).id[0]);
       for(i = 0; i < block->data.its_count; i++)
           pal_print_msg(ACS_PRINT_INFO,
-                        "  ITS ID : %d\n",
+                        "\n       ITS ID : %d",
                         (*map).id[i]);
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
       pal_print_msg(ACS_PRINT_INFO,
-                    " Named Component:\n Device Name:%s",
+                    "\n       Named Component:\n   Device Name:%s",
                     block->data.named_comp.name);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n CCA Attribute: 0x%lx\n",
+                    "\n       CCA Attribute: 0x%lx",
                     block->data.named_comp.cca);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
       pal_print_msg(ACS_PRINT_INFO,
-                    " Root Complex: PCI segment number:%d\n",
+                    "\n       Root Complex: PCI segment number:%d",
                     block->data.rc.segment);
       break;
       case IOVIRT_NODE_SMMU:
       case IOVIRT_NODE_SMMU_V3:
       pal_print_msg(ACS_PRINT_INFO,
-                    " SMMU: Major Rev:%d Base Address:0x%llx\n",
+                    "\n       SMMU: Major Rev:%d Base Address:0x%llx",
                     block->data.smmu.arch_major_rev,
                     block->data.smmu.base);
       break;
       case IOVIRT_NODE_PMCG:
       pal_print_msg(ACS_PRINT_INFO,
-                    " PMCG: Base:0x%x\n Overflow GSIV:0x%x Node Reference:0x%x\n",
+                    "\n       PMCG: Base:0x%x\n   Overflow GSIV:0x%x Node Reference:0x%x",
                     block->data.pmcg.base,
                     block->data.pmcg.overflow_gsiv,
                     block->data.pmcg.node_ref);
       break;
   }
   pal_print_msg(ACS_PRINT_INFO,
-                " Number of ID Mappings:%d\n",
+                "\n       Number of ID Mappings:%d",
                 block->num_data_map);
   for(i = 0; i < block->num_data_map; i++, map++) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "  input_base:0x%x id_count:0x%x\n  output_base:0x%x output ref:0x%x\n",
+                    "\n       input_base:0x%x id_count:0x%x\n   output_base:0x%x output ref:0x%x",
                     (*map).map.input_base,
                     (*map).map.id_count,
                     (*map).map.output_base,
                     (*map).map.output_ref);
   }
-  pal_print_msg(ACS_PRINT_INFO,
-                "\n");
 }
 
 void
@@ -268,7 +266,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
              break;
           default:
              pal_print_msg(ACS_PRINT_ERR,
-                           "Invalid IORT node type\n");
+                           "\n       Invalid IORT node type");
              return;
      }
      node[i] = (uint8_t*)(block) - (uint8_t*)IoVirtTable;
@@ -309,7 +307,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
 
   block = &(IoVirtTable->blocks[0]);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " Number of IOVIRT blocks = %d\n",
+                "\n       Number of IOVIRT blocks = %d",
                 IoVirtTable->num_blocks);
 
   if (acs_policy_get_print_level() <= ACS_PRINT_INFO) {

--- a/pal/baremetal/base/src/pal_misc.c
+++ b/pal/baremetal/base/src/pal_misc.c
@@ -421,7 +421,7 @@ pal_mmio_read8(uint64_t addr)
   data = (*(volatile uint8_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %llx  Data = %lx\n",
+                    "\n       %s Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -445,7 +445,7 @@ pal_mmio_read16(uint64_t addr)
   data = (*(volatile uint16_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %llx  Data = %lx\n",
+                    "\n       %s Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -469,7 +469,7 @@ pal_mmio_read64(uint64_t addr)
   data = (*(volatile uint64_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %llx  Data = %llx\n",
+                    "\n       %s Address = %llx  Data = %llx",
                     __func__,
                     addr,
                     data);
@@ -494,7 +494,7 @@ pal_mmio_read(uint64_t addr)
   data = (*(volatile uint32_t *)addr);
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %8x  Data = %x\n",
+                    "\n       %s Address = %8x  Data = %x",
                     __func__,
                     addr,
                     data);
@@ -517,7 +517,7 @@ pal_mmio_write8(uint64_t addr, uint8_t data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %llx  Data = %lx\n",
+                    "\n       %s Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -539,7 +539,7 @@ pal_mmio_write16(uint64_t addr, uint16_t data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %llx  Data = %lx\n",
+                    "\n       %s Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -561,7 +561,7 @@ pal_mmio_write64(uint64_t addr, uint64_t data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %llx  Data = %llx\n",
+                    "\n       %s Address = %llx  Data = %llx",
                     __func__,
                     addr,
                     data);
@@ -584,7 +584,7 @@ pal_mmio_write(uint64_t addr, uint32_t data)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %s Address = %8x  Data = %x\n",
+                    "\n       %s Address = %8x  Data = %x",
                     __func__,
                     addr,
                     data);
@@ -1103,7 +1103,7 @@ loop:
 }
 
 static const char *prefix_str[] = {
-        "", "", "", "", ""};
+        "   ", "   ", "", "   WARN : ", "   ERROR: "};
 
 const char *log_get_prefix(int log_level)
 {
@@ -1124,18 +1124,43 @@ void pal_uart_print(int log, const char *fmt, ...)
 {
         va_list args;
         const char *prefix_str;
+        uint32_t i;
+        uint32_t new_log_record;
 
-        prefix_str = log_get_prefix(log);
+        if (fmt == NULL) {
+                return;
+        }
 
-        while (*prefix_str != '\0') {
-                pal_uart_putc(*prefix_str);
-                prefix_str++;
+        new_log_record = (*fmt == '\n');
+
+        while (*fmt == '\n') {
+                pal_uart_putc('\n');
+                pal_uart_putc('\r');
+                fmt++;
+        }
+
+        if (new_log_record) {
+                for (i = 0; i < 7 && *fmt == ' '; i++) {
+                        fmt++;
+                }
+
+                for (i = 0; i < acs_policy_get_log_indent(); i++) {
+                        pal_uart_putc(' ');
+                        pal_uart_putc(' ');
+                        pal_uart_putc(' ');
+                        pal_uart_putc(' ');
+                }
+
+                prefix_str = log_get_prefix(log);
+                while (*prefix_str != '\0') {
+                        pal_uart_putc(*prefix_str);
+                        prefix_str++;
+                }
         }
 
         va_start(args, fmt);
         (void)vprintf(fmt, args);
         va_end(args);
-        (void) log;
 }
 
 /**
@@ -1149,7 +1174,7 @@ void
 pal_dump_dtb()
 {
   pal_print_msg(ACS_PRINT_ERR,
-                " DTB dump not available for platform initialized with ACPI table\n",
+                "\n       DTB dump not available for platform initialized with ACPI table",
                 0);
 }
 

--- a/pal/baremetal/base/src/pal_mpam.c
+++ b/pal/baremetal/base/src/pal_mpam.c
@@ -134,7 +134,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
 
   if (MpamTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Input MPAM Table Pointer is NULL\n");
+                    "\n       Input MPAM Table Pointer is NULL");
       return;
   }
 
@@ -200,7 +200,7 @@ pal_mpam_parse_dsdt_info(MPAM_INFO_TABLE *MpamTable)
 {
   if (MpamTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Input MPAM Table Pointer is NULL\n");
+                    "\n       Input MPAM Table Pointer is NULL");
       return 0;
   }
   return 0;
@@ -221,7 +221,7 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
 
   if (SratTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Input SRAT Table Pointer is NULL\n");
+                    "\n       Input SRAT Table Pointer is NULL");
       return;
   }
 

--- a/pal/baremetal/base/src/pal_pcc.c
+++ b/pal/baremetal/base/src/pal_pcc.c
@@ -36,7 +36,7 @@ pal_pcc_dump_info_table(PCC_INFO_TABLE *PccInfoTable)
 
   if (PccInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\nUnable to dump PCC info table, input pointer is NULL\n");
+                    "\n       Unable to dump PCC info table, input pointer is NULL");
       return;
   }
 
@@ -106,7 +106,7 @@ pal_pcc_create_info_table(PCC_INFO_TABLE *PccInfoTable)
 
   if (PccInfoTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Unable to create PCC info table, input pointer is NULL\n");
+                  "\n       Unable to create PCC info table, input pointer is NULL");
     return;
   }
 

--- a/pal/baremetal/base/src/pal_pcie.c
+++ b/pal/baremetal/base/src/pal_pcie.c
@@ -42,7 +42,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
 
   if (PcieTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
+                  "\n       Input PCIe Table Pointer is NULL. Cannot create PCIe INFO");
     return;
   }
 
@@ -50,7 +50,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
 
   if(platform_pcie_cfg.num_entries == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "Number of ECAM is 0. Cannot create PCIe INFO\n");
+                  "\n       Number of ECAM is 0. Cannot create PCIe INFO");
     return;
   }
 
@@ -169,7 +169,7 @@ pal_pcie_io_read_cfg(uint32_t Bdf, uint32_t offset, uint32_t *data)
   }
 
   pal_print_msg(ACS_PRINT_ERR,
-                "No PCI devices found in the system\n");
+                "\n       No PCI devices found in the system");
   return PCIE_NO_MAPPING;
 }
 
@@ -504,7 +504,7 @@ pal_pcie_get_legacy_irq_map(uint32_t Seg, uint32_t Bus, uint32_t Dev, uint32_t F
   }
 
   pal_print_msg(ACS_PRINT_ERR,
-                "No PCI devices found in the system\n");
+                "\n       No PCI devices found in the system");
   return PCIE_NO_MAPPING;
 }
 
@@ -601,9 +601,9 @@ uint32_t pal_pcie_check_device_list(void)
 
     if (platform_pcie_device_hierarchy.num_entries != bdf_tbl_ptr->num_entries) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Number of PCIe devices entries in ");
+                    "\n       Number of PCIe devices entries in ");
       pal_print_msg(ACS_PRINT_ERR,
-                    "info table not equal to platform hierarchy\n",
+                    "info table not equal to platform hierarchy",
                     0);
       return 1;
     }
@@ -634,14 +634,14 @@ uint32_t pal_pcie_check_device_list(void)
              vendor_id = data & 0xFFFF;
              if (vendor_id != pltf_vendor_id) {
                 pal_print_msg(ACS_PRINT_ERR,
-                              " VendorID mismatch for PCIe device with bdf = 0x%x\n",
+                              "\n       VendorID mismatch for PCIe device with bdf = 0x%x",
                               bdf);
                 return 1;
              }
              device_id = data >> DEVICE_ID_OFFSET;
              if (device_id != pltf_device_id) {
                 pal_print_msg(ACS_PRINT_ERR,
-                              " DeviceID mismatch for PCIe device with bdf = 0x%x\n",
+                              "\n       DeviceID mismatch for PCIe device with bdf = 0x%x",
                               bdf);
                 return 1;
              }
@@ -649,7 +649,7 @@ uint32_t pal_pcie_check_device_list(void)
              class_code = class_code >> CC_SHIFT;
              if (class_code != pltf_class_code) {
                 pal_print_msg(ACS_PRINT_ERR,
-                              "ClassCode mismatch for PCIe device with bdf = 0x%x\n",
+                              "\n       ClassCode mismatch for PCIe device with bdf = 0x%x",
                               bdf);
                 return 1;
              }
@@ -663,7 +663,7 @@ uint32_t pal_pcie_check_device_list(void)
       /* If any bdf match not found in platform device hierarchy and info table, return false */
       if (i == bdf_tbl_ptr->num_entries) {
           pal_print_msg(ACS_PRINT_ERR,
-                        " Bdf not found in info table = 0x%x\n",
+                        "\n       Bdf not found in info table = 0x%x",
                         pltf_pcie_device_bdf);
           return 1;
       }

--- a/pal/baremetal/base/src/pal_pcie_enumeration.c
+++ b/pal/baremetal/base/src/pal_pcie_enumeration.c
@@ -180,7 +180,7 @@ pal_pcie_rp_program_bar(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t func)
       if (BAR_REG(bar_reg_value) == BAR_64_BIT)
       {
           pal_print_msg(ACS_PRINT_INFO,
-                        "The RP BAR supports P_MEM 64-bit addr decoding capability\n",
+                        "\n       The RP BAR supports P_MEM 64-bit addr decoding capability",
                         0);
 
           /** BAR supports 64-bit address therefore, write all 1's
@@ -212,7 +212,7 @@ pal_pcie_rp_program_bar(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t func)
       else
       {
           pal_print_msg(ACS_PRINT_INFO,
-                        "The RP BAR supports P_MEM 32-bit addr decoding capability\n",
+                        "\n       The RP BAR supports P_MEM 32-bit addr decoding capability",
                         0);
 
           /**BAR supports 32-bit address. Write all 1's
@@ -231,7 +231,7 @@ pal_pcie_rp_program_bar(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t func)
           }
           pal_pci_cfg_write(seg, bus, dev, func, offset, g_rp_bar32_value);
           pal_print_msg(ACS_PRINT_INFO,
-                        "Value written to BAR register is %x\n",
+                        "\n       Value written to BAR register is %x",
                         g_rp_bar32_value);
           g_rp_bar32_value = g_rp_bar32_value + bar_size;
           offset = offset + 4;
@@ -265,7 +265,7 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
         if (BAR_REG(bar_reg_value) == BAR_64_BIT)
         {
             pal_print_msg(ACS_PRINT_INFO,
-                          "The BAR supports P_MEM 64-bit addr decoding capability\n",
+                          "\n       The BAR supports P_MEM 64-bit addr decoding capability",
                           0);
 
             /** BAR supports 64-bit address therefore, write all 1's
@@ -311,7 +311,7 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
             pal_pci_cfg_write(seg, bus, dev, func, offset + 4, g_bar64_p_start >> 32);
 
             pal_print_msg(ACS_PRINT_INFO,
-                          "Value written to BAR register is %llx\n",
+                          "\n       Value written to BAR register is %llx",
                           g_bar64_p_start);
             p_bar64_size = bar_size;
             g_bar64_size = bar_size;
@@ -323,7 +323,7 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
         else
         {
             pal_print_msg(ACS_PRINT_INFO,
-                          "The BAR supports P_MEM 32-bit addr decoding capability\n",
+                          "\n       The BAR supports P_MEM 32-bit addr decoding capability",
                           0);
 
             /**BAR supports 32-bit address. Write all 1's
@@ -362,7 +362,7 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
 
             pal_pci_cfg_write(seg, bus, dev, func, offset, g_bar32_p_start);
             pal_print_msg(ACS_PRINT_INFO,
-                          "Value written to BAR register is %x\n",
+                          "\n       Value written to BAR register is %x",
                           g_bar32_p_start);
             p_bar_size = bar_size;
             g_p_bar_size = bar_size;
@@ -375,7 +375,7 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
     else
     {
          pal_print_msg(ACS_PRINT_INFO,
-                       "The BAR supports NP_MEM 32-bit addr decoding capability\n",
+                       "\n       The BAR supports NP_MEM 32-bit addr decoding capability",
                        0);
 
          /**BAR supports 32-bit address. Write all 1's
@@ -416,7 +416,7 @@ void pal_pcie_program_bar_reg(uint32_t seg, uint32_t bus, uint32_t dev, uint32_t
 
          pal_pci_cfg_write(seg, bus, dev, func, offset, g_bar32_np_start);
          pal_print_msg(ACS_PRINT_INFO,
-                       "Value written to BAR register is %x\n",
+                       "\n       Value written to BAR register is %x",
                        g_bar32_np_start);
          np_bar_size = bar_size;
          g_np_bar_size = bar_size;
@@ -480,10 +480,10 @@ uint32_t pal_pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
                 continue;
 
         pal_print_msg(ACS_PRINT_INFO,
-                      "The Vendor id read is %x\n",
+                      "\n       The Vendor id read is %x",
                       vendor_id);
         pal_print_msg(ACS_PRINT_INFO,
-                      "Valid PCIe device found at %x %x %x\n ",
+                      "\n       Valid PCIe device found at %x %x %x",
                       bus,
                       dev,
                       func);
@@ -491,7 +491,7 @@ uint32_t pal_pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
         if (PCIE_HEADER_TYPE(header_value) == TYPE1_HEADER)
         {
             pal_print_msg(ACS_PRINT_INFO,
-                          "TYPE1 HEADER found\n",
+                          "\n       TYPE1 HEADER found",
                           0);
 
             /* Enable memory access, Bus master enable and I/O access*/
@@ -534,7 +534,7 @@ uint32_t pal_pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
         if (PCIE_HEADER_TYPE(header_value) == TYPE0_HEADER)
         {
             pal_print_msg(ACS_PRINT_INFO,
-                          "END POINT found\n",
+                          "\n       END POINT found",
                           0);
             pal_pcie_program_bar_reg(seg, bus, dev, func);
             sub_bus = sec_bus - 1;
@@ -612,7 +612,7 @@ void pal_pcie_enumerate(void)
     }
 
     pal_print_msg(ACS_PRINT_INFO,
-                  "\nStarting Enumeration\n",
+                  "\n       Starting Enumeration",
                   0);
     while (pcie_index < g_pcie_info_table->num_entries)
     {
@@ -743,7 +743,7 @@ pal_pcie_get_base(uint32_t bdf, uint32_t bar_index)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "value read from BAR 0x%llx\n",
+                "\n       value read from BAR 0x%llx",
                 bar_value);
 
   return bar_value;

--- a/pal/baremetal/base/src/pal_pe.c
+++ b/pal/baremetal/base/src/pal_pe.c
@@ -100,7 +100,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
   SmbiosTable->slot_count = platform_smbios_cfg.slot_count;
   if (SmbiosTable->slot_count == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "SMBIOS Table Not Found\n",
+                  "\n       SMBIOS Table Not Found",
                   0);
     return;
   }
@@ -140,7 +140,7 @@ PalAllocateSecondaryStack(uint64_t mpidr)
       gSecondaryPeStack = pal_aligned_alloc(MEM_ALIGN_4K, NumPe * SIZE_STACK_SECONDARY_PE);
       if (gSecondaryPeStack == NULL){
           pal_print_msg(ACS_PRINT_ERR,
-                        "FATAL - Allocation for Secondary stack failed\n",
+                        "\n       FATAL - Allocation for Secondary stack failed",
                         0);
       }
       pal_pe_data_cache_ops_by_va((uint64_t)&gSecondaryPeStack, CLEAN_AND_INVALIDATE);
@@ -182,22 +182,22 @@ PalCaptureMmuConfig(void)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "  MMU Config captured at EL%d\n",
+                "\n       MMU Config captured at EL%d",
                 gMmuConfig.current_el);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TTBR0: 0x%lx\n",
+                "\n       TTBR0: 0x%lx",
                 gMmuConfig.ttbr0);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TTBR1: 0x%lx\n",
+                "\n       TTBR1: 0x%lx",
                 gMmuConfig.ttbr1);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TCR:   0x%lx\n",
+                "\n       TCR:   0x%lx",
                 gMmuConfig.tcr);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    MAIR:  0x%lx\n",
+                "\n       MAIR:  0x%lx",
                 gMmuConfig.mair);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    SCTLR: 0x%lx\n",
+                "\n       SCTLR: 0x%lx",
                 gMmuConfig.sctlr);
 
   /* Clean cache to ensure secondary PEs see the config */

--- a/pal/baremetal/base/src/pal_peripherals.c
+++ b/pal/baremetal/base/src/pal_peripherals.c
@@ -56,7 +56,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
 
   if (peripheralInfoTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
+                  "\n       Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO");
     return;
   }
 
@@ -76,7 +76,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   do {
 
        pal_print_msg(ACS_PRINT_INFO,
-                     "Entered USB loop\n");
+                     "\n       Entered USB loop");
        DeviceBdf = pal_pcie_get_bdf(USB_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_USB;
@@ -90,7 +90,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->platform_type = 0;
 
           pal_print_msg(ACS_PRINT_INFO,
-                        "Found a USB controller %4x\n",
+                        "\n       Found a USB controller %4x",
                         per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
@@ -106,7 +106,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   do {
 
        pal_print_msg(ACS_PRINT_INFO,
-                     "Entered SATA loop\n");
+                     "\n       Entered SATA loop");
        DeviceBdf = pal_pcie_get_bdf(SATA_CLASSCODE, StartBdf);
        if (DeviceBdf != 0) {
           per_info->type  = PERIPHERAL_TYPE_SATA;
@@ -121,7 +121,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->bdf   = DeviceBdf;
 
           pal_print_msg(ACS_PRINT_INFO,
-                        "Found a SATA controller %4x\n",
+                        "\n       Found a SATA controller %4x",
                         per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
@@ -191,7 +191,7 @@ uint32_t pal_peripheral_is_pcie(uint32_t seg, uint32_t bus, uint32_t dev, uint32
      if ((reg_value & PCIE_CIDR_MASK) == CID_PCIECS)
      {
          pal_print_msg(ACS_PRINT_INFO,
-                       "PCIe Capable",
+                       "\n       PCIe Capable",
                        0);
          return 1;
      }
@@ -258,7 +258,7 @@ pal_memory_get_unpopulated_addr(uint64_t *addr, uint32_t instance)
           {
               *addr =  platform_mem_cfg.info[index].virt_addr;
               pal_print_msg(ACS_PRINT_INFO,
-                            "Unpopulated region with base address 0x%lX found\n",
+                            "\n       Unpopulated region with base address 0x%lX found",
                             *addr);
               return MEM_MAP_SUCCESS;
           }

--- a/pal/baremetal/base/src/pal_pptt.c
+++ b/pal/baremetal/base/src/pal_pptt.c
@@ -39,46 +39,44 @@ pal_cache_dump_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable)
   /*Iterate cache info table and print cache info entries*/
   for (i = 0 ; i < CacheTable->num_of_cache ; i++) {
     pal_print_msg(ACS_PRINT_INFO,
-                  "\nCache info * Index %d *",
+                  "\n       Cache info * Index %d *",
                   i);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Offset:                  0x%llx",
+                  "\n       Offset:                  0x%llx",
                   curr_entry->my_offset);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Type:                    0x%llx",
+                  "\n       Type:                    0x%llx",
                   curr_entry->cache_type);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Cache ID:                0x%llx",
+                  "\n       Cache ID:                0x%llx",
                   curr_entry->cache_id);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Size:                    0x%llx",
+                  "\n       Size:                    0x%llx",
                   curr_entry->size);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Next level index:        %d",
+                  "\n       Next level index:        %d",
                   curr_entry->next_level_index);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Private flag:            0x%llx\n",
+                  "\n       Private flag:            0x%llx",
                   curr_entry->is_private);
     curr_entry++;
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "\nPE level one cache index info");
+                "\n       PE level one cache index info");
   /*Iterate PE info table and print level one cache index info*/
   for (i = 0 ; i < PeTable->header.num_of_pe; i++) {
     pal_print_msg(ACS_PRINT_INFO,
-                  "\nPE Index * %d *",
+                  "\n       PE Index * %d *",
                   i);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Level 1 Cache index(s) :");
+                  "\n       Level 1 Cache index(s) :");
 
     for (j = 0; j < MAX_L1_CACHE_RES && pe_entry->level_1_res[j] != DEFAULT_CACHE_IDX; j++) {
       pal_print_msg(ACS_PRINT_INFO,
                     " %d,",
                     pe_entry->level_1_res[j]);
     }
-    pal_print_msg(ACS_PRINT_INFO,
-                  "\n");
     pe_entry++;
   }
 }
@@ -132,7 +130,7 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
 
   if (CacheTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Unable to create cache info table, input pointer is NULL\n");
+                  "\n       Unable to create cache info table, input pointer is NULL");
     return;
   }
 

--- a/pal/baremetal/base/src/pal_ras.c
+++ b/pal/baremetal/base/src/pal_ras.c
@@ -60,44 +60,44 @@ pal_ras_dump_info_table(RAS_INFO_TABLE *RasInfoTable)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "\nRAS Info :");
+                "\n       RAS Info :");
   pal_print_msg(ACS_PRINT_INFO,
-                "\nRAS Num Nodes : %d ",
+                "\n       RAS Num Nodes : %d ",
                 RasInfoTable->num_nodes);
 
   curr = &(RasInfoTable->node[0]);
 
   for (i = 0; i < RasInfoTable->num_nodes; i++) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Index    : %d ",
+                    "\n       Index    : %d ",
                     i);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Type     : 0x%x ",
+                    "\n       Type     : 0x%x ",
                     curr->type);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Num Intr : 0x%x ",
+                    "\n       Num Intr : 0x%x ",
                     curr->num_intr_entries);
 
       switch (curr->type) {
        case NODE_TYPE_PE:
            /* Print Processor Node Details */
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n ProcessorID : 0x%x ",
+                         "\n       ProcessorID : 0x%x ",
                          curr->node_data.pe.processor_id);
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n resource_type : 0x%x ",
+                         "\n       resource_type : 0x%x ",
                          curr->node_data.pe.resource_type);
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n flags : 0x%x ",
+                         "\n       flags : 0x%x ",
                          curr->node_data.pe.flags);
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n affinity : 0x%x ",
+                         "\n       affinity : 0x%x ",
                          curr->node_data.pe.affinity);
            break;
        case NODE_TYPE_MC:
            /* Print Memory Controller Node Details */
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n proximity_domain : 0x%x ",
+                         "\n       proximity_domain : 0x%x ",
                          curr->node_data.mc.proximity_domain);
            break;
        default:
@@ -105,32 +105,30 @@ pal_ras_dump_info_table(RAS_INFO_TABLE *RasInfoTable)
       }
 
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Interface Info :");
+                    "\n       Interface Info :");
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  type    : 0x%x ",
+                    "\n       type    : 0x%x ",
                     curr->intf_info.intf_type);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  base    : 0x%x ",
+                    "\n       base    : 0x%x ",
                     curr->intf_info.base_addr);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  num_err : 0x%x ",
+                    "\n       num_err : 0x%x ",
                     curr->intf_info.num_err_rec);
 
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Interrupt Info :");
+                    "\n       Interrupt Info :");
       for (j = 0; j < curr->num_intr_entries; j++) {
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  type    : 0x%x ",
+                      "\n       type    : 0x%x ",
                       curr->intr_info[j].type);
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  gsiv    : 0x%x ",
+                      "\n       gsiv    : 0x%x ",
                       curr->intr_info[j].gsiv);
       }
 
       curr++;
   }
-  pal_print_msg(ACS_PRINT_INFO,
-                "\n");
 }
 
 void fill_node_specific_data (
@@ -226,7 +224,7 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
 
   if (RasInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n Input RAS Table Pointer is NULL");
+                    "\n       Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -259,7 +257,7 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
 
       if (RasInfoTable->num_nodes >= RAS_MAX_NUM_NODES) {
           pal_print_msg(ACS_PRINT_WARN,
-                        "\n Number of RAS nodes greater than %d",
+                        "\n       Number of RAS nodes greater than %d",
                         RAS_MAX_NUM_NODES);
           break;
       }
@@ -286,7 +284,7 @@ pal_ras2_dump_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
 
   if (RasFeatInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n Input RAS Table Pointer is NULL");
+                    "\n       Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -294,34 +292,34 @@ pal_ras2_dump_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   uint32_t i;
 
   pal_print_msg(ACS_PRINT_INFO,
-                "\n RAS2 Feature Info :");
+                "\n       RAS2 Feature Info :");
   pal_print_msg(ACS_PRINT_INFO,
-                "\n Total number of RAS2 feature info blocks  : %d",
+                "\n       Total number of RAS2 feature info blocks  : %d",
                 RasFeatInfoTable->num_all_block);
   pal_print_msg(ACS_PRINT_INFO,
-                "\n Number of RAS2 memory feature info blocks : %d\n",
+                "\n       Number of RAS2 memory feature info blocks : %d",
                 RasFeatInfoTable->num_of_mem_block);
 
   /*Iterate RAS2 feature info table and print info fields */
   for (i = 0 ; i < RasFeatInfoTable->num_all_block ; i++) {
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n RAS2 feature info * Index %d *",
+                  "\n       RAS2 feature info * Index %d *",
                   i);
     switch(curr_block->type) {
     case RAS2_TYPE_MEMORY:
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Type                            : 0x%x",
+                      "\n       Type                            : 0x%x",
                       curr_block->type);
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Proximity Domain                : 0x%llx",
+                      "\n       Proximity Domain                : 0x%llx",
                       curr_block->block_info.mem_feat_info.proximity_domain);
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Patrol scrub support            : 0x%lx\n",
+                      "\n       Patrol scrub support            : 0x%lx",
                       curr_block->block_info.mem_feat_info.patrol_scrub_support);
         break;
     default:
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Invalid RAS feature type : 0x%x",
+                      "\n       Invalid RAS feature type : 0x%x",
                       curr_block->type);
     }
     curr_block++;
@@ -343,7 +341,7 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
 
   if (RasFeatInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n Input RAS Table Pointer is NULL");
+                    "\n       Input RAS Table Pointer is NULL");
       return;
   }
 

--- a/pal/baremetal/target/RDN2/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDN2/src/pal_exerciser.c
@@ -130,7 +130,7 @@ pal_exerciser_get_base(uint32_t bdf, uint32_t bar_index)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "value read from BAR 0x%llx\n",
+                "\n       value read from BAR 0x%llx",
                 bar_value);
 
   return bar_value;

--- a/pal/baremetal/target/RDV3/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3/src/pal_exerciser.c
@@ -117,7 +117,7 @@ pal_exerciser_get_base(uint32_t bdf, uint32_t bar_index)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "value read from BAR 0x%llx\n",
+                "\n       value read from BAR 0x%llx",
                 bar_value);
 
   return bar_value;

--- a/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
+++ b/pal/baremetal/target/RDV3CFG1/src/pal_exerciser.c
@@ -117,7 +117,7 @@ pal_exerciser_get_base(uint32_t bdf, uint32_t bar_index)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "value read from BAR 0x%llx\n",
+                "\n       value read from BAR 0x%llx",
                 bar_value);
 
   return bar_value;

--- a/pal/include/pal_print.h
+++ b/pal/include/pal_print.h
@@ -52,11 +52,57 @@ void pal_uart_print(int log, const char *fmt, ...);
 #elif defined(TARGET_UEFI)
 #include <Library/UefiLib.h>
 
+#define PAL_LOG_MSG_INDENT 7
+
+static inline void pal_print_log_indent(void)
+{
+    uint32_t i;
+
+    for (i = 0; i < acs_policy_get_log_indent(); i++)
+        Print(L"    ");
+}
+
+static inline void pal_print_log_prefix(uint32_t verbose)
+{
+    switch (verbose) {
+    case ACS_PRINT_INFO:
+    case ACS_PRINT_DEBUG:
+        Print(L"   ");
+        break;
+    case ACS_PRINT_WARN:
+        Print(L"   WARN : ");
+        break;
+    case ACS_PRINT_ERR:
+        Print(L"   ERROR: ");
+        break;
+    case ACS_PRINT_TEST:
+    default:
+        break;
+    }
+}
+
 #define PAL_PRINT_FORMAT(verbose, string, ...) \
     PAL_PRINT_IF((verbose), Print((string), ##__VA_ARGS__))
 
 #define PAL_PRINT_LITERAL(verbose, string, ...) \
-    PAL_PRINT_IF((verbose), Print(L"" string, ##__VA_ARGS__))
+    do { \
+        if ((verbose) >= acs_policy_get_print_level()) { \
+            const CHAR16 *_pal_fmt = L"" string; \
+            uint32_t _pal_i; \
+            bool _pal_new_record = (*_pal_fmt == L'\n'); \
+            while (*_pal_fmt == L'\n') { \
+                Print(L"\n"); \
+                _pal_fmt++; \
+            } \
+            if (_pal_new_record) { \
+                for (_pal_i = 0; _pal_i < PAL_LOG_MSG_INDENT && *_pal_fmt == L' '; _pal_i++) \
+                    _pal_fmt++; \
+                pal_print_log_indent(); \
+                pal_print_log_prefix((verbose)); \
+            } \
+            Print(_pal_fmt, ##__VA_ARGS__); \
+        } \
+    } while (0)
 #else
 #error "pal_print.h requires TARGET_BAREMETAL or TARGET_UEFI"
 #endif

--- a/pal/uefi_acpi/src/pal_acpi.c
+++ b/pal/uefi_acpi/src/pal_acpi.c
@@ -55,7 +55,7 @@ VOID
 pal_dump_dtb()
 {
   pal_print_msg(ACS_PRINT_ERR,
-                " DTB dump not available for platform initialized with ACPI table\n");
+                "\n       DTB dump not available for platform initialized with ACPI table");
 }
 
 /**
@@ -122,7 +122,7 @@ pal_get_madt_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -157,7 +157,7 @@ pal_get_gtdt_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -191,7 +191,7 @@ pal_get_mcfg_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -225,7 +225,7 @@ pal_get_spcr_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -259,7 +259,7 @@ pal_get_iort_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -298,7 +298,7 @@ pal_get_fadt_ptr (
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -332,7 +332,7 @@ pal_get_acpi_table_ptr(UINT32 table_signature)
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -365,7 +365,7 @@ pal_get_aest_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -398,7 +398,7 @@ pal_get_apmt_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -432,7 +432,7 @@ pal_get_hmat_ptr(void)
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -466,7 +466,7 @@ pal_get_mpam_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -501,7 +501,7 @@ pal_get_pptt_ptr(void)
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -536,7 +536,7 @@ pal_get_srat_ptr(void)
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -570,7 +570,7 @@ pal_get_tpm2_ptr(void)
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -1055,7 +1055,7 @@ pal_acpi_parse_root_bridges(VOID)
   else
   {
     pal_print_msg(ACS_PRINT_WARN,
-                  " DSDT not found; root bridge AML unavailable ");
+                  "\n       DSDT not found; root bridge AML unavailable");
     dsdt = NULL;
   }
 
@@ -1104,7 +1104,7 @@ pal_acpi_get_root_bridge_uid(UINT16 segment, UINT8 bbn, UINT32 *uid)
 {
   if (uid == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " pal_acpi_get_root_bridge_uid UID pointer NULL ");
+                  "\n       pal_acpi_get_root_bridge_uid UID pointer NULL");
     return 1;
   }
 

--- a/pal/uefi_acpi/src/pal_cxl.c
+++ b/pal/uefi_acpi/src/pal_cxl.c
@@ -92,7 +92,7 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
 
   if (CxlTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input CXL Table Pointer is NULL. Cannot create CXL INFO ");
+                  "\n       Input CXL Table Pointer is NULL. Cannot create CXL INFO");
     return;
   }
   CxlTable->num_entries = 0;
@@ -100,7 +100,7 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
   cedt_address = pal_get_acpi_table_ptr(EFI_ACPI_6_4_CXL_EARLY_DISCOVERY_TABLE_SIGNATURE);
   if (cedt_address == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " ACPI - CEDT Table not found.\n");
+                  "\n    ACPI - CEDT Table not found.");
     return;
   }
 
@@ -114,13 +114,13 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
 
     if (Host->RecordLength == 0) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " CEDT record length is zero. Aborting parse. ");
+                    "\n       CEDT record length is zero. Aborting parse.");
       return;
     }
 
     if ((ptr + Host->RecordLength) > end) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " CEDT record overruns table length. Stopping parse. ");
+                    "\n       CEDT record overruns table length. Stopping parse.");
       break;
     }
 
@@ -150,13 +150,13 @@ pal_cxl_create_info_table(CXL_INFO_TABLE *CxlTable)
 
     if (len == 0) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " CEDT record length is zero. Aborting parse. ");
+                    "\n       CEDT record length is zero. Aborting parse.");
       return;
     }
 
     if ((ptr + len) > end) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " CEDT record overruns table length. Stopping parse. ");
+                    "\n       CEDT record overruns table length. Stopping parse.");
       break;
     }
 
@@ -187,7 +187,7 @@ pal_cxl_get_host_bridge_uid(UINT32 bdf, UINT32 *uid)
   /* Map root port BDF to the root bridge UID for CEDT lookup. */
   if (uid == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " %a UID pointer NULL ",
+                  "\n       %a UID pointer NULL",
                   __func__);
     return 1;
   }

--- a/pal/uefi_acpi/src/pal_dsdt.c
+++ b/pal/uefi_acpi/src/pal_dsdt.c
@@ -456,7 +456,7 @@ pal_acpi_parse_aml_for_device(CONST UINT8 *aml,
         pal_acpi_copy_name_seg(dev_name, sizeof(dev_name), stack[depth].name_seg);
         if (record_fn != NULL) {
           pal_print_msg(ACS_PRINT_INFO,
-                        " DSDT MSC: UID=0x%x Device=%a\n",
+                        "\n       DSDT MSC: UID=0x%x Device=%a",
                         stack[depth].uid,
                         dev_name);
           record_fn(record_ctx, stack[depth].uid, dev_name);
@@ -619,7 +619,7 @@ pal_acpi_parse_aml_for_device(CONST UINT8 *aml,
       pal_acpi_copy_name_seg(dev_name, sizeof(dev_name), stack[depth].name_seg);
       if (record_fn != NULL) {
         pal_print_msg(ACS_PRINT_INFO,
-                      " DSDT MSC: UID=0x%x Device=%a\n",
+                      "\n       DSDT MSC: UID=0x%x Device=%a",
                       stack[depth].uid,
                       dev_name);
         record_fn(record_ctx, stack[depth].uid, dev_name);

--- a/pal/uefi_acpi/src/pal_gic.c
+++ b/pal/uefi_acpi/src/pal_gic.c
@@ -57,7 +57,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
 
   if (GicTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
+                  "\n       Input GIC Table Pointer is NULL. Cannot create GIC INFO");
     return;
   }
 
@@ -75,12 +75,12 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
     pal_print_msg(ACS_PRINT_INFO,
-                  "  MADT is at %x and length is %x\n",
+                  "\n       MADT is at %x and length is %x",
                   gMadtHdr,
                   TableLength);
   } else {
     pal_print_msg(ACS_PRINT_ERR,
-                  " MADT not found\n");
+                  "\n       MADT not found");
     return;
   }
 
@@ -115,7 +115,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_CPUIF;
         GicEntry->base = Entry->PhysicalBaseAddress;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC CPUIF base %lx\n",
+                      "\n       GIC CPUIF base %lx",
                       GicEntry->base);
         GicEntry++;
       }
@@ -127,13 +127,13 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
           GicEntry->base = Entry->GICRBaseAddress;
           GicEntry->length = 0;
           pal_print_msg(ACS_PRINT_INFO,
-                        "  GICC RD base %lx\n",
+                        "\n       GICC RD base %lx",
                         GicEntry->base);
           GicTable->header.num_gicc_rd++;
           GicEntry++;
         } else {
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Warning : GICR Structure Present, GICC RD Base Non-Zero\n",
+                        "\n       Warning : GICR Structure Present, GICC RD Base Non-Zero",
                         0);
         }
       }
@@ -143,7 +143,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = Entry->GICH;
         GicEntry->length = 0;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GICH base %lx\n",
+                      "\n       GICH base %lx",
                       GicEntry->base);
         GicEntry++;
       }
@@ -154,7 +154,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicTable->header.gic_version = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->GicVersion;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC DIS base %lx\n",
+                      "\n       GIC DIS base %lx",
                       GicEntry->base);
         GicTable->header.num_gicd++;
         GicEntry++;
@@ -165,10 +165,10 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GICR RD base %lx\n",
+                      "\n       GICR RD base %lx",
                       GicEntry->base);
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GICR RD Length %lx\n",
+                      "\n       GICR RD Length %lx",
                       GicEntry->length);
         GicTable->header.num_gicr_rd++;
         GicEntry++;
@@ -179,10 +179,10 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicEntry->entry_id = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->GicItsId;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC ITS base %lx\n",
+                      "\n       GIC ITS base %lx",
                       GicEntry->base);
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC ITS ID%x\n",
+                      "\n       GIC ITS ID%x",
                       GicEntry->entry_id);
         GicTable->header.num_its++;
         GicEntry++;
@@ -196,13 +196,13 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->spi_count = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPICount;
         GicEntry->spi_base = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPIBase;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC MSI Frame base %lx\n",
+                      "\n       GIC MSI Frame base %lx",
                       GicEntry->base);
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC MSI SPI base %x\n",
+                      "\n       GIC MSI SPI base %x",
                       GicEntry->spi_base);
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC MSI SPI Count %x\n",
+                      "\n       GIC MSI SPI Count %x",
                       GicEntry->spi_count);
         GicTable->header.num_msi_frame++;
         GicEntry++;

--- a/pal/uefi_acpi/src/pal_hmat.c
+++ b/pal/uefi_acpi/src/pal_hmat.c
@@ -196,7 +196,7 @@ VOID pal_hmat_dump_info_table(HMAT_INFO_TABLE *HmatTable)
 
   curr_entry = HmatTable->bw_info;
   pal_print_msg(ACS_PRINT_INFO,
-                "\n*** HMAT info table entries ***\n");
+                "\n       *** HMAT info table entries ***");
   for (i = 0 ; i < HmatTable->num_of_mem_prox_domain ; i++) {
       pal_print_msg(ACS_PRINT_INFO,
                     "\nMemory Proximity domain  :   0x%llx",
@@ -205,7 +205,7 @@ VOID pal_hmat_dump_info_table(HMAT_INFO_TABLE *HmatTable)
                     "\n  Write bandwidth        :   0x%llx",
                     curr_entry->write_bw);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  Read  bandwidth        :   0x%llx\n",
+                    "\n       Read  bandwidth        :   0x%llx",
                     curr_entry->read_bw);
       curr_entry++;
   }
@@ -228,7 +228,7 @@ VOID pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
 
   if (HmatTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Unable to create HMAT info table, input pointer is NULL\n");
+                    "\n       Unable to create HMAT info table, input pointer is NULL");
       return;
   }
 
@@ -238,13 +238,13 @@ VOID pal_hmat_create_info_table(HMAT_INFO_TABLE *HmatTable)
   HmatHdr = (EFI_ACPI_6_4_HETEROGENEOUS_MEMORY_ATTRIBUTE_TABLE_HEADER *) pal_get_hmat_ptr();
   if (HmatHdr == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " HMAT ACPI table not found\n");
+                    "\n       HMAT ACPI table not found");
       return;
   }
   else {
       TableLength = HmatHdr->Header.Length;
       pal_print_msg(ACS_PRINT_INFO,
-                    "HMAT ACPI table found at 0x%llx with length 0x%x\n",
+                    "\n       HMAT ACPI table found at 0x%llx with length 0x%x",
                     HmatHdr,
                     TableLength);
   }

--- a/pal/uefi_acpi/src/pal_iovirt.c
+++ b/pal/uefi_acpi/src/pal_iovirt.c
@@ -65,54 +65,52 @@ dump_block(IOVIRT_BLOCK *block) {
   switch(block->type) {
       case IOVIRT_NODE_ITS_GROUP:
       pal_print_msg(ACS_PRINT_INFO,
-                    "  ITS Group Num ITS: %d\n",
+                    "\n       ITS Group Num ITS: %d",
                     block->data.its_count);
       for(i = 0; i < block->data.its_count; i++)
           pal_print_msg(ACS_PRINT_INFO,
-                        "  ITS ID: %d\n",
+                        "\n       ITS ID: %d",
                         (*map).id[i]);
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
       pal_print_msg(ACS_PRINT_INFO,
-                    " Named Component:\n Device Name:%a",
+                    "\n       Named Component:\n   Device Name:%a",
                     block->data.named_comp.name);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n CCA Attribute: 0x%lx\n",
+                    "\n       CCA Attribute: 0x%lx",
                     block->data.named_comp.cca);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Root Complex  Segment Num:%d\n",
+                    "\n       Root Complex  Segment Num:%d",
                     block->data.rc.segment);
       break;
       case IOVIRT_NODE_SMMU:
       case IOVIRT_NODE_SMMU_V3:
       pal_print_msg(ACS_PRINT_INFO,
-                    "  SMMU: Major Rev:%d Base Address:0x%llx\n",
+                    "\n       SMMU: Major Rev:%d Base Address:0x%llx",
                     block->data.smmu.arch_major_rev,
                     block->data.smmu.base);
       break;
       case IOVIRT_NODE_PMCG:
       pal_print_msg(ACS_PRINT_INFO,
-                    "  PMCG: Base:0x%x Overflow GSIV:0x%x Node Reference:0x%x\n",
+                    "\n       PMCG: Base:0x%x Overflow GSIV:0x%x Node Reference:0x%x",
                     block->data.pmcg.base,
                     block->data.pmcg.overflow_gsiv,
                     block->data.pmcg.node_ref);
       break;
   }
   pal_print_msg(ACS_PRINT_INFO,
-                "  Number of ID Mappings:%d\n",
+                "\n       Number of ID Mappings:%d",
                 block->num_data_map);
   for(i = 0; i < block->num_data_map; i++, map++) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "  input_base:0x%x id_count:0x%x output_base:0x%x output ref:0x%x\n",
+                    "\n       input_base:0x%x id_count:0x%x output_base:0x%x output ref:0x%x",
                     (*map).map.input_base,
                     (*map).map.id_count,
                     (*map).map.output_base,
                     (*map).map.output_ref);
   }
-  pal_print_msg(ACS_PRINT_INFO,
-                "\n");
 }
 
 /**
@@ -148,7 +146,7 @@ dump_iort_table(IOVIRT_INFO_TABLE *iovirt)
   UINT32 i;
   IOVIRT_BLOCK *block = &iovirt->blocks[0];
   pal_print_msg(ACS_PRINT_INFO,
-                "  Number of IOVIRT blocks = %d\n",
+                "\n       Number of IOVIRT blocks = %d",
                 iovirt->num_blocks);
   for(i = 0; i < iovirt->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
     dump_block(block);
@@ -209,7 +207,7 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
                key_block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                pal_print_msg(ACS_PRINT_INFO,
-                             "\n Overlapping device ids %x-%x and %x-%x\n",
+                             "\n       Overlapping device ids %x-%x and %x-%x",
                              key_start,
                              key_end,
                              start,
@@ -219,7 +217,7 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
                key_block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                pal_print_msg(ACS_PRINT_INFO,
-                             "\n Overlapping stream ids %x-%x and %x-%x\n",
+                             "\n       Overlapping stream ids %x-%x and %x-%x",
                              key_start,
                              key_end,
                              start,
@@ -288,7 +286,7 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
   VOID *node_data = &(iort_node->node_data[0]);
 
   pal_print_msg(ACS_PRINT_INFO,
-                "  IORT node offset:%x, type: %d\n",
+                "\n       IORT node offset:%x, type: %d",
                 (UINT8 *)iort_node - (UINT8 *)iort,
                 iort_node->type);
 
@@ -354,7 +352,7 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
       break;
     default:
        pal_print_msg(ACS_PRINT_ERR,
-                     " Invalid IORT node type\n");
+                     "\n       Invalid IORT node type");
        return (UINT32) -1;
   }
 
@@ -482,7 +480,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   for (i = 0; i < iort->node_count; i++) {
     if (iort_node >= iort_end) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Bad IORT table\n");
+                    "\n       Bad IORT table");
       return;
     }
     iort_add_block(iort, iort_node, IoVirtTable, &next_block);
@@ -603,7 +601,7 @@ pal_iovirt_get_rc_smmu_base (
    * is not behind any SMMU. Return NULL pointer
    */
   pal_print_msg(ACS_PRINT_DEBUG,
-                " No SMMU found behind the RootComplex with seg :%x",
+                "\n       No SMMU found behind the RootComplex with seg :%x",
                 RcSegmentNum);
   return 0;
 }

--- a/pal/uefi_acpi/src/pal_misc.c
+++ b/pal/uefi_acpi/src/pal_misc.c
@@ -39,7 +39,7 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %lx\n",
+                    "\n       %a Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -61,7 +61,7 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %lx\n",
+                    "\n       %a Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -83,7 +83,7 @@ pal_mmio_write64(UINT64 addr, UINT64 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %llx\n",
+                    "\n       %a Address = %llx  Data = %llx",
                     __func__,
                     addr,
                     data);
@@ -108,7 +108,7 @@ pal_mmio_read8(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %lx\n",
+                    "\n       %a Address = %lx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -133,7 +133,7 @@ pal_mmio_read16(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %lx\n",
+                    "\n       %a Address = %lx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -158,7 +158,7 @@ pal_mmio_read64(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %lx\n",
+                    "\n       %a Address = %lx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -183,7 +183,7 @@ pal_mmio_read(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %x\n",
+                    "\n       %a Address = %lx  Data = %x",
                     __func__,
                     addr,
                     data);
@@ -206,7 +206,7 @@ pal_mmio_write(UINT64 addr, UINT32 data)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %x\n",
+                    "\n       %a Address = %llx  Data = %x",
                     __func__,
                     addr,
                     data);
@@ -237,7 +237,7 @@ pal_print(UINT64 data)
     Status = ShellWriteFile(g_acs_log_file_handle, &BufferSize, (VOID *)buf);
     if (EFI_ERROR(Status))
       pal_print_msg(ACS_PRINT_ERR,
-                    " Error in writing to log file\n");
+                    "\n       Error in writing to log file");
   }
   else
   {
@@ -346,12 +346,12 @@ pal_mem_allocate_shared(UINT32 num_pe, UINT32 sizeofentry)
                                (VOID **) &gSharedMemory );
 
   pal_print_msg(ACS_PRINT_INFO,
-                " Shared memory is %llx\n",
+                "\n       Shared memory is %llx",
                 gSharedMemory);
 
   if (EFI_ERROR(Status)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool shared memory failed %x\n",
+                  "\n       Allocate Pool shared memory failed %x",
                   Status);
   }
   pal_pe_data_cache_ops_by_va((UINT64)&gSharedMemory, CLEAN_AND_INVALIDATE);
@@ -412,7 +412,7 @@ pal_mem_alloc (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool failed %x\n",
+                  "\n       Allocate Pool failed %x",
                   Status);
     return NULL;
   }
@@ -445,7 +445,7 @@ pal_mem_calloc (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool failed %x\n",
+                  "\n       Allocate Pool failed %x",
                   Status);
     return NULL;
   }
@@ -536,7 +536,7 @@ pal_mem_alloc_pages (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pages failed %x\n",
+                  "\n       Allocate Pages failed %x",
                   Status);
     return NULL;
   }
@@ -640,7 +640,7 @@ pal_mem_alloc_at_address (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pages failed %x\n",
+                  "\n       Allocate Pages failed %x",
                   Status);
     return NULL;
   }
@@ -691,7 +691,7 @@ pal_mem_alloc_cacheable (
                                &Address);
   if (EFI_ERROR(Status)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool failed %x\n",
+                  "\n       Allocate Pool failed %x",
                   Status);
     return NULL;
   }
@@ -700,7 +700,7 @@ pal_mem_alloc_cacheable (
   Status = gBS->LocateProtocol ( &gEfiCpuArchProtocolGuid, NULL, (VOID **)&Cpu);
   if (EFI_ERROR(Status)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Could not get Cpu Arch Protocol %x\n",
+                  "\n       Could not get Cpu Arch Protocol %x",
                   Status);
     return NULL;
   }
@@ -712,7 +712,7 @@ pal_mem_alloc_cacheable (
                                      EFI_MEMORY_WB);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Could not Set Memory Attribute %x\n",
+                  "\n       Could not Set Memory Attribute %x",
                   Status);
     return NULL;
   }
@@ -763,7 +763,7 @@ pal_mem_set_wb_executable (
   Status = gBS->LocateProtocol(&gEfiCpuArchProtocolGuid, NULL, (VOID **)&Cpu);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "Could not get CPU Arch Protocol: %x\n",
+                    "\n       Could not get CPU Arch Protocol: %x",
                     Status);
       return 1;
   }
@@ -772,7 +772,7 @@ pal_mem_set_wb_executable (
   Status = Cpu->SetMemoryAttributes(Cpu, (EFI_PHYSICAL_ADDRESS) addr, Size, EFI_MEMORY_WB);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "Could not set memory attributes: %x\n",
+                    "\n       Could not set memory attributes: %x",
                     Status);
       return 1;
   }
@@ -791,7 +791,7 @@ void pal_uart_putc(char c)
         EFI_STATUS Status = ShellWriteFile(g_acs_log_file_handle, &n, &ch);
         if (EFI_ERROR(Status)) {
             pal_print_msg(ACS_PRINT_ERR,
-                          " Error in writing to log file\n");
+                          "\n       Error in writing to log file");
         }
     }
 }

--- a/pal/uefi_acpi/src/pal_mpam.c
+++ b/pal/uefi_acpi/src/pal_mpam.c
@@ -149,7 +149,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
 
   if (MpamTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Input MPAM Table Pointer is NULL\n");
+                    "\n       Input MPAM Table Pointer is NULL");
       return;
   }
 
@@ -162,7 +162,7 @@ pal_mpam_create_info_table(MPAM_INFO_TABLE *MpamTable)
   mpam = (EFI_ACPI_MPAM_TABLE *)pal_get_mpam_ptr();
   if (mpam == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " MPAM table not found\n");
+                    "\n       MPAM table not found");
       return;
   }
 
@@ -237,7 +237,7 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
 
   if (SratTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Input SRAT Table Pointer is NULL\n");
+                    "\n       Input SRAT Table Pointer is NULL");
       return;
   }
 
@@ -250,12 +250,12 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
   if (SratHdr != NULL) {
     TableLength =  SratHdr->Header.Length;
     pal_print_msg(ACS_PRINT_INFO,
-                  " SRAT is at %x and length is %x\n",
+                  "\n       SRAT is at %x and length is %x",
                   SratHdr,
                   TableLength);
   } else {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " SRAT not found\n");
+                  "\n       SRAT not found");
     return;
   }
 
@@ -276,13 +276,13 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
                                                               Mem_Aff_Entry->LengthLow;
       Ptr->node_data.mem_aff.flags       = Mem_Aff_Entry->Flags;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Proximity Domain %x\n",
+                    "\n       Proximity Domain %x",
                     Ptr->node_data.mem_aff.prox_domain);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Address %x\n",
+                    "\n       Address %x",
                     Ptr->node_data.mem_aff.addr_base);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Length %x\n",
+                    "\n       Length %x",
                     Ptr->node_data.mem_aff.addr_len);
       pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
       Ptr++;
@@ -298,13 +298,13 @@ pal_srat_create_info_table(SRAT_INFO_TABLE *SratTable)
       Ptr->node_data.gicc_aff.flags = Gicc_Aff_Entry->Flags;
       Ptr->node_data.gicc_aff.clk_domain = Gicc_Aff_Entry->ClockDomain;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Proximity Domain %x\n",
+                    "\n       Proximity Domain %x",
                     Ptr->node_data.gicc_aff.prox_domain);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Processor UID %x\n",
+                    "\n       Processor UID %x",
                     Ptr->node_data.gicc_aff.proc_uid);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Clock Domain %x\n",
+                    "\n       Clock Domain %x",
                     Ptr->node_data.gicc_aff.clk_domain);
       pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);
       Ptr++;

--- a/pal/uefi_acpi/src/pal_pcie.c
+++ b/pal/uefi_acpi/src/pal_pcie.c
@@ -57,7 +57,7 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
 
   if (gMcfgHdr == NULL) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
+                    "\n       ACPI - MCFG Table not found. Setting ECAM Base to 0.");
       return 0x0;
   }
 
@@ -71,7 +71,7 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
       if ((bus >= Entry->StartBusNumber) && (bus <= Entry->EndBusNumber) &&
           (seg == Entry->PciSegmentGroupNumber)) {
           pal_print_msg(ACS_PRINT_INFO,
-                        " ECAM base address is %llx\n",
+                        "\n       ECAM base address is %llx",
                         Entry->BaseAddress);
           return Entry->BaseAddress;
       }
@@ -82,7 +82,7 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
   }
 
   pal_print_msg(ACS_PRINT_ERR,
-                " ECAM base address for bdf 0x%x is 0\n",
+                "\n       ECAM base address for bdf 0x%x is 0",
                 bdf);
   return 0;
 }
@@ -105,7 +105,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
 
   if (PcieTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
+                  "\n       Input PCIe Table Pointer is NULL. Cannot create PCIe INFO");
     return;
   }
 
@@ -115,7 +115,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
 
   if (gMcfgHdr == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " ACPI - MCFG Table not found.\n");
+                    "\n       ACPI - MCFG Table not found.");
       return;
   }
 
@@ -137,19 +137,19 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
       PcieTable->block[i].start_bus_num = Entry->StartBusNumber;
       PcieTable->block[i].end_bus_num   = Entry->EndBusNumber;
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Ecam Index = %d\n",
+                    "\n       Ecam Index = %d",
                     i);
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Base Address = 0x%llx\n",
+                    "\n       Base Address = 0x%llx",
                     Entry->BaseAddress);
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Segment   = 0x%llx\n",
+                    "\n       Segment   = 0x%llx",
                     Entry->PciSegmentGroupNumber);
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Start Bus = 0x%llx\n",
+                    "\n       Start Bus = 0x%llx",
                     Entry->StartBusNumber);
       pal_print_msg(ACS_PRINT_INFO,
-                    "  End Bus   = 0x%llx\n",
+                    "\n       End Bus   = 0x%llx",
                     Entry->EndBusNumber);
       length += sizeof(EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE);
       Entry++;
@@ -185,7 +185,7 @@ pal_pcie_io_read_cfg(UINT32 Bdf, UINT32 offset, UINT32 *data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return PCIE_NO_MAPPING;
   }
 
@@ -238,7 +238,7 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return;
   }
 
@@ -284,7 +284,7 @@ pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No Root Bridge found in the system\n");
+                  "\n       No Root Bridge found in the system");
     return PCIE_NO_MAPPING;
   }
 
@@ -333,7 +333,7 @@ pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No Root Bridge found in the system\n");
+                  "\n       No Root Bridge found in the system");
     return PCIE_NO_MAPPING;
   }
 
@@ -631,7 +631,7 @@ pal_pcie_is_devicedma_64bit(UINT32 seg, UINT32 bus, UINT32 dev, UINT32 fn)
   Status = gBS->LocateHandleBuffer(ByProtocol, &gEfiPciIoProtocolGuid, NULL,
                                    &HandleCount, &HandleBuffer);
   if (EFI_ERROR(Status)) {
-    pal_print_msg(ACS_PRINT_ERR, " No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_ERR, "\n       No PCI devices found in the system");
     return 0;
   }
 

--- a/pal/uefi_acpi/src/pal_pcie_enumeration.c
+++ b/pal/uefi_acpi/src/pal_pcie_enumeration.c
@@ -84,7 +84,7 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return EFI_SUCCESS;
   }
 
@@ -109,7 +109,7 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
           if (!EFI_ERROR (Status)) {
             Hdr = &PciHeader.Bridge.Hdr;
             pal_print_msg(ACS_PRINT_INFO,
-                          "  %03d.%02d.%02d class_code = %d %d\n",
+                          "\n       %03d.%02d.%02d class_code = %d %d",
                           Bus,
                           Dev,
                           Index,
@@ -179,7 +179,7 @@ palPcieGetBase(UINT32 bdf, UINT32 bar_index)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return EFI_SUCCESS;
   }
 

--- a/pal/uefi_acpi/src/pal_pe.c
+++ b/pal/uefi_acpi/src/pal_pe.c
@@ -83,7 +83,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
   if (SmbiosTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
+                  "\n       Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO");
     return;
   }
 
@@ -106,7 +106,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
     /* Check of record if of type 4 */
     if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Smbios type %d found\n",
+                    "\n       Smbios type %d found",
                     Record->Type);
 
       Type4Record = (SMBIOS_TABLE_TYPE4 *)Record;
@@ -118,7 +118,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
         Type4Entry->processor_family = Type4Record->ProcessorFamily;
 
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Processor Family 0x%x\n",
+                    "\n       Processor Family 0x%x",
                     Type4Entry->processor_family);
 
       /* Save Processor core count */
@@ -128,7 +128,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
         Type4Entry->core_count = Type4Record->CoreCount;
 
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Processor Count 0x%x\n",
+                    "\n       Processor Count 0x%x",
                     Type4Entry->core_count);
 
       Type4Entry++;
@@ -136,10 +136,10 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
       if (SmbiosTable->slot_count >= MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED) {
         pal_print_msg(ACS_PRINT_WARN,
-                      " Total Slots/Sockets 0x%x\n",
+                      "\n       Total Slots/Sockets 0x%x",
                       SmbiosTable->slot_count);
         pal_print_msg(ACS_PRINT_WARN,
-                      " Number of SMBIOS Slots greater than %d\n",
+                      "\n       Number of SMBIOS Slots greater than %d",
                       MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
         SmbiosTable->slot_count = MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED;
         return;
@@ -147,7 +147,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
     }
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " Total Slots/Sockets 0x%x\n",
+                "\n       Total Slots/Sockets 0x%x",
                 SmbiosTable->slot_count);
 }
 
@@ -173,7 +173,7 @@ pal_psci_get_conduit (
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return CONDUIT_NO_TABLE;
   }
 
@@ -268,24 +268,24 @@ PalCaptureMmuConfig(VOID)
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  MMU Config captured at EL%d\n",
+                "\n       MMU Config captured at EL%d",
                 gMmuConfig.current_el);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TTBR0: 0x%lx\n",
+                "\n       TTBR0: 0x%lx",
                 gMmuConfig.ttbr0);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TCR:   0x%lx\n",
+                "\n       TCR:   0x%lx",
                 gMmuConfig.tcr);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    MAIR:  0x%lx\n",
+                "\n       MAIR:  0x%lx",
                 gMmuConfig.mair);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    SCTLR: 0x%lx\n",
+                "\n       SCTLR: 0x%lx",
                 gMmuConfig.sctlr);
 
   if (!SkipTtbr1)
     pal_print_msg(ACS_PRINT_DEBUG,
-                  "    TTBR1: 0x%lx\n",
+                  "\n       TTBR1: 0x%lx",
                   gMmuConfig.ttbr1);
 
   /* Clean cache to ensure secondary PEs see the config */
@@ -340,7 +340,7 @@ PalAllocateSecondaryStack(UINT64 mpidr)
                     (VOID **) &Buffer);
       if (EFI_ERROR(Status)) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "\n FATAL - Allocation for Seconday stack failed %x\n",
+                        "\n       FATAL - Allocation for Seconday stack failed %x",
                         Status);
       }
       pal_pe_data_cache_ops_by_va((UINT64)&Buffer, CLEAN_AND_INVALIDATE);
@@ -380,7 +380,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 
   if (PeTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input PE Table Pointer is NULL. Cannot create PE INFO\n");
+                  "\n       Input PE Table Pointer is NULL. Cannot create PE INFO");
     return;
   }
 
@@ -392,12 +392,12 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
     pal_print_msg(ACS_PRINT_INFO,
-                  "  MADT is at %x and length is %x\n",
+                  "\n       MADT is at %x and length is %x",
                   gMadtHdr,
                   TableLength);
   } else {
     pal_print_msg(ACS_PRINT_ERR,
-                  " MADT not found\n");
+                  "\n       MADT not found");
     return;
   }
 
@@ -411,10 +411,10 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
       //Fill in the cpu num and the mpidr in pe info table
       Flags           = Entry->Flags;
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Flags %x\n",
+                    "\n       Flags %x",
                     Flags);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  PE Enabled %d, Online Capable %d\n",
+                    "\n       PE Enabled %d, Online Capable %d",
                     ENABLED_BIT(Flags),
                     ONLINE_CAP_BIT(Flags));
 
@@ -442,13 +442,13 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
                                      ((UINT8 *)Entry))->TrbeInterrupt;
 
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  MADT Revision %llx \n",
+                        "\n       MADT Revision %llx",
                         gMadtHdr->Header.Revision);
 
           for (i = 0; i < MAX_L1_CACHE_RES; i++)
               Ptr->level_1_res[i] = DEFAULT_CACHE_IDX; //initialize cache index fields with all 1's
           pal_print_msg(ACS_PRINT_DEBUG,
-                        " MPIDR %llx PE num %x\n",
+                        "\n       MPIDR %llx PE num %x",
                         Ptr->mpidr,
                         Ptr->pe_num);
           pal_pe_data_cache_ops_by_va((UINT64)Ptr, CLEAN_AND_INVALIDATE);

--- a/pal/uefi_acpi/src/pal_peripherals.c
+++ b/pal/uefi_acpi/src/pal_peripherals.c
@@ -104,7 +104,7 @@ pal_peripheral_add_all_pci(PERIPHERAL_INFO_TABLE *peripheralInfoTable,
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL,
                                     &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    pal_print_msg(ACS_PRINT_ERR, "  No PCI devices found while populating peripheral table\n");
+    pal_print_msg(ACS_PRINT_ERR, "\n       No PCI devices found while populating peripheral table");
     return;
   }
 
@@ -200,7 +200,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
 
   if (peripheralInfoTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
+                  "\n       Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO");
     return;
   }
 
@@ -228,7 +228,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->irq   = 0;
           per_info->platform_type = PLATFORM_TYPE_ACPI;
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Found a USB controller %4x\n",
+                        "\n       Found a USB controller %4x",
                         per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
@@ -255,7 +255,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->irq   = 0;
           per_info->platform_type = PLATFORM_TYPE_ACPI;
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Found a SATA controller %4x\n",
+                        "\n       Found a SATA controller %4x",
                         per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
@@ -288,10 +288,10 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
   }
   else {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  "  WARNING:SPCR acpi table not found\n",
+                  "\n       WARNING:SPCR acpi table not found",
                   0);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  "  UEFI console setting must be set to serial\n",
+                  "\n       UEFI console setting must be set to serial",
                   0);
   }
 
@@ -427,7 +427,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
 
   if (memoryInfoTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
+                  "\n       Input Memory Table Pointer is NULL. Cannot create Memory INFO");
     return;
   }
 
@@ -455,7 +455,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
     MemoryMapPtr = MemoryMap;
     for (Index = 0; Index < (MemoryMapSize / DescriptorSize); Index++) {
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Reserved region of type %d [0x%lX, 0x%lX]\n",
+                        "\n       Reserved region of type %d [0x%lX, 0x%lX]",
                         MemoryMapPtr->Type,
                         (UINTN)MemoryMapPtr->PhysicalStart,
                         (UINTN)(MemoryMapPtr->PhysicalStart +
@@ -483,7 +483,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
       i++;
       if (i >= MEM_INFO_TBL_MAX_ENTRY) {
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  Memory Info tbl limit exceeded, Skipping remaining\n",
+                      "\n       Memory Info tbl limit exceeded, Skipping remaining",
                       0);
         break;
       }
@@ -518,7 +518,7 @@ pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance)
   if (Status != EFI_SUCCESS)
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Failed to get GCD memory with error: %x\n",
+                  "\n       Failed to get GCD memory with error: %x",
                   Status);
     if (Status == EFI_NO_MAPPING)
     {
@@ -539,7 +539,7 @@ pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance)
           continue;
 
         pal_print_msg(ACS_PRINT_INFO,
-                      " Unpopulated region with base address 0x%lX found\n",
+                      "\n       Unpopulated region with base address 0x%lX found",
                       *addr);
         return MEM_MAP_SUCCESS;
       }

--- a/pal/uefi_acpi/src/pal_pmu.c
+++ b/pal/uefi_acpi/src/pal_pmu.c
@@ -99,7 +99,7 @@ pal_pmu_create_info_table(PMU_INFO_TABLE *PmuTable)
   apmt = (APMT_TABLE *)pal_get_apmt_ptr();
   if (apmt == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " APMT table not found\n");
+                    "\n       APMT table not found");
       return;
   }
 

--- a/pal/uefi_acpi/src/pal_pptt.c
+++ b/pal/uefi_acpi/src/pal_pptt.c
@@ -48,49 +48,47 @@ pal_cache_dump_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable)
   /*Iterate cache info table and print cache info entries*/
   for (i = 0 ; i < CacheTable->num_of_cache ; i++) {
     pal_print_msg(ACS_PRINT_INFO,
-                  "\nCache info * Index %d *",
+                  "\n       Cache info * Index %d *",
                   i);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Offset:                  0x%llx",
+                  "\n       Offset:                  0x%llx",
                   curr_entry->my_offset);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Type:                    0x%llx",
+                  "\n       Type:                    0x%llx",
                   curr_entry->cache_type);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Cache ID:                0x%llx",
+                  "\n       Cache ID:                0x%llx",
                   curr_entry->cache_id);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Size:                    0x%llx",
+                  "\n       Size:                    0x%llx",
                   curr_entry->size);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Next level index:        %d",
+                  "\n       Next level index:        %d",
                   curr_entry->next_level_index);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Private flag:            0x%llx",
+                  "\n       Private flag:            0x%llx",
                   curr_entry->is_private);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Associativity:           0x%llx\n",
+                  "\n       Associativity:           0x%llx",
                   curr_entry->associativity);
     curr_entry++;
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "\nPE level one cache index info");
+                "\n       PE level one cache index info");
   /*Iterate PE info table and print level one cache index info*/
   for (i = 0 ; i < PeTable->header.num_of_pe; i++) {
     pal_print_msg(ACS_PRINT_INFO,
-                  "\nPE Index * %d *",
+                  "\n       PE Index * %d *",
                   i);
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n  Level 1 Cache index(s) :");
+                  "\n       Level 1 Cache index(s) :");
 
     for (j = 0; j < MAX_L1_CACHE_RES && pe_entry->level_1_res[j] != DEFAULT_CACHE_IDX; j++) {
       pal_print_msg(ACS_PRINT_INFO,
                     " %d,",
                     pe_entry->level_1_res[j]);
     }
-    pal_print_msg(ACS_PRINT_INFO,
-                  "\n");
     pe_entry++;
   }
 }
@@ -185,7 +183,7 @@ pal_cache_store_pe_res(PE_INFO_TABLE *PeTable, UINT32 acpi_uid,
   }
   else
     pal_print_msg(ACS_PRINT_ERR,
-                  "\n  The input resource index is greater than supported value %d",
+                  "\n       The input resource index is greater than supported value %d",
                   MAX_L1_CACHE_RES);
 }
 
@@ -212,7 +210,7 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
 
   if (CacheTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Unable to create cache info table, input pointer is NULL\n");
+                  "\n       Unable to create cache info table, input pointer is NULL");
     return;
   }
 
@@ -222,13 +220,13 @@ pal_cache_create_info_table(CACHE_INFO_TABLE *CacheTable, PE_INFO_TABLE *PeTable
   PpttHdr = (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_HEADER *) pal_get_pptt_ptr();
   if (PpttHdr == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " PPTT Table not found\n");
+                  "\n       PPTT Table not found");
     return;
   }
   else {
     TableLength = PpttHdr->Header.Length;
     pal_print_msg(ACS_PRINT_INFO,
-                  "PPTT table found at 0x%llx with length 0x%x\n",
+                  "\n       PPTT table found at 0x%llx with length 0x%x",
                   PpttHdr,
                   TableLength);
   }

--- a/pal/uefi_acpi/src/pal_ras.c
+++ b/pal/uefi_acpi/src/pal_ras.c
@@ -124,44 +124,44 @@ pal_ras_dump_info_table(RAS_INFO_TABLE *RasInfoTable)
   }
 
   pal_print_msg(ACS_PRINT_INFO,
-                "\nRAS Info :");
+                "\n       RAS Info :");
   pal_print_msg(ACS_PRINT_INFO,
-                "\nRAS Num Nodes : %d ",
+                "\n       RAS Num Nodes : %d ",
                 RasInfoTable->num_nodes);
 
   curr = &(RasInfoTable->node[0]);
 
   for (i = 0; i < RasInfoTable->num_nodes; i++) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Index    : %d ",
+                    "\n       Index    : %d ",
                     i);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Type     : 0x%x ",
+                    "\n       Type     : 0x%x ",
                     curr->type);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Num Intr : 0x%x ",
+                    "\n       Num Intr : 0x%x ",
                     curr->num_intr_entries);
 
       switch (curr->type) {
        case NODE_TYPE_PE:
            /* Print Processor Node Details */
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n ProcessorID : 0x%x ",
+                         "\n       ProcessorID : 0x%x ",
                          curr->node_data.pe.processor_id);
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n resource_type : 0x%x ",
+                         "\n       resource_type : 0x%x ",
                          curr->node_data.pe.resource_type);
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n flags : 0x%x ",
+                         "\n       flags : 0x%x ",
                          curr->node_data.pe.flags);
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n affinity : 0x%x ",
+                         "\n       affinity : 0x%x ",
                          curr->node_data.pe.affinity);
            break;
        case NODE_TYPE_MC:
            /* Print Memory Controller Node Details */
            pal_print_msg(ACS_PRINT_INFO,
-                         "\n proximity_domain : 0x%x ",
+                         "\n       proximity_domain : 0x%x ",
                          curr->node_data.mc.proximity_domain);
            break;
        default:
@@ -169,32 +169,30 @@ pal_ras_dump_info_table(RAS_INFO_TABLE *RasInfoTable)
       }
 
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Interface Info :");
+                    "\n       Interface Info :");
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  type    : 0x%x ",
+                    "\n       type    : 0x%x ",
                     curr->intf_info.intf_type);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  base    : 0x%x ",
+                    "\n       base    : 0x%x ",
                     curr->intf_info.base_addr);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n  num_err : 0x%x ",
+                    "\n       num_err : 0x%x ",
                     curr->intf_info.num_err_rec);
 
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Interrupt Info :");
+                    "\n       Interrupt Info :");
       for (j = 0; j < curr->num_intr_entries; j++) {
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  type    : 0x%x ",
+                      "\n       type    : 0x%x ",
                       curr->intr_info[j].type);
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  gsiv    : 0x%x ",
+                      "\n       gsiv    : 0x%x ",
                       curr->intr_info[j].gsiv);
       }
 
       curr++;
   }
-  pal_print_msg(ACS_PRINT_INFO,
-                "\n");
 }
 
 void fill_node_specific_data (
@@ -294,7 +292,7 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
 
   if (RasInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n Input RAS Table Pointer is NULL");
+                    "\n       Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -306,13 +304,13 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
   aest = (EFI_ACPI_ARM_ERROR_SOURCE_TABLE *)pal_get_aest_ptr();
   if (aest == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " AEST table not found\n");
+                    "\n       AEST table not found");
       return;
   }
 
   if (aest->Header.Revision == 2) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " NOT_SUPPORTED: AEST Revision %d detected.\n",
+                    "\n       NOT_SUPPORTED: AEST Revision %d detected.",
                     aest->Header.Revision);
       return;
   }
@@ -345,7 +343,7 @@ pal_ras_create_info_table(RAS_INFO_TABLE *RasInfoTable)
 
       if (RasInfoTable->num_nodes >= MAX_NUM_OF_RAS_SUPPORTED) {
           pal_print_msg(ACS_PRINT_WARN,
-                        "\n Number of RAS nodes greater than %d",
+                        "\n       Number of RAS nodes greater than %d",
                         MAX_NUM_OF_RAS_SUPPORTED);
           break;
       }
@@ -372,7 +370,7 @@ pal_ras2_dump_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
 
   if (RasFeatInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n Input RAS Table Pointer is NULL");
+                    "\n       Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -380,34 +378,34 @@ pal_ras2_dump_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   UINT32 i;
 
   pal_print_msg(ACS_PRINT_INFO,
-                "\n RAS2 Feature Info :");
+                "\n       RAS2 Feature Info :");
   pal_print_msg(ACS_PRINT_INFO,
-                "\n Total number of RAS2 feature info blocks  : %d",
+                "\n       Total number of RAS2 feature info blocks  : %d",
                 RasFeatInfoTable->num_all_block);
   pal_print_msg(ACS_PRINT_INFO,
-                "\n Number of RAS2 memory feature info blocks : %d\n",
+                "\n       Number of RAS2 memory feature info blocks : %d",
                 RasFeatInfoTable->num_of_mem_block);
 
   /*Iterate RAS2 feature info table and print info fields */
   for (i = 0 ; i < RasFeatInfoTable->num_all_block ; i++) {
     pal_print_msg(ACS_PRINT_INFO,
-                  "\n RAS2 feature info * Index %d *",
+                  "\n       RAS2 feature info * Index %d *",
                   i);
     switch(curr_block->type) {
     case RAS2_FEATURE_TYPE_MEMORY:
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Type                            : 0x%x",
+                      "\n       Type                            : 0x%x",
                       curr_block->type);
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Proximity Domain                : 0x%llx",
+                      "\n       Proximity Domain                : 0x%llx",
                       curr_block->block_info.mem_feat_info.proximity_domain);
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Patrol scrub support            : 0x%lx\n",
+                      "\n       Patrol scrub support            : 0x%lx",
                       curr_block->block_info.mem_feat_info.patrol_scrub_support);
         break;
     default:
         pal_print_msg(ACS_PRINT_INFO,
-                      "\n  Invalid RAS feature type : 0x%x",
+                      "\n       Invalid RAS feature type : 0x%x",
                       curr_block->type);
     }
     curr_block++;
@@ -466,7 +464,7 @@ VOID pal_ras2_fill_mem_pcct_info(
 
   if (ras2_pcc_shared_mem == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n No PCC subspace found for PCCT index : 0x%x",
+                    "\n       No PCC subspace found for PCCT index : 0x%x",
                     pcct_array_idx);
       return;
   }
@@ -494,7 +492,7 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
 
   if (RasFeatInfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "\n Input RAS Table Pointer is NULL");
+                    "\n       Input RAS Table Pointer is NULL");
       return;
   }
 
@@ -505,7 +503,7 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
   ras2 = (RAS_FEATURE_2_TABLE_HEADER *)pal_get_acpi_table_ptr(EFI_ACPI_6_5_RAS2_FEATURE_TABLE_SIGNATURE);
   if (ras2 == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " RAS2 ACPI table not found\n");
+                    "\n       RAS2 ACPI table not found");
       return;
   }
 
@@ -513,7 +511,7 @@ pal_ras2_create_info_table(RAS2_INFO_TABLE *RasFeatInfoTable)
           pal_get_acpi_table_ptr(EFI_ACPI_6_4_PLATFORM_COMMUNICATIONS_CHANNEL_TABLE_SIGNATURE);
   if (pcct == NULL) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " PCCT ACPI table not found\n");
+                    "\n       PCCT ACPI table not found");
       return;
   }
   /* pointer to the start of RAS2 PCC descriptor array */

--- a/pal/uefi_acpi/src/pal_timer_wd.c
+++ b/pal/uefi_acpi/src/pal_timer_wd.c
@@ -43,7 +43,7 @@ pal_get_platform_time_us (
 
   Status = gRT->GetTime(&Time, NULL);
   if (EFI_ERROR(Status)) {
-    pal_print_msg(ACS_PRINT_WARN, " GetTime failed: %x\n", Status);
+    pal_print_msg(ACS_PRINT_WARN, "\n       GetTime failed: %x", Status);
     return ~0ULL;
   }
 
@@ -98,7 +98,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
 
   if (TimerTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
+                  "\n       Input Timer Table Pointer is NULL. Cannot create Timer INFO");
     return;
   }
 
@@ -109,18 +109,18 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
 
   if (gGtdtHdr == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " GTDT not found\n");
+                  "\n       GTDT not found");
     return;
   }
   gtdt_ptr = (UINT8 *)gGtdtHdr;
   pal_print_msg(ACS_PRINT_INFO,
-                "  GTDT is at %x and length is %x\n",
+                "\n       GTDT is at %x and length is %x",
                 gGtdtHdr,
                 gGtdtHdr->Header.Length);
 
   revision = gGtdtHdr->Header.Revision;
   pal_print_msg(ACS_PRINT_INFO,
-                "  GTDT revision is at %d\n",
+                "\n       GTDT revision is at %d",
                 revision);
 
   //Fill in our internal table
@@ -145,18 +145,18 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
 
     if (Entry->Type == EFI_ACPI_6_1_GTDT_GT_BLOCK) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Found block entry\n");
+                    "\n       Found block entry");
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  CNTCTLBase = %llx\n",
+                    "\n       CNTCTLBase = %llx",
                     GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)
                         (((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
         pal_print_msg(ACS_PRINT_INFO,
-                      "  Found timer entry\n");
+                      "\n       Found timer entry");
         GtEntry->frame_num[i]    = GtBlockTimer->GTFrameNumber;
         GtEntry->GtCntBase[i]    = GtBlockTimer->CntBaseX;
         GtEntry->GtCntEl0Base[i] = GtBlockTimer->CntEL0BaseX;
@@ -166,7 +166,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
                                    (GtBlockTimer->GTxVirtualTimerFlags << 8) |
                                    (GtBlockTimer->GTxCommonFlags << 16);
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  CNTBaseN = %llx for sys counter = %d\n",
+                      "\n       CNTBaseN = %llx for sys counter = %d",
                       GtEntry->GtCntBase[i],
                       i);
         GtBlockTimer++;
@@ -193,7 +193,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
       }
       if (TimerTable->header.el2_virt_timer_gsiv == 0)
          pal_print_msg(ACS_PRINT_DEBUG,
-                       "  GTDT don't have el2 virt timer info\n");
+                       "\n       GTDT don't have el2 virt timer info");
   }
   else
       pal_timer_platform_override(TimerTable);
@@ -242,7 +242,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
 
   if (WdTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
+                  "\n       Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO");
     return;
   }
 
@@ -252,7 +252,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
 
   if (gGtdtHdr == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " GTDT not found\n");
+                  "\n       GTDT not found");
     return;
   }
 
@@ -276,7 +276,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Watchdog base = 0x%llx INTID = 0x%x\n",
+                    "\n       Watchdog base = 0x%llx INTID = 0x%x",
                     WdEntry->wd_ctrl_base,
                     WdEntry->wd_gsiv);
       WdEntry++;

--- a/pal/uefi_acpi/src/pal_tpm2.c
+++ b/pal/uefi_acpi/src/pal_tpm2.c
@@ -50,7 +50,7 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
 
   if (Tpm2InfoTable == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " TPM2 Info Table pointer is NULL. Cannot create TPM2 info.\n",
+                    "\n       TPM2 Info Table pointer is NULL. Cannot create TPM2 info.",
                     0);
       return;
   }
@@ -64,7 +64,7 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   Status = gBS->LocateProtocol(&gEfiTcg2ProtocolGuid, NULL, (VOID **)&Tcg2);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " TCG2 Protocol Not Found\n",
+                    "\n       TCG2 Protocol Not Found",
                     0);
       status_flag = 1;
   }
@@ -73,7 +73,7 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   gtpm2ptr = (EFI_TPM2_ACPI_TABLE *)pal_get_tpm2_ptr();
   if (gtpm2ptr == NULL) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " TPM2 ACPI Table not found\n",
+                    "\n       TPM2 ACPI Table not found",
                     0);
       status_flag = 1;
   }
@@ -87,7 +87,7 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
   Status = Tcg2->GetCapability(Tcg2, &Capability);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Failed to retrieve TPM capability from TCG2 protocol, Status: 0x%x\n",
+                    "\n       Failed to retrieve TPM capability from TCG2 protocol, Status: 0x%x",
                     Status);
       return;
   }
@@ -102,13 +102,13 @@ pal_tpm2_create_info_table(TPM2_INFO_TABLE * Tpm2InfoTable)
 
   /* Log TPM presence and configuration */
   pal_print_msg(ACS_PRINT_INFO,
-                " TPM2 Protocol Present\n",
+                "\n       TPM2 Protocol Present",
                 0);
   pal_print_msg(ACS_PRINT_TEST,
-                " TPM2 Interface Type (StartMethod): %llx\n",
+                "\n       TPM2 Interface Type (StartMethod): %llx",
                 Tpm2InfoTable->tpm_interface);
   pal_print_msg(ACS_PRINT_TEST,
-                " TPM2 Base Address: %llx\n",
+                "\n       TPM2 Base Address: %llx",
                 Tpm2InfoTable->base);
 
 
@@ -143,7 +143,7 @@ pal_tpm2_get_version()
   Status = gBS->LocateProtocol(&gEfiTcg2ProtocolGuid, NULL, (VOID **)&Tcg2);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "       TCG2 Protocol Not Found\n",
+                    "\n       TCG2 Protocol Not Found",
                     0);
       return Status;
   }
@@ -152,7 +152,7 @@ pal_tpm2_get_version()
   Status = gBS->AllocatePool(EfiBootServicesData, TempBufferSize, (VOID **)&TempBuffer);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "       Failed to allocate memory for TPM capability data.\n",
+                    "\n       Failed to allocate memory for TPM capability data.",
                     0);
       return Status;
   }
@@ -178,7 +178,7 @@ pal_tpm2_get_version()
 
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "       TPM2 command submission failed\n",
+                    "\n       TPM2 command submission failed",
                     0);
       return Status;
   }
@@ -186,7 +186,7 @@ pal_tpm2_get_version()
   /* Check response status */
   if (SwapBytes32 (RecvBuffer.Header.responseCode) != TPM_RC_SUCCESS) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "       Tpm2GetCapability failed: Response Code error! 0x%08x\n",
+                    "\n       Tpm2GetCapability failed: Response Code error! 0x%08x",
                     SwapBytes32 (RecvBuffer.Header.responseCode));
       return Status;
   }
@@ -198,7 +198,7 @@ pal_tpm2_get_version()
 
   PropertyCount = SwapBytes32(cap_data->data.tpmProperties.count);
   pal_print_msg(ACS_PRINT_INFO,
-                "      TPM Property Count: %d\n",
+                "\n       TPM Property Count: %d",
                 PropertyCount);
 
   /* Search for TPM_PT_FAMILY_INDICATOR */
@@ -207,10 +207,10 @@ pal_tpm2_get_version()
       UINT32 PropertyVal = cap_data->data.tpmProperties.tpmProperty[i].value;
 
       pal_print_msg(ACS_PRINT_INFO,
-                    "       TPM Property ID   : 0x%08x\n",
+                    "\n       TPM Property ID   : 0x%08x",
                     PropertyId);
       pal_print_msg(ACS_PRINT_INFO,
-                    "       TPM Property Value: 0x%08x\n",
+                    "\n       TPM Property Value: 0x%08x",
                     PropertyVal);
 
 
@@ -220,7 +220,7 @@ pal_tpm2_get_version()
           CopyMem(family, &PropertyVal, 4);
           family[4] = '\0';
           pal_print_msg(ACS_PRINT_TEST,
-                        "       TPM Family: %a\n",
+                        "\n       TPM Family: %a",
                         family);
 
           FreePool(TempBuffer);

--- a/pal/uefi_dt/src/pal_acpi.c
+++ b/pal/uefi_dt/src/pal_acpi.c
@@ -91,7 +91,7 @@ pal_get_madt_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_INFO,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -126,7 +126,7 @@ pal_get_gtdt_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_INFO,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -160,7 +160,7 @@ pal_get_mcfg_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_INFO,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 
@@ -226,7 +226,7 @@ pal_get_iort_ptr()
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *) pal_get_xsdt_ptr();
   if (Xsdt == NULL) {
       pal_print_msg(ACS_PRINT_INFO,
-                    " XSDT not found\n");
+                    "\n       XSDT not found");
       return 0;
   }
 

--- a/pal/uefi_dt/src/pal_dt.c
+++ b/pal/uefi_dt/src/pal_dt.c
@@ -50,12 +50,12 @@ pal_target_is_dt()
   Status = gBS->LocateProtocol (&gHardwareInterruptProtocolGuid, NULL, (VOID **)&Interrupt);
   if (EFI_ERROR(Status)) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Using ACS interrupt API's\n");
+                    "\n       Using ACS interrupt API's");
       return 1; /* Not able to locate HW Interrupt Protocol, use ACS interrupt handlers API */
   }
   else {
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Using F/W interrupt API's\n");
+                    "\n       Using F/W interrupt API's");
       return 0; /* Use F/W interrupt handlers */
   }
 }
@@ -77,7 +77,7 @@ pal_get_dt_ptr()
     if (CompareGuid (&gFdtTableGuid, &(gST->ConfigurationTable[Index].VendorGuid))) {
       DTB = gST->ConfigurationTable[Index].VendorTable;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Platform DTB PTR %x\n",
+                    "\n       Platform DTB PTR %x",
                     DTB);
       break;
     }
@@ -85,13 +85,13 @@ pal_get_dt_ptr()
 
   if (!DTB) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " DTB not present in platform\n");
+                  "\n       DTB not present in platform");
     return 0; //No fdt blob addr found
   }
 
   if (fdt_check_header(DTB)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " fdt hdr check failed\n");
+                  "\n       fdt hdr check failed");
     return 0;
   }
 
@@ -151,7 +151,7 @@ int fdt_interrupt_cells(const void *fdt, int nodeoffset)
 
   if (nodeoffset < 0) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  No interrupt cell found\n");
+                    "\n       No interrupt cell found");
       return 3; /* default value 3*/
   }
 
@@ -206,12 +206,12 @@ pal_dump_dtb()
     BufferSize = fdt_totalsize(dtb);
     if (!BufferSize) {
         pal_print_msg(ACS_PRINT_ERR,
-                      " dtb size 0\n");
+                      "\n       dtb size 0");
         return;
     }
     Status = ShellWriteFile(g_dtb_log_file_handle, &BufferSize, (VOID *)dtb);
     if (EFI_ERROR(Status))
       pal_print_msg(ACS_PRINT_ERR,
-                    " Error in writing to dtb log file\n");
+                    "\n       Error in writing to dtb log file");
   }
 }

--- a/pal/uefi_dt/src/pal_dt_debug.c
+++ b/pal/uefi_dt/src/pal_dt_debug.c
@@ -34,36 +34,36 @@ dt_dump_pe_table(PE_INFO_TABLE *PeTable)
 
   if (!PeTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " PeTable ptr NULL\n");
+                  "\n       PeTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************PE TABLE DUMP************\n");
+                "\n       ************PE TABLE DUMP************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " NUM PE %d\n",
+                "\n       NUM PE %d",
                 PeTable->header.num_of_pe);
 
   while (Index < PeTable->header.num_of_pe) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " PE NUM      :%x\n",
+                  "\n       PE NUM      :%x",
                   PeTable->pe_info[Index].pe_num);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " MPIDR       :%llx\n",
+                  "\n       MPIDR       :%llx",
                   PeTable->pe_info[Index].mpidr);
 //    pal_print_msg(ACS_PRINT_DEBUG,
 //                  "    ATTR     :%x\n",
 //                  PeTable->pe_info[Index].attr);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " PMU GSIV    :%x\n",
+                  "\n       PMU GSIV    :%x",
                   PeTable->pe_info[Index].pmu_gsiv);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GIC MAINT GSIV    :%x\n",
+                  "\n       GIC MAINT GSIV    :%x",
                   PeTable->pe_info[Index].gmain_gsiv);
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }
 
 /**
@@ -80,23 +80,23 @@ dt_dump_gic_table(GIC_INFO_TABLE *GicTable)
 
   if (!GicTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " GicTable ptr NULL\n");
+                  "\n       GicTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************GIC TABLE************\n");
+                "\n       ************GIC TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " GIC version %d\n",
+                "\n       GIC version %d",
                 GicTable->header.gic_version);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " GIC num D %d\n",
+                "\n       GIC num D %d",
                 GicTable->header.num_gicd);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " GIC num GICC RD %d\n",
+                "\n       GIC num GICC RD %d",
                 GicTable->header.num_gicc_rd);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " GIC num GICR RD %d\n",
+                "\n       GIC num GICR RD %d",
                 GicTable->header.num_gicr_rd);
 //  pal_print_msg(ACS_PRINT_DEBUG,
 //                " GIC num ITS %d\n",
@@ -104,13 +104,13 @@ dt_dump_gic_table(GIC_INFO_TABLE *GicTable)
 
   while (GicTable->gic_info[Index].type != 0xFF) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GIC TYPE     :%x\n",
+                  "\n       GIC TYPE     :%x",
                   GicTable->gic_info[Index].type);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " BASE         :%x\n",
+                  "\n       BASE         :%x",
                   GicTable->gic_info[Index].base);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " LEN          :%x\n",
+                  "\n       LEN          :%x",
                   GicTable->gic_info[Index].length);
 //    pal_print_msg(ACS_PRINT_DEBUG,
 //                  "     ITS ID   :%x\n",
@@ -118,7 +118,7 @@ dt_dump_gic_table(GIC_INFO_TABLE *GicTable)
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }
 
 /**
@@ -135,33 +135,33 @@ dt_dump_wd_table(WD_INFO_TABLE *WdTable)
 
   if (!WdTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " WdTable ptr NULL\n");
+                  "\n       WdTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************WD TABLE************\n");
+                "\n       ************WD TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " NUM WD %d\n",
+                "\n       NUM WD %d",
                 WdTable->header.num_wd);
 
   while (Index < WdTable->header.num_wd) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " REFRESH BASE  :%x\n",
+                  "\n       REFRESH BASE  :%x",
                   WdTable->wd_info[Index].wd_refresh_base);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " CONTROL BASE  :%x\n",
+                  "\n       CONTROL BASE  :%x",
                   WdTable->wd_info[Index].wd_ctrl_base);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GSIV          :%x\n",
+                  "\n       GSIV          :%x",
                   WdTable->wd_info[Index].wd_gsiv);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " FLAGS         :%x\n",
+                  "\n       FLAGS         :%x",
                   WdTable->wd_info[Index].wd_flags);
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }
 
 /**
@@ -179,25 +179,25 @@ dt_dump_pcie_table(PCIE_INFO_TABLE *PcieTable)
 
   if (!PcieTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " PcieTable ptr NULL\n");
+                  "\n       PcieTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************PCIE TABLE************\n");
+                "\n       ************PCIE TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " NUM ECAM %d\n",
+                "\n       NUM ECAM %d",
                 PcieTable->num_entries);
 
   while (Index < PcieTable->num_entries) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " ECAM BASE          :%x\n",
+                  "\n       ECAM BASE          :%x",
                   PcieTable->block[Index].ecam_base);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " START BUS          :%x\n",
+                  "\n       START BUS          :%x",
                   PcieTable->block[Index].start_bus_num);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " END BUS            :%x\n",
+                  "\n       END BUS            :%x",
                   PcieTable->block[Index].end_bus_num);
 //    pal_print_msg(ACS_PRINT_DEBUG,
 //                  "      SEGMENT NUM   :%x\n",
@@ -205,7 +205,7 @@ dt_dump_pcie_table(PCIE_INFO_TABLE *PcieTable)
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }
 
 /**
@@ -222,39 +222,39 @@ dt_dump_memory_table(MEMORY_INFO_TABLE *memoryInfoTable)
 
   if (!memoryInfoTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " memoryInfoTable ptr NULL\n");
+                  "\n       memoryInfoTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************MEMORY TABLE************\n");
+                "\n       ************MEMORY TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " dram base  :%x\n",
+                "\n       dram base  :%x",
                 memoryInfoTable->dram_base);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " dram size  :%x\n",
+                "\n       dram size  :%x",
                 memoryInfoTable->dram_size);
 
   while (memoryInfoTable->info[Index].type < 0x1004) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " Type      :%x\n",
+                  "\n       Type      :%x",
                   memoryInfoTable->info[Index].type);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " PHY addr  :%x\n",
+                  "\n       PHY addr  :%x",
                   memoryInfoTable->info[Index].phy_addr);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " VIRT addr :%x\n",
+                  "\n       VIRT addr :%x",
                   memoryInfoTable->info[Index].virt_addr);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " size      :%x\n",
+                  "\n       size      :%x",
                   memoryInfoTable->info[Index].size);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " flags     :%x\n",
+                  "\n       flags     :%x",
                   memoryInfoTable->info[Index].flags);
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }
 
 /**
@@ -271,72 +271,72 @@ dt_dump_timer_table(TIMER_INFO_TABLE *TimerTable)
 
   if (!TimerTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " TimerTable ptr NULL\n");
+                  "\n       TimerTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************TIMER TABLE************\n");
+                "\n       ************TIMER TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " Num of system timers %d\n",
+                "\n       Num of system timers %d",
                 TimerTable->header.num_platform_timer);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " s_el1_timer_flag %x\n",
+                "\n       s_el1_timer_flag %x",
                 TimerTable->header.s_el1_timer_flag);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ns_el1_timer_flag %x\n",
+                "\n       ns_el1_timer_flag %x",
                 TimerTable->header.ns_el1_timer_flag);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " el2_timer_flag %x\n",
+                "\n       el2_timer_flag %x",
                 TimerTable->header.el2_timer_flag);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " el2_virt_timer_flag %x\n",
+                "\n       el2_virt_timer_flag %x",
                 TimerTable->header.el2_virt_timer_flag);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " s_el1_timer_gsiv %x\n",
+                "\n       s_el1_timer_gsiv %x",
                 TimerTable->header.s_el1_timer_gsiv);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ns_el1_timer_gsiv %x\n",
+                "\n       ns_el1_timer_gsiv %x",
                 TimerTable->header.ns_el1_timer_gsiv);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " el2_timer_gsiv %x\n",
+                "\n       el2_timer_gsiv %x",
                 TimerTable->header.el2_timer_gsiv);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " virtual_timer_flag %x\n",
+                "\n       virtual_timer_flag %x",
                 TimerTable->header.virtual_timer_flag);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " virtual_timer_gsiv %x\n",
+                "\n       virtual_timer_gsiv %x",
                 TimerTable->header.virtual_timer_gsiv);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " el2_virt_timer_gsiv %x\n",
+                "\n       el2_virt_timer_gsiv %x",
                 TimerTable->header.el2_virt_timer_gsiv);
   pal_print_msg(ACS_PRINT_DEBUG,
-                " CNTBase             %x\n",
+                "\n       CNTBase             %x",
                 TimerTable->gt_info->block_cntl_base);
 
   while (Index < TimerTable->gt_info->timer_count) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " Frame num   :%x\n",
+                  "\n       Frame num   :%x",
                   TimerTable->gt_info->frame_num[Index]);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GtCntBase   :%x\n",
+                  "\n       GtCntBase   :%x",
                   TimerTable->gt_info->GtCntBase[Index]);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GtCntEl0Base:%x\n",
+                  "\n       GtCntEl0Base:%x",
                   TimerTable->gt_info->GtCntEl0Base[Index]);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " gsiv        :%x\n",
+                  "\n       gsiv        :%x",
                   TimerTable->gt_info->gsiv[Index]);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " virt_gsiv   :%x\n",
+                  "\n       virt_gsiv   :%x",
                   TimerTable->gt_info->virt_gsiv[Index]);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " flags       :%x\n",
+                  "\n       flags       :%x",
                   TimerTable->gt_info->flags[Index]);
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }
 
 /**
@@ -353,82 +353,82 @@ dt_dump_peripheral_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
 
   if (!peripheralInfoTable) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " peripheralInfoTable ptr NULL\n");
+                  "\n       peripheralInfoTable ptr NULL");
     return;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************USB TABLE************\n");
+                "\n       ************USB TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " NUM USB %d\n",
+                "\n       NUM USB %d",
                 peripheralInfoTable->header.num_usb);
 
   while (Index < peripheralInfoTable->header.num_usb) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " TYPE          :%x\n",
+                  "\n       TYPE          :%x",
                   peripheralInfoTable->info[Index].type);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " CONTROL BASE  :%x\n",
+                  "\n       CONTROL BASE  :%x",
                   peripheralInfoTable->info[Index].base0);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GSIV          :%d\n",
+                  "\n       GSIV          :%d",
                   peripheralInfoTable->info[Index].irq);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " FLAGS         :%x\n",
+                  "\n       FLAGS         :%x",
                   peripheralInfoTable->info[Index].flags);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " BDF           :%x\n",
+                  "\n       BDF           :%x",
                   peripheralInfoTable->info[Index].bdf);
     Index++;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************SATA TABLE************\n");
+                "\n       ************SATA TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " NUM SATA %d\n",
+                "\n       NUM SATA %d",
                 peripheralInfoTable->header.num_sata);
 
   while (Index < (peripheralInfoTable->header.num_sata + peripheralInfoTable->header.num_usb)) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " TYPE          :%x\n",
+                  "\n       TYPE          :%x",
                   peripheralInfoTable->info[Index].type);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " CONTROL BASE  :%x\n",
+                  "\n       CONTROL BASE  :%x",
                   peripheralInfoTable->info[Index].base0);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GSIV          :%d\n",
+                  "\n       GSIV          :%d",
                   peripheralInfoTable->info[Index].irq);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " FLAGS         :%x\n",
+                  "\n       FLAGS         :%x",
                   peripheralInfoTable->info[Index].flags);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " BDF           :%x\n",
+                  "\n       BDF           :%x",
                   peripheralInfoTable->info[Index].bdf);
     Index++;
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                " ************UART TABLE************\n");
+                "\n       ************UART TABLE************");
   pal_print_msg(ACS_PRINT_DEBUG,
-                " NUM UART %d\n",
+                "\n       NUM UART %d",
                 peripheralInfoTable->header.num_uart);
 
   while (Index < (peripheralInfoTable->header.num_sata + peripheralInfoTable->header.num_usb +
       peripheralInfoTable->header.num_uart)) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " TYPE          :%x\n",
+                  "\n       TYPE          :%x",
                   peripheralInfoTable->info[Index].type);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " CONTROL BASE  :%x\n",
+                  "\n       CONTROL BASE  :%x",
                   peripheralInfoTable->info[Index].base0);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " GSIV          :%d\n",
+                  "\n       GSIV          :%d",
                   peripheralInfoTable->info[Index].irq);
     pal_print_msg(ACS_PRINT_DEBUG,
-                  " FLAGS         :%x\n",
+                  "\n       FLAGS         :%x",
                   peripheralInfoTable->info[Index].flags);
     Index++;
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " *************************************\n");
+                "\n       *************************************");
 }

--- a/pal/uefi_dt/src/pal_gic.c
+++ b/pal/uefi_dt/src/pal_gic.c
@@ -86,7 +86,7 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -96,13 +96,13 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv3_dt_arr[i]);
       if (offset < 0) {
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  GICv3 compatible value not found for index : %d\n",
+                      "\n       GICv3 compatible value not found for index : %d",
                       i);
         continue; /* Search for next compatible item*/
       }
       else {
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  GIC_V3: NODE Int Ctrl offset  %x\n",
+                      "\n       GIC_V3: NODE Int Ctrl offset  %x",
                       offset);
         break;
       }
@@ -114,13 +114,13 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv2_dt_arr[i]);
           if (offset < 0) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  GICv2 compatible value not found for index : %d\n",
+                            "\n       GICv2 compatible value not found for index : %d",
                             i);
               continue; /* Search for next compatible item*/
           }
           else {
             pal_print_msg(ACS_PRINT_DEBUG,
-                          "  GIC_V2: NODE Int Ctrl offset  %x\n",
+                          "\n       GIC_V2: NODE Int Ctrl offset  %x",
                           offset);
             break;
           }
@@ -129,7 +129,7 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
 
   if (offset < 0) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  GIC compatible node not found\n");
+                    "\n       GIC compatible node not found");
       return;
   }
 
@@ -137,18 +137,18 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
   Pintr = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
   if ((prop_len < 0) || (Pintr == NULL)) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  PROPERTY interrupts read Error %d\n",
+                    "\n       PROPERTY interrupts read Error %d",
                     prop_len);
       return;
   }
 
   interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  interrupt_cell  %d\n",
+                "\n       interrupt_cell  %d",
                 interrupt_cell);
   if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid interrupt cell : %d\n",
+                    "\n       Invalid interrupt cell : %d",
                     interrupt_cell);
       return;
   }
@@ -159,7 +159,7 @@ pal_pe_info_table_gmaint_gsiv_dt(PE_INFO_TABLE *PeTable)
               Ptr->gmain_gsiv = fdt32_to_cpu(Pintr[1]) + PPI_OFFSET;
           else
               pal_print_msg(ACS_PRINT_WARN,
-                            "  Int is not PPI\n",
+                            "\n       Int is not PPI",
                             0);
       }
       else
@@ -186,7 +186,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
 
   if (GicTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input GIC Table Pointer is NULL. Cannot create GIC INFO\n");
+                  "\n       Input GIC Table Pointer is NULL. Cannot create GIC INFO");
     return;
   }
 
@@ -207,7 +207,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
   if (gMadtHdr != NULL) {
     TableLength =  gMadtHdr->Header.Length;
     pal_print_msg(ACS_PRINT_INFO,
-                  "  MADT is at %x and length is %x\n",
+                  "\n       MADT is at %x and length is %x",
                   gMadtHdr,
                   TableLength);
   }
@@ -223,7 +223,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->type = ENTRY_TYPE_CPUIF;
         GicEntry->base = Entry->PhysicalBaseAddress;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC CPUIF base %x\n",
+                      "\n       GIC CPUIF base %x",
                       GicEntry->base);
         GicEntry++;
       }
@@ -233,7 +233,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = Entry->GICRBaseAddress;
         GicEntry->length = 0;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GICC RD base %x\n",
+                      "\n       GICC RD base %x",
                       GicEntry->base);
         GicTable->header.num_gicc_rd++;
         GicEntry++;
@@ -244,7 +244,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = Entry->GICH;
         GicEntry->length = 0;
         pal_print_msg(ACS_PRINT_INFO,
-                      " GICH base %x\n",
+                      "\n       GICH base %x",
                       GicEntry->base);
         GicEntry++;
       }
@@ -255,7 +255,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicTable->header.gic_version = ((EFI_ACPI_6_1_GIC_DISTRIBUTOR_STRUCTURE *)Entry)->GicVersion;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC DIS base %x\n",
+                      "\n       GIC DIS base %x",
                       GicEntry->base);
         GicTable->header.num_gicd++;
         GicEntry++;
@@ -266,7 +266,7 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeBaseAddress;
         GicEntry->length = ((EFI_ACPI_6_1_GICR_STRUCTURE *)Entry)->DiscoveryRangeLength;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GICR RD base %x\n",
+                      "\n       GICR RD base %x",
                       GicEntry->base);
         GicTable->header.num_gicr_rd++;
         GicEntry++;
@@ -277,10 +277,10 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->base = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->PhysicalBaseAddress;
         GicEntry->entry_id = ((EFI_ACPI_6_1_GIC_ITS_STRUCTURE *)Entry)->GicItsId;
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC ITS base %x\n",
+                      "\n       GIC ITS base %x",
                       GicEntry->base);
         pal_print_msg(ACS_PRINT_INFO,
-                      "  GIC ITS ID%x\n",
+                      "\n       GIC ITS ID%x",
                       GicEntry->entry_id);
         GicTable->header.num_its++;
         GicEntry++;
@@ -294,13 +294,13 @@ pal_gic_create_info_table(GIC_INFO_TABLE *GicTable)
         GicEntry->spi_count = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPICount;
         GicEntry->spi_base = ((EFI_ACPI_6_1_GIC_MSI_FRAME_STRUCTURE *)Entry)->SPIBase;
         pal_print_msg(ACS_PRINT_INFO,
-                      " GIC MSI Frame base %x\n",
+                      "\n       GIC MSI Frame base %x",
                       GicEntry->base);
         pal_print_msg(ACS_PRINT_INFO,
-                      " GIC MSI SPI base %x\n",
+                      "\n       GIC MSI SPI base %x",
                       GicEntry->spi_base);
         pal_print_msg(ACS_PRINT_INFO,
-                      " GIC MSI SPI Count %x\n",
+                      "\n       GIC MSI SPI Count %x",
                       GicEntry->spi_count);
         GicTable->header.num_msi_frame++;
         GicEntry++;
@@ -415,7 +415,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -427,13 +427,13 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv3_dt_arr[i]);
       if (offset < 0) {
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  GICv3 compatible value not found for index : %d\n",
+                      "\n       GICv3 compatible value not found for index : %d",
                       i);
         continue; /* Search for next compatible item*/
       }
       else {
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  NODE Int Ctrl offset  %x\n",
+                      "\n       NODE Int Ctrl offset  %x",
                       offset);
         GicTable->header.gic_version = 3;
         break;
@@ -442,19 +442,19 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
   if (offset < 0) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  GIC v3 compatible node not found\n");
+                    "\n       GIC v3 compatible node not found");
       for (i = 0; i < (sizeof(gicv2_dt_arr)/GIC_COMPATIBLE_STR_LEN); i++) {
           /* Search for GICv2 nodes*/
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv2_dt_arr[i]);
           if (offset < 0) {
             pal_print_msg(ACS_PRINT_DEBUG,
-                          "  GICv2 compatible value not found for index : %d\n",
+                          "\n       GICv2 compatible value not found for index : %d",
                           i);
             continue; /* Search for next compatible item*/
           }
           else {
             pal_print_msg(ACS_PRINT_DEBUG,
-                          "  NODE Int Ctrl offset  %x\n",
+                          "\n       NODE Int Ctrl offset  %x",
                           offset);
             GicTable->header.gic_version = 2;
             break;
@@ -464,7 +464,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
   if (offset < 0) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  GIC v2 compatible node not found\n");
+                    "\n       GIC v2 compatible node not found");
       return;
   }
 
@@ -473,21 +473,21 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
   size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  NODE gic size cell %d\n",
+                "\n       NODE gic size cell %d",
                 size_cell);
   if (size_cell < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid size cell for node gic\n");
+                    "\n       Invalid size cell for node gic");
       return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  NODE gic addr cell %d\n",
+                "\n       NODE gic addr cell %d",
                 addr_cell);
   if (addr_cell < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid address cell for node gic\n");
+                    "\n       Invalid address cell for node gic");
       return;
   }
 
@@ -495,7 +495,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
   Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
   if ((prop_len < 0) || (Preg_val == NULL)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  PROPERTY reg offset %x, Error %d\n",
+                    "\n       PROPERTY reg offset %x, Error %d",
                     offset,
                     prop_len);
       return;
@@ -503,7 +503,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
   num_gic_interfaces = (prop_len/sizeof(int))/(addr_cell + size_cell);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  Gic frame count : %d\n",
+                "\n       Gic frame count : %d",
                 num_gic_interfaces);
 
   /* Fill details for Distributor */
@@ -521,7 +521,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
     GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  GIC DIS base %lx\n",
+                "\n       GIC DIS base %lx",
                 GicEntry->base);
   GicTable->header.num_gicd++;
   GicEntry++;
@@ -532,13 +532,13 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
                                     "redistributor-regions", 21, &prop_len);
       if (prop_len < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  Single redistributor regions present\n");
+                        "\n       Single redistributor regions present");
           num_of_rd = 1;
       } else
           num_of_rd = fdt32_to_cpu(Prdregions_val[0]);
 
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NUM GIC RD %d\n",
+                    "\n       NUM GIC RD %d",
                     num_of_rd);
       i = num_of_rd;
       /* Fill details for Redistributor */
@@ -557,7 +557,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
               GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  GICR RD base %lx\n",
+                        "\n       GICR RD base %lx",
                         GicEntry->base);
           GicTable->header.num_gicr_rd++;
           GicEntry++;
@@ -580,7 +580,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
       num_of_pe = pal_pe_get_num();
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  GIC CPUIF base %lx\n",
+                    "\n       GIC CPUIF base %lx",
                     cpuif_base);
       while (num_of_pe--) {
           GicEntry->type = ENTRY_TYPE_CPUIF;
@@ -590,18 +590,18 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       }
   } else
     pal_print_msg(ACS_PRINT_WARN,
-                  "  GIC CPUIF not present\n");
+                  "\n       GIC CPUIF not present");
 
   pal_print_msg(ACS_PRINT_INFO,
-                "  Number of gic interface %d\n",
+                "\n       Number of gic interface %d",
                 num_gic_interfaces);
   pal_print_msg(ACS_PRINT_INFO,
-                "  Number of RD %d\n",
+                "\n       Number of RD %d",
                 num_of_rd);
 
   num_gic_interfaces -= (num_of_rd + 1);
   pal_print_msg(ACS_PRINT_INFO,
-                "  Number of gic interface %d\n",
+                "\n       Number of gic interface %d",
                 num_gic_interfaces);
 
   if (GicTable->header.gic_version == 2) { /* parse v2m frame if present */
@@ -620,7 +620,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           } else
             GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  GICH base %x\n",
+                        "\n       GICH base %x",
                         GicEntry->base);
           GicEntry++;
       }
@@ -629,7 +629,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, gicv2m_frame_dt_arr[0]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  No v2m-frame present\n",
+                        "\n       No v2m-frame present",
                         0);
           GicEntry->type = 0xFF;
           return;
@@ -640,34 +640,34 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE gic size cell %d\n",
+                    "\n       NODE gic size cell %d",
                     size_cell);
       if (size_cell < 0) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell for node gic\n");
+                        "\n       Invalid size cell for node gic");
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE gic addr cell %d\n",
+                    "\n       NODE gic addr cell %d",
                     addr_cell);
       if (addr_cell < 0) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell for node gic\n");
+                        "\n       Invalid address cell for node gic");
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  NODE v2m frame offset %x\n",
+                        "\n       NODE v2m frame offset %x",
                         offset);
           Index = 0;
           /* read the reg property value */
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY reg offset %x, Error %d\n",
+                            "\n       PROPERTY reg offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -690,7 +690,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
              GicEntry->length = fdt32_to_cpu(Preg_val[Index++]);
 
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  GIC v2m frame base %x\n",
+                        "\n       GIC v2m frame base %x",
                         GicEntry->base);
 
           /* read the arm,msi-base-spi property value */
@@ -698,7 +698,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
                                                     &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  PROPERTY arm,msi-base-spi Error %d\n",
+                            "\n       PROPERTY arm,msi-base-spi Error %d",
                             prop_len);
               GicEntry->spi_base = 0;
           } else
@@ -709,7 +709,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
                                                     &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  PROPERTY arm,msi-num-spis Error %d\n",
+                            "\n       PROPERTY arm,msi-num-spis Error %d",
                             prop_len);
               GicEntry->spi_count = 0;
           } else
@@ -720,7 +720,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
                                                  gicv2m_frame_dt_arr[0]);
       }
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Num of v2m frame %x\n",
+                    "\n       Num of v2m frame %x",
                     GicTable->header.num_msi_frame);
   }
 
@@ -729,7 +729,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, its_dt_arr[0]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  No ITS present\n",
+                        "\n       No ITS present",
                         0);
           GicEntry->type = 0xFF;
           return;
@@ -739,7 +739,7 @@ pal_gic_create_info_table_dt(GIC_INFO_TABLE *GicTable)
           offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset, its_dt_arr[0]);
       }
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Num of ITS frame %x\n",
+                    "\n       Num of ITS frame %x",
                     GicTable->header.num_its);
   }
 

--- a/pal/uefi_dt/src/pal_iovirt.c
+++ b/pal/uefi_dt/src/pal_iovirt.c
@@ -78,7 +78,7 @@ dump_block(IOVIRT_BLOCK *block) {
   switch(block->type) {
       case IOVIRT_NODE_ITS_GROUP:
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n ITS Group:\n Num ITS:%d\n",
+                    "\n       ITS Group:\n   Num ITS:%d",
                     (*map).id[0]);
       for(i = 0; i < block->data.its_count; i++)
           pal_print_msg(ACS_PRINT_INFO,
@@ -89,45 +89,43 @@ dump_block(IOVIRT_BLOCK *block) {
       return;
       case IOVIRT_NODE_NAMED_COMPONENT:
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Named Component:\n Device Name:%a\n",
+                    "\n       Named Component:\n   Device Name:%a",
                     block->data.named_comp.name);
       break;
       case IOVIRT_NODE_PCI_ROOT_COMPLEX:
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n Root Complex:\n PCI segment number:%d\n",
+                    "\n       Root Complex:\n   PCI segment number:%d",
                     block->data.rc.segment);
       break;
       case IOVIRT_NODE_SMMU:
       case IOVIRT_NODE_SMMU_V3:
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n SMMU:\n Major Rev:%d\n Base Address:0x%llx\n",
+                    "\n       SMMU:\n       Major Rev:%d\n   Base Address:0x%llx",
                     block->data.smmu.arch_major_rev,
                     block->data.smmu.base);
       break;
       case IOVIRT_NODE_PMCG:
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n PMCG:\n Base:0x%x\n Overflow GSIV:0x%x\n Node Reference:0x%x\n",
+                    "\n       PMCG:\n       Base:0x%x\n   Overflow GSIV:0x%x\n   Node Reference:0x%x",
                     block->data.pmcg.base,
                     block->data.pmcg.overflow_gsiv,
                     block->data.pmcg.node_ref);
       break;
   }
   pal_print_msg(ACS_PRINT_INFO,
-                " Number of ID Mappings:%d\n",
+                "\n       Number of ID Mappings:%d",
                 block->num_data_map);
   for(i = 0; i < block->num_data_map; i++, map++) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n input_base:0x%x\n id_count:0x%x\n output_base:0x%x\n",
+                    "\n       input_base:0x%x\n   id_count:0x%x\n   output_base:0x%x",
                     (*map).map.input_base,
                     (*map).map.id_count,
                     (*map).map.output_base);
       pal_print_msg(ACS_PRINT_INFO,
-                    "\n output ref:0x%x\n",
+                    "\n       output ref:0x%x",
                     (*map).map.output_ref);
 
   }
-  pal_print_msg(ACS_PRINT_INFO,
-                "\n");
 }
 
 /**
@@ -163,7 +161,7 @@ dump_iort_table(IOVIRT_INFO_TABLE *iovirt)
   UINT32 i;
   IOVIRT_BLOCK *block = &iovirt->blocks[0];
   pal_print_msg(ACS_PRINT_INFO,
-                " Number of IOVIRT blocks = %d\n",
+                "\n       Number of IOVIRT blocks = %d",
                 iovirt->num_blocks);
   for(i = 0; i < iovirt->num_blocks; i++, block = IOVIRT_NEXT_BLOCK(block))
     dump_block(block);
@@ -224,7 +222,7 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
                key_block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_DEVID_OVERLAP_SHIFT);
                pal_print_msg(ACS_PRINT_INFO,
-                             "\n Overlapping device ids %x-%x and %x-%x\n",
+                             "\n       Overlapping device ids %x-%x and %x-%x",
                              key_start,
                              key_end,
                              start,
@@ -234,7 +232,7 @@ check_mapping_overlap(IOVIRT_INFO_TABLE *iovirt)
                key_block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                block->flags |= (1 << IOVIRT_FLAG_STRID_OVERLAP_SHIFT);
                pal_print_msg(ACS_PRINT_INFO,
-                             "\n Overlapping stream ids %x-%x and %x-%x\n",
+                             "\n       Overlapping stream ids %x-%x and %x-%x",
                              key_start,
                              key_end,
                              start,
@@ -302,7 +300,7 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
   VOID *node_data = &(iort_node->node_data[0]);
 
   pal_print_msg(ACS_PRINT_INFO,
-                " IORT node offset:%x, type: %d\n",
+                "\n       IORT node offset:%x, type: %d",
                 (UINT8 *)iort_node - (UINT8 *)iort,
                 iort_node->type);
 
@@ -358,7 +356,7 @@ iort_add_block(IORT_TABLE *iort, IORT_NODE *iort_node, IOVIRT_INFO_TABLE *IoVirt
       break;
     default:
        pal_print_msg(ACS_PRINT_ERR,
-                     " Invalid IORT node type\n");
+                     "\n       Invalid IORT node type");
        return (UINT32) -1;
   }
 
@@ -472,7 +470,7 @@ pal_iovirt_create_info_table(IOVIRT_INFO_TABLE *IoVirtTable)
   for (i = 0; i < iort->node_count; i++) {
     if (iort_node >= iort_end) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " Bad IORT table\n");
+                    "\n       Bad IORT table");
       return;
     }
     iort_add_block(iort, iort_node, IoVirtTable, &next_block);
@@ -581,7 +579,7 @@ pal_iovirt_get_rc_smmu_base (
                                                     (*map).map.id_count))
           {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  find RC block->data.smmu.base : %llx",
+                            "\n       find RC block->data.smmu.base : %llx",
                             block->data.smmu.base);
               return block->data.smmu.base;
           }
@@ -592,7 +590,7 @@ pal_iovirt_get_rc_smmu_base (
    * is not behind any SMMU. Return NULL pointer
    */
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  No SMMU found behind the RootComplex with segment :%d",
+                "\n       No SMMU found behind the RootComplex with segment :%d",
                 RcSegmentNum);
   return 0;
 
@@ -626,7 +624,7 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " dt_ptr is NULL\n");
+                  "\n       dt_ptr is NULL");
     return;
   }
 
@@ -650,34 +648,34 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Parent Node offset %d\n",
+                    "\n       Parent Node offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  size cell %d\n",
+                    "\n       size cell %d",
                     size_cell);
       if (size_cell < 1) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell :%d\n",
+                        "\n       Invalid size cell :%d",
                         size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  addr cell %d\n",
+                    "\n       addr cell %d",
                     addr_cell);
       if (addr_cell < 1) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell : %d\n",
+                        "\n       Invalid address cell : %d",
                         addr_cell);
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  SMMUv3 node:%d offset:%d\n",
+                        "\n       SMMUv3 node:%d offset:%d",
                         IoVirtTable->num_smmus,
                         offset);
 
@@ -686,11 +684,11 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
           Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
           if ((prop_len > 0) && (Pstatus != NULL)) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  Status field length %d\n",
+                            "\n       Status field length %d",
                             prop_len);
               if (pal_strncmp(Pstatus, "disabled", 9) == 0) {
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  SMMU instance is disabled\n");
+                                "\n       SMMU instance is disabled");
                   offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                           smmu3_dt_arr[i]);
                   continue;
@@ -700,7 +698,7 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY reg offset %x, Error %d\n",
+                            "\n       PROPERTY reg offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -736,34 +734,34 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Parent Node offset %d\n",
+                    "\n       Parent Node offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  size cell %d\n",
+                    "\n       size cell %d",
                     size_cell);
       if (size_cell < 1) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell :%d\n",
+                        "\n       Invalid size cell :%d",
                         size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  addr cell %d\n",
+                    "\n       addr cell %d",
                     addr_cell);
       if (addr_cell < 1) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell : %d\n",
+                        "\n       Invalid address cell : %d",
                         addr_cell);
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  SMMUv2 node:%d offset:%d\n",
+                        "\n       SMMUv2 node:%d offset:%d",
                         IoVirtTable->num_smmus,
                         offset);
 
@@ -772,11 +770,11 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
           Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
           if ((prop_len > 0) && (Pstatus != NULL)) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  Status field length %d\n",
+                            "\n       Status field length %d",
                             prop_len);
               if (pal_strncmp(Pstatus, "disabled", 9) == 0) {
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  SMMU instance is disabled\n");
+                                "\n       SMMU instance is disabled");
                   offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                           smmu3_dt_arr[i]);
                   continue;
@@ -786,7 +784,7 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY reg offset %x, Error %d\n",
+                            "\n       PROPERTY reg offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -817,40 +815,40 @@ pal_iovirt_create_info_table_dt(IOVIRT_INFO_TABLE *IoVirtTable)
   offset = fdt_node_offset_by_prop_value((const void *) dt_ptr, -1, "device_type", "pci", 4);
   if (offset < 0) {
     pal_print_msg(ACS_PRINT_DEBUG,
-                  "  PCIE node not found %d\n",
+                  "\n       PCIE node not found %d",
                   offset);
     return;
   }
 
   parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  NODE pcie offset %d\n",
+                "\n       NODE pcie offset %d",
                 offset);
 
   size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  NODE pcie size cell %d\n",
+                "\n       NODE pcie size cell %d",
                 size_cell);
   if (size_cell < 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "  Invalid size cell\n");
+                  "\n       Invalid size cell");
     return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  NODE pcie addr cell %d\n",
+                "\n       NODE pcie addr cell %d",
                 addr_cell);
   if (addr_cell <= 0 || addr_cell > 2) {
     pal_print_msg(ACS_PRINT_ERR,
-                  "  Invalid address cell\n");
+                  "\n       Invalid address cell");
     return;
   }
 
   /* Perform a DT traversal till all pcie node are parsed */
   while (offset != -FDT_ERR_NOTFOUND) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  SUBNODE  offset %x\n",
+                    "\n       SUBNODE  offset %x",
                     offset);
 
       /* parse iommu-map is present */

--- a/pal/uefi_dt/src/pal_misc.c
+++ b/pal/uefi_dt/src/pal_misc.c
@@ -41,7 +41,7 @@ pal_mmio_write8(UINT64 addr, UINT8 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %lx\n",
+                    "\n       %a Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -63,7 +63,7 @@ pal_mmio_write16(UINT64 addr, UINT16 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %lx\n",
+                    "\n       %a Address = %llx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -85,7 +85,7 @@ pal_mmio_write64(UINT64 addr, UINT64 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %llx\n",
+                    "\n       %a Address = %llx  Data = %llx",
                     __func__,
                     addr,
                     data);
@@ -110,7 +110,7 @@ pal_mmio_read8(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %lx\n",
+                    "\n       %a Address = %lx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -135,7 +135,7 @@ pal_mmio_read16(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %lx\n",
+                    "\n       %a Address = %lx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -160,7 +160,7 @@ pal_mmio_read64(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %lx\n",
+                    "\n       %a Address = %lx  Data = %lx",
                     __func__,
                     addr,
                     data);
@@ -185,7 +185,7 @@ pal_mmio_read(UINT64 addr)
 
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %lx  Data = %x\n",
+                    "\n       %a Address = %lx  Data = %x",
                     __func__,
                     addr,
                     data);
@@ -207,7 +207,7 @@ pal_mmio_write(UINT64 addr, UINT32 data)
 {
   if (acs_policy_get_print_mmio() || (g_curr_module & g_enable_module))
       pal_print_msg(ACS_PRINT_INFO,
-                    " %a Address = %llx  Data = %x\n",
+                    "\n       %a Address = %llx  Data = %x",
                     __func__,
                     addr,
                     data);
@@ -237,7 +237,7 @@ pal_print(UINT64 data)
     Status = ShellWriteFile(g_acs_log_file_handle, &BufferSize, (VOID *)buf);
     if (EFI_ERROR(Status))
       pal_print_msg(ACS_PRINT_ERR,
-                    " Error in writing to log file\n");
+                    "\n       Error in writing to log file");
   }
   else
   {
@@ -346,12 +346,12 @@ pal_mem_allocate_shared(UINT32 num_pe, UINT32 sizeofentry)
                                (VOID **) &gSharedMemory );
 
   pal_print_msg(ACS_PRINT_INFO,
-                " Shared memory is %llx\n",
+                "\n       Shared memory is %llx",
                 gSharedMemory);
 
   if (EFI_ERROR(Status)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool shared memory failed %x\n",
+                  "\n       Allocate Pool shared memory failed %x",
                   Status);
   }
   pal_pe_data_cache_ops_by_va((UINT64)&gSharedMemory, CLEAN_AND_INVALIDATE);
@@ -412,7 +412,7 @@ pal_mem_alloc (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool failed %x\n",
+                  "\n       Allocate Pool failed %x",
                   Status);
     return NULL;
   }
@@ -445,7 +445,7 @@ pal_mem_calloc (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool failed %x\n",
+                  "\n       Allocate Pool failed %x",
                   Status);
     return NULL;
   }
@@ -481,7 +481,7 @@ pal_mem_alloc_cacheable (
                                &Address);
   if (EFI_ERROR(Status)) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pool failed %x\n",
+                  "\n       Allocate Pool failed %x",
                   Status);
     return NULL;
   }
@@ -612,7 +612,7 @@ pal_mem_alloc_pages (
   if (EFI_ERROR(Status))
   {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Allocate Pages failed %x\n",
+                  "\n       Allocate Pages failed %x",
                   Status);
     return NULL;
   }
@@ -700,7 +700,7 @@ void pal_uart_putc(char c)
         EFI_STATUS Status = ShellWriteFile(g_acs_log_file_handle, &n, &ch);
         if (EFI_ERROR(Status)) {
             pal_print_msg(ACS_PRINT_ERR,
-                          " Error in writing to log file\n");
+                          "\n       Error in writing to log file");
         }
     }
 }

--- a/pal/uefi_dt/src/pal_pcie.c
+++ b/pal/uefi_dt/src/pal_pcie.c
@@ -66,7 +66,7 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
 
   if (gMcfgHdr == NULL) {
       pal_print_msg(ACS_PRINT_WARN,
-                    " ACPI - MCFG Table not found. Setting ECAM Base to 0.\n");
+                    "\n       ACPI - MCFG Table not found. Setting ECAM Base to 0.");
       return 0x0;
   }
 
@@ -80,7 +80,7 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
       if ((bus >= Entry->StartBusNumber) && (bus <= Entry->EndBusNumber) &&
           (seg == Entry->PciSegmentGroupNumber)) {
           pal_print_msg(ACS_PRINT_INFO,
-                        " ECAM base address is %llx\n",
+                        "\n       ECAM base address is %llx",
                         Entry->BaseAddress);
           return Entry->BaseAddress;
       }
@@ -91,7 +91,7 @@ pal_pcie_get_mcfg_ecam(UINT32 bdf)
   }
 
   pal_print_msg(ACS_PRINT_ERR,
-                " ECAM base address for bdf 0x%x is 0\n",
+                "\n       ECAM base address for bdf 0x%x is 0",
                 bdf);
   return 0;
 }
@@ -114,7 +114,7 @@ pal_pcie_create_info_table(PCIE_INFO_TABLE *PcieTable)
 
   if (PcieTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input PCIe Table Pointer is NULL. Cannot create PCIe INFO\n");
+                  "\n       Input PCIe Table Pointer is NULL. Cannot create PCIe INFO");
     return;
   }
 
@@ -177,7 +177,7 @@ pal_pcie_io_read_cfg(UINT32 Bdf, UINT32 offset, UINT32 *data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return PCIE_NO_MAPPING;
   }
 
@@ -230,7 +230,7 @@ pal_pcie_io_write_cfg(UINT32 Bdf, UINT32 offset, UINT32 data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return;
   }
 
@@ -276,7 +276,7 @@ pal_pcie_bar_mem_read(UINT32 Bdf, UINT64 address, UINT32 *data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No Root Bridge found in the system\n");
+                  "\n       No Root Bridge found in the system");
     return PCIE_NO_MAPPING;
   }
 
@@ -325,7 +325,7 @@ pal_pcie_bar_mem_write(UINT32 Bdf, UINT64 address, UINT32 data)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciRootBridgeIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No Root Bridge found in the system\n");
+                  "\n       No Root Bridge found in the system");
     return PCIE_NO_MAPPING;
   }
 
@@ -556,7 +556,7 @@ pal_pcie_is_devicedma_64bit(UINT32 seg, UINT32 bus, UINT32 dev, UINT32 fn)
   Status = gBS->LocateHandleBuffer(ByProtocol, &gEfiPciIoProtocolGuid, NULL,
                                    &HandleCount, &HandleBuffer);
   if (EFI_ERROR(Status)) {
-    pal_print_msg(ACS_PRINT_ERR, " No PCI devices found in the system\n");
+    pal_print_msg(ACS_PRINT_ERR, "\n       No PCI devices found in the system");
     return 0;
   }
 
@@ -629,7 +629,7 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " dt_ptr is NULL\n");
+                  "\n       dt_ptr is NULL");
     return;
   }
 
@@ -639,33 +639,33 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, pci_dt_arr[i]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  PCI node offset not found %d\n",
+                        "\n       PCI node offset not found %d",
                         offset);
           continue; /* Search for next compatible node*/
       }
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE pcie offset %d\n",
+                    "\n       NODE pcie offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE pcie size cell %d\n",
+                    "\n       NODE pcie size cell %d",
                     size_cell);
       if (size_cell < 0) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell\n");
+                        "\n       Invalid size cell");
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE pcie addr cell %d\n",
+                    "\n       NODE pcie addr cell %d",
                     addr_cell);
       if (addr_cell <= 0 || addr_cell > 2) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell\n");
+                        "\n       Invalid address cell");
           return;
       }
 
@@ -675,7 +675,7 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((Preg_val == NULL) || prop_len < 0) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY reg offset %x, Error %d\n",
+                            "\n       PROPERTY reg offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -690,7 +690,7 @@ pal_pcie_create_info_table_dt(PCIE_INFO_TABLE *PcieTable)
                                                                 &prop_len);
           if ((Pbus_val == NULL) || prop_len < 0) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY reg offset %x, Error %d\n",
+                            "\n       PROPERTY reg offset %x, Error %d",
                             offset,
                             prop_len);
               return;

--- a/pal/uefi_dt/src/pal_pcie_enumeration.c
+++ b/pal/uefi_dt/src/pal_pcie_enumeration.c
@@ -84,7 +84,7 @@ palPcieGetBdf(UINT32 ClassCode, UINT32 StartBdf)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return EFI_SUCCESS;
   }
 
@@ -179,7 +179,7 @@ palPcieGetBase(UINT32 bdf, UINT32 bar_index)
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL, &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
     pal_print_msg(ACS_PRINT_INFO,
-                  " No PCI devices found in the system\n");
+                  "\n       No PCI devices found in the system");
     return EFI_SUCCESS;
   }
 

--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -110,7 +110,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
   if (SmbiosTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO\n");
+                  "\n       Input SMBIOS Table Pointer is NULL. Cannot create SMBIOS INFO");
     return;
   }
 
@@ -133,7 +133,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
     /* Check of record if of type 4 */
     if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    " Smbios type %d found\n",
+                    "\n       Smbios type %d found",
                     Record->Type);
 
       Type4Record = (SMBIOS_TABLE_TYPE4 *)Record;
@@ -145,7 +145,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
         Type4Entry->processor_family = Type4Record->ProcessorFamily;
 
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Processor Family 0x%x\n",
+                    "\n       Processor Family 0x%x",
                     Type4Entry->processor_family);
 
       /* Save Processor core count */
@@ -155,7 +155,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
         Type4Entry->core_count = Type4Record->CoreCount;
 
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Processor Count 0x%x\n",
+                    "\n       Processor Count 0x%x",
                     Type4Entry->core_count);
 
       Type4Entry++;
@@ -163,10 +163,10 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
 
       if (SmbiosTable->slot_count >= MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED) {
         pal_print_msg(ACS_PRINT_WARN,
-                      " Total Slots/Sockets 0x%x\n",
+                      "\n       Total Slots/Sockets 0x%x",
                       SmbiosTable->slot_count);
         pal_print_msg(ACS_PRINT_WARN,
-                      " Number of SMBIOS Slots greater than %d\n",
+                      "\n       Number of SMBIOS Slots greater than %d",
                       MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED);
         SmbiosTable->slot_count = MAX_NUM_OF_SMBIOS_SLOTS_SUPPORTED;
         return;
@@ -174,7 +174,7 @@ pal_smbios_create_info_table(PE_SMBIOS_PROCESSOR_INFO_TABLE *SmbiosTable)
     }
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                " Total Slots/Sockets 0x%x\n",
+                "\n       Total Slots/Sockets 0x%x",
                 SmbiosTable->slot_count);
 }
 
@@ -201,7 +201,7 @@ pal_psci_get_conduit (
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return CONDUIT_NO_TABLE;
   }
 
@@ -213,23 +213,23 @@ pal_psci_get_conduit (
   }
   if (offset < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  psci node offset not found\n");
+                    "\n       psci node offset not found");
       return CONDUIT_UNKNOWN;
   }
 
   Pmethod = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "method", 6, &prop_len);
   if ((prop_len > 0) && (Pmethod != NULL)) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  method field length %d\n",
+                    "\n       method field length %d",
                     prop_len);
       if (pal_strncmp(Pmethod, "hvc", 4) == 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  psci method hvc\n");
+                        "\n       psci method hvc");
           return CONDUIT_HVC;
       }
       if (pal_strncmp(Pmethod, "smc", 4) == 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  psci method smc\n");
+                        "\n       psci method smc");
           return CONDUIT_SMC;
       }
   }
@@ -316,24 +316,24 @@ PalCaptureMmuConfig(VOID)
   }
 
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  MMU Config captured at EL%d\n",
+                "\n       MMU Config captured at EL%d",
                 gMmuConfig.current_el);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TTBR0: 0x%lx\n",
+                "\n       TTBR0: 0x%lx",
                 gMmuConfig.ttbr0);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    TCR:   0x%lx\n",
+                "\n       TCR:   0x%lx",
                 gMmuConfig.tcr);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    MAIR:  0x%lx\n",
+                "\n       MAIR:  0x%lx",
                 gMmuConfig.mair);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "    SCTLR: 0x%lx\n",
+                "\n       SCTLR: 0x%lx",
                 gMmuConfig.sctlr);
 
   if (!SkipTtbr1)
     pal_print_msg(ACS_PRINT_DEBUG,
-                  "    TTBR1: 0x%lx\n",
+                  "\n       TTBR1: 0x%lx",
                   gMmuConfig.ttbr1);
 
   /* Clean cache to ensure secondary PEs see the config */
@@ -388,7 +388,7 @@ PalAllocateSecondaryStack(UINT64 mpidr)
                     (VOID **) &Buffer);
       if (EFI_ERROR(Status)) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "\n FATAL - Allocation for Seconday stack failed %x\n",
+                        "\n       FATAL - Allocation for Seconday stack failed %x",
                         Status);
       }
       pal_pe_data_cache_ops_by_va((UINT64)&Buffer, CLEAN_AND_INVALIDATE);
@@ -420,7 +420,7 @@ pal_pe_create_info_table(PE_INFO_TABLE *PeTable)
 {
   if (PeTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input PE Table Pointer is NULL. Cannot create PE INFO\n");
+                  "\n       Input PE Table Pointer is NULL. Cannot create PE INFO");
     return;
   }
   PeTable->header.num_of_pe = 0;
@@ -608,7 +608,7 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -620,7 +620,7 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, pmu_dt_arr[arr_idx]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  PMU compatible value not found for index:%d\n",
+                        "\n       PMU compatible value not found for index:%d",
                         arr_idx);
           continue; /* Search for next compatible item*/
       }
@@ -631,7 +631,7 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            "\n       PROPERTY interrupts offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -639,23 +639,23 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  interrupt_cell  %d\n",
+                        "\n       interrupt_cell  %d",
                         interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  Invalid interrupt cell : %d\n",
+                            "\n       Invalid interrupt cell : %d",
                             interrupt_cell);
               return;
           }
 
           interrupt_frame_count = ((prop_len/sizeof(int))/interrupt_cell);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  interrupt frame count : %d\n",
+                        "\n       interrupt frame count : %d",
                         interrupt_frame_count);
 
           if (interrupt_frame_count == 0) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  interrupt_frame_count is invalid\n");
+                            "\n       interrupt_frame_count is invalid");
               return;
           }
 
@@ -677,15 +677,15 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
                     Ptr++;
                 }
                 pal_print_msg(ACS_PRINT_WARN,
-                              "  PMU interrupt type not mentioned\n");
+                              "\n       PMU interrupt type not mentioned");
                 return;
               }
 
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  intr_type    : %d\n",
+                            "\n       intr_type    : %d",
                             intr_type);
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  pmu_intr_num : %d\n",
+                            "\n       pmu_intr_num : %d",
                             curr_pmu_intr_num);
 
               if (intr_type == INTERRUPT_TYPE_PPI) {
@@ -697,7 +697,7 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
                       Ptr++;
                     }
                     pal_print_msg(ACS_PRINT_WARN,
-                                  "  PMU interrupt number mismatch found\n");
+                                  "\n       PMU interrupt number mismatch found");
                     return;
                 }
                 if (prev_pmu_intr_num == 0) { /* Update table first time with same id*/
@@ -746,7 +746,7 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " dt_ptr is NULL\n");
+                  "\n       dt_ptr is NULL");
     return;
   }
 
@@ -756,31 +756,31 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
   if (offset != -FDT_ERR_NOTFOUND) {
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE cpu offset %d\n",
+                    "\n       NODE cpu offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE cpu size cell %d\n",
+                    "\n       NODE cpu size cell %d",
                     size_cell);
       if (size_cell != 0) {
         pal_print_msg(ACS_PRINT_ERR,
-                      "  Invalid size cell for node cpu\n");
+                      "\n       Invalid size cell for node cpu");
         return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  NODE cpu  addr cell %d\n",
+                    "\n       NODE cpu  addr cell %d",
                     addr_cell);
       if (addr_cell <= 0 || addr_cell > 2) {
         pal_print_msg(ACS_PRINT_ERR,
-                      "  Invalid address cell for node cpu\n");
+                      "\n       Invalid address cell for node cpu");
         return;
       }
   } else {
         pal_print_msg(ACS_PRINT_ERR,
-                      "  No CPU node found\n");
+                      "\n       No CPU node found");
         return;
   }
 
@@ -789,14 +789,14 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
   /* Perform a DT traversal till all cpu node are parsed */
   while (offset != -FDT_ERR_NOTFOUND) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  SUBNODE cpu%d offset %x\n",
+                    "\n       SUBNODE cpu%d offset %x",
                     PeTable->header.num_of_pe,
                     offset);
 
       prop_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
       if ((prop_len < 0) || (prop_val == NULL)) {
         pal_print_msg(ACS_PRINT_ERR,
-                      "  PROPERTY reg offset %x, Error %d\n",
+                      "\n       PROPERTY reg offset %x, Error %d",
                       offset,
                       prop_len);
         return;
@@ -808,11 +808,11 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
       Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
       if ((prop_len > 0) && (Pstatus != NULL)) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  Status field length %d\n",
+                        "\n       Status field length %d",
                         prop_len);
           if (pal_strncmp(Pstatus, "fail", 5) == 0) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  CPU is not operational..SKIP\n");
+                            "\n       CPU is not operational..SKIP");
               offset = fdt_node_offset_by_prop_value((const void *) dt_ptr, offset,
                                                       "device_type", "cpu", 4);
               continue;
@@ -821,12 +821,12 @@ pal_pe_create_info_table_dt(PE_INFO_TABLE *PeTable)
 
       reg_val[0] = fdt32_to_cpu(prop_val[0]);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  reg_val<0> = %x\n",
+                    "\n       reg_val<0> = %x",
                     reg_val[0]);
       if (addr_cell == 2) {
         reg_val[1] = fdt32_to_cpu(prop_val[1]);
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  reg_val<1> = %x\n",
+                      "\n       reg_val<1> = %x",
                       reg_val[1]);
         Ptr->mpidr = (((INT64)(reg_val[0] & PROPERTY_MASK_PE_AFF3) << 32) |
                      (reg_val[1] & PROPERTY_MASK_PE_AFF0_AFF2));

--- a/pal/uefi_dt/src/pal_peripherals.c
+++ b/pal/uefi_dt/src/pal_peripherals.c
@@ -127,7 +127,7 @@ pal_peripheral_add_all_pci(PERIPHERAL_INFO_TABLE *peripheralInfoTable,
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiPciIoProtocolGuid, NULL,
                                     &HandleCount, &HandleBuffer);
   if (EFI_ERROR (Status)) {
-    pal_print_msg(ACS_PRINT_ERR, "  No PCI devices found while populating peripheral table\n");
+    pal_print_msg(ACS_PRINT_ERR, "\n       No PCI devices found while populating peripheral table");
     return;
   }
 
@@ -217,7 +217,7 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -230,7 +230,7 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, usb_dt_compatible[i]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  USB compatible value not found for index:%d\n",
+                        "\n       USB compatible value not found for index:%d",
                         i);
           continue; /* Search for next compatible item*/
       }
@@ -238,27 +238,27 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
       /* Get Address_cell & Size_cell length to parse reg property of timer*/
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Parent Node offset %d\n",
+                    "\n       Parent Node offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  size cell %d\n",
+                    "\n       size cell %d",
                     size_cell);
       if (size_cell < 0) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell :%d\n",
+                        "\n       Invalid size cell :%d",
                         size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  addr cell %d\n",
+                    "\n       addr cell %d",
                     addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell : %d\n",
+                        "\n       Invalid address cell : %d",
                         addr_cell);
           return;
       }
@@ -270,7 +270,7 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
           Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY REG offset %x, Error %d\n",
+                            "\n       PROPERTY REG offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -281,7 +281,7 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            "\n       PROPERTY interrupts offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -289,11 +289,11 @@ pal_peripheral_usb_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTab
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  interrupt_cell  %d\n",
+                        "\n       interrupt_cell  %d",
                         interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  Invalid interrupt cell : %d\n",
+                            "\n       Invalid interrupt cell : %d",
                             interrupt_cell);
               return;
           }
@@ -359,7 +359,7 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -373,7 +373,7 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, sata_dt_compatible[i]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  SATA compatible value not found for index:%d\n",
+                        "\n       SATA compatible value not found for index:%d",
                         i);
           continue; /* Search for next compatible item*/
       }
@@ -381,27 +381,27 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
       /* Get Address_cell & Size_cell length to parse reg property of timer*/
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Parent Node offset %d\n",
+                    "\n       Parent Node offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  size cell %d\n",
+                    "\n       size cell %d",
                     size_cell);
       if (size_cell < 0) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell :%d\n",
+                        "\n       Invalid size cell :%d",
                         size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  addr cell %d\n",
+                    "\n       addr cell %d",
                     addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell : %d\n",
+                        "\n       Invalid address cell : %d",
                         addr_cell);
           return;
       }
@@ -413,7 +413,7 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY REG offset %x, Error %d\n",
+                            "\n       PROPERTY REG offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -424,7 +424,7 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            "\n       PROPERTY interrupts offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -432,11 +432,11 @@ pal_peripheral_sata_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  interrupt_cell  %d\n",
+                        "\n       interrupt_cell  %d",
                         interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
               pal_print_msg(ACS_PRINT_ERR,
-                            " Invalid interrupt cell : %d\n",
+                            "\n       Invalid interrupt cell : %d",
                             interrupt_cell);
               return;
           }
@@ -505,7 +505,7 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -520,7 +520,7 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, uart_dt_compatible[i]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  UART compatible value not found for index:%d\n",
+                        "\n       UART compatible value not found for index:%d",
                         i);
           continue; /* Search for next compatible item*/
       }
@@ -528,27 +528,27 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
       /* Get Address_cell & Size_cell length to parse reg property of uart*/
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Parent Node offset %d\n",
+                    "\n       Parent Node offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  size cell %d\n",
+                    "\n       size cell %d",
                     size_cell);
       if (size_cell < 0) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell :%d\n",
+                        "\n       Invalid size cell :%d",
                         size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  addr cell %d\n",
+                    "\n       addr cell %d",
                     addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell : %d\n",
+                        "\n       Invalid address cell : %d",
                         addr_cell);
           return;
       }
@@ -559,11 +559,11 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           Pstatus = (CHAR8 *)fdt_getprop_namelen((void *)dt_ptr, offset, "status", 6, &prop_len);
           if ((prop_len > 0) && (Pstatus != NULL)) {
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  Status field length %d\n",
+                            "\n       Status field length %d",
                             prop_len);
               if (pal_strncmp(Pstatus, "disabled", 9) == 0) {
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  UART access is secure\n");
+                                "\n       UART access is secure");
                   offset = fdt_node_offset_by_compatible((const void *)dt_ptr, offset,
                                                           uart_dt_compatible[i]);
                   continue;
@@ -574,7 +574,7 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY REG offset %x, Error %d\n",
+                            "\n       PROPERTY REG offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -604,18 +604,18 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
               Pranges = (UINT32 *)
                   fdt_getprop_namelen((void *)dt_ptr, range_parent_offset, "ranges", 6, &prop_len);
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  Parent ranges length %d\n",
+                            "\n       Parent ranges length %d",
                             prop_len);
               if ((prop_len < 0) || (Pranges == NULL)) {
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  No ranges is present\n");
+                                "\n       No ranges is present");
                   range_node_left = 0;
                   break;
               }
               range_node_left--;
               if ((Pranges != NULL) && (prop_len == 0)) {// Empty ranges
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  Empty ranges is present\n");
+                                "\n       Empty ranges is present");
                   range_parent_offset = fdt_parent_offset((const void *) dt_ptr,
                                                                              range_parent_offset);
               } else {
@@ -627,13 +627,13 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
                   child_size_cell = fdt_size_cells((const void *) dt_ptr, range_node_offset);
 
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  child addr cell %d\n",
+                                "\n       child addr cell %d",
                                 child_addr_cell);
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  parent addr cell %d\n",
+                                "\n       parent addr cell %d",
                                 parent_addr_cell);
                   pal_print_msg(ACS_PRINT_DEBUG,
-                                "  child size cell %d\n",
+                                "\n       child size cell %d",
                                 child_size_cell);
                   if ((child_addr_cell < 1 || child_addr_cell > 2) ||
                      (parent_addr_cell < 1 || parent_addr_cell > 2) || (child_size_cell < 0))
@@ -646,37 +646,37 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
                           range_node_addr = (range_node_addr << 32) |
                                                 fdt32_to_cpu(Pranges[range_index++]);
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  range node addr %lx\n",
+                                    "\n       range node addr %lx",
                                     range_node_addr);
                       continue;
                   }
                   while (range_index < (prop_len / 4)) {
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  range_index %d\n",
+                                    "\n       range_index %d",
                                     range_index);
                       temp_child_addr = fdt32_to_cpu(Pranges[range_index++]);
                       if (child_addr_cell == 2)
                           temp_child_addr = (temp_child_addr << 32) |
                                                     fdt32_to_cpu(Pranges[range_index++]);
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  temp node addr %lx\n",
+                                    "\n       temp node addr %lx",
                                     temp_child_addr);
                       if (temp_child_addr == range_node_addr) {
                           parent_offset_addr = fdt32_to_cpu(Pranges[range_index++]);
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  parent offset addr %lx\n",
+                                    "\n       parent offset addr %lx",
                                     parent_offset_addr);
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  range index %d\n",
+                                    "\n       range index %d",
                                     range_index);
                           if (parent_addr_cell == 2) {
                               parent_offset_addr = (parent_offset_addr << 32) |
                                                             fdt32_to_cpu(Pranges[range_index++]);
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  2 parent offset addr %lx\n",
+                                    "\n       2 parent offset addr %lx",
                                     parent_offset_addr);
                       pal_print_msg(ACS_PRINT_DEBUG,
-                                    "  2 range index %d\n",
+                                    "\n       2 range index %d",
                                     range_index);
                           }
                           break;
@@ -688,7 +688,7 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
           }
 
          pal_print_msg(ACS_PRINT_DEBUG,
-                       "  parent offset addr  %lx\n",
+                       "\n       parent offset addr  %lx",
                        parent_offset_addr);
          per_info->base0 += parent_offset_addr;
 
@@ -697,7 +697,7 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
                     fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            "\n       PROPERTY interrupts offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -705,11 +705,11 @@ pal_peripheral_uart_create_info_table_dt(PERIPHERAL_INFO_TABLE *peripheralInfoTa
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  interrupt_cell  %d\n",
+                        "\n       interrupt_cell  %d",
                         interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  Invalid interrupt cell : %d\n",
+                            "\n       Invalid interrupt cell : %d",
                             interrupt_cell);
               return;
           }
@@ -762,7 +762,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
 
   if (peripheralInfoTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO\n");
+                  "\n       Input Peripheral Table Pointer is NULL. Cannot create Peripheral INFO");
     return;
   }
 
@@ -790,7 +790,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->bdf   = DeviceBdf;
           per_info->irq   = 0;
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Found a USB controller %4x\n",
+                        "\n       Found a USB controller %4x",
                         per_info->base0);
           peripheralInfoTable->header.num_usb++;
           peripheralInfoTable->header.num_all++;
@@ -821,7 +821,7 @@ pal_peripheral_create_info_table(PERIPHERAL_INFO_TABLE *peripheralInfoTable)
           per_info->bdf   = DeviceBdf;
           per_info->irq   = 0;
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Found a SATA controller %4x\n",
+                        "\n       Found a SATA controller %4x",
                         per_info->base0);
           peripheralInfoTable->header.num_sata++;
           peripheralInfoTable->header.num_all++;
@@ -968,7 +968,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
 
   if (memoryInfoTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Memory Table Pointer is NULL. Cannot create Memory INFO\n");
+                  "\n       Input Memory Table Pointer is NULL. Cannot create Memory INFO");
     return;
   }
 
@@ -995,7 +995,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
     MemoryMapPtr = MemoryMap;
     for (Index = 0; Index < (MemoryMapSize / DescriptorSize); Index++) {
           pal_print_msg(ACS_PRINT_INFO,
-                        "  Reserved region of type %d [0x%lX, 0x%lX]\n",
+                        "\n       Reserved region of type %d [0x%lX, 0x%lX]",
                         MemoryMapPtr->Type,
                         (UINTN)MemoryMapPtr->PhysicalStart,
                         (UINTN)(MemoryMapPtr->PhysicalStart +
@@ -1019,7 +1019,7 @@ pal_memory_create_info_table(MEMORY_INFO_TABLE *memoryInfoTable)
       i++;
       if (i >= MEM_INFO_TBL_MAX_ENTRY) {
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  Memory Info tbl limit exceeded, Skipping remaining\n",
+                      "\n       Memory Info tbl limit exceeded, Skipping remaining",
                       0);
         break;
       }
@@ -1100,7 +1100,7 @@ pal_memory_get_unpopulated_addr(UINT64 *addr, UINT32 instance)
           continue;
 
         pal_print_msg(ACS_PRINT_INFO,
-                      "  Unpopulated region with base address 0x%lX found\n",
+                      "\n       Unpopulated region with base address 0x%lX found",
                       *addr);
         return EFI_SUCCESS;
       }

--- a/pal/uefi_dt/src/pal_timer_wd.c
+++ b/pal/uefi_dt/src/pal_timer_wd.c
@@ -60,7 +60,7 @@ pal_get_platform_time_us (
 
   Status = gRT->GetTime(&Time, NULL);
   if (EFI_ERROR(Status)) {
-    pal_print_msg(ACS_PRINT_WARN, " GetTime failed: %x\n", Status);
+    pal_print_msg(ACS_PRINT_WARN, "\n       GetTime failed: %x", Status);
     return ~0ULL;
   }
 
@@ -117,7 +117,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
 
   if (TimerTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Timer Table Pointer is NULL. Cannot create Timer INFO\n");
+                  "\n       Input Timer Table Pointer is NULL. Cannot create Timer INFO");
     return;
   }
 
@@ -130,7 +130,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
   gGtdtHdr = (EFI_ACPI_6_1_GENERIC_TIMER_DESCRIPTION_TABLE *) pal_get_gtdt_ptr();
 
   pal_print_msg(ACS_PRINT_INFO,
-                " GTDT is at %x and length is %x\n",
+                "\n       GTDT is at %x and length is %x",
                 gGtdtHdr,
                 gGtdtHdr->Header.Length);
 
@@ -153,17 +153,17 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
 
     if (Entry->Type == EFI_ACPI_6_1_GTDT_GT_BLOCK) {
       pal_print_msg(ACS_PRINT_INFO,
-                    "  Found block entry\n");
+                    "\n       Found block entry");
       GtEntry->type = TIMER_TYPE_SYS_TIMER;
       GtEntry->block_cntl_base = Entry->CntCtlBase;
       GtEntry->timer_count     = Entry->GTBlockTimerCount;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  CNTCTLBase = %llx\n",
+                    "\n       CNTCTLBase = %llx",
                     GtEntry->block_cntl_base);
       GtBlockTimer = (EFI_ACPI_6_1_GTDT_GT_BLOCK_TIMER_STRUCTURE *)(((UINT8 *)Entry) + Entry->GTBlockTimerOffset);
       for (i = 0; i < GtEntry->timer_count; i++) {
         pal_print_msg(ACS_PRINT_INFO,
-                      "  Found timer entry\n");
+                      "\n       Found timer entry");
         GtEntry->frame_num[i]    = GtBlockTimer->GTFrameNumber;
         GtEntry->GtCntBase[i]    = GtBlockTimer->CntBaseX;
         GtEntry->GtCntEl0Base[i] = GtBlockTimer->CntEL0BaseX;
@@ -171,7 +171,7 @@ pal_timer_create_info_table(TIMER_INFO_TABLE *TimerTable)
         GtEntry->virt_gsiv[i]    = GtBlockTimer->GTxVirtualTimerGSIV;
         GtEntry->flags[i]        = GtBlockTimer->GTxPhysicalTimerFlags | (GtBlockTimer->GTxVirtualTimerFlags << 8) | (GtBlockTimer->GTxCommonFlags << 16);
         pal_print_msg(ACS_PRINT_DEBUG,
-                      "  CNTBaseN = %llx for sys counter = %d\n",
+                      "\n       CNTBaseN = %llx for sys counter = %d",
                       GtEntry->GtCntBase[i],
                       i);
         GtBlockTimer++;
@@ -250,7 +250,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
 
   if (WdTable == NULL) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO\n");
+                  "\n       Input Watchdog Table Pointer is NULL. Cannot create Watchdog INFO");
     return;
   }
 
@@ -281,7 +281,7 @@ pal_wd_create_info_table(WD_INFO_TABLE *WdTable)
       WdEntry->wd_flags        = Entry->WatchdogTimerFlags;
       WdTable->header.num_wd++;
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Watchdog base = 0x%llx INTID = 0x%x\n",
+                    "\n       Watchdog base = 0x%llx INTID = 0x%x",
                     WdEntry->wd_ctrl_base,
                     WdEntry->wd_gsiv);
       WdEntry++;
@@ -324,7 +324,7 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
     pal_print_msg(ACS_PRINT_ERR,
-                  " dt_ptr is NULL\n");
+                  "\n       dt_ptr is NULL");
     return;
   }
 
@@ -332,48 +332,48 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
       offset = fdt_node_offset_by_compatible((const void *)dt_ptr, -1, wd_dt_arr[i]);
       if (offset < 0) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  WD node offset not found %d\n",
+                        "\n       WD node offset not found %d",
                         offset);
           continue; /* Search for next compatible wd*/
       }
 
       parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Parent Node offset %d\n",
+                    "\n       Parent Node offset %d",
                     offset);
 
       size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  size cell %d\n",
+                    "\n       size cell %d",
                     size_cell);
       if (size_cell < 1 || size_cell > 2) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid size cell :%d\n",
+                        "\n       Invalid size cell :%d",
                         size_cell);
           return;
       }
 
       addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  addr cell %d\n",
+                    "\n       addr cell %d",
                     addr_cell);
       if (addr_cell < 1 || addr_cell > 2) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid address cell : %d\n",
+                        "\n       Invalid address cell : %d",
                         addr_cell);
           return;
       }
 
       while (offset != -FDT_ERR_NOTFOUND) {
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  WD node:%d offset:%d\n",
+                        "\n       WD node:%d offset:%d",
                         WdTable->header.num_wd,
                         offset);
 
           Preg_val = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
           if ((prop_len < 0) || (Preg_val == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY reg offset %x, Error %d\n",
+                            "\n       PROPERTY reg offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -383,7 +383,7 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
               (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
           if ((prop_len < 0) || (Pintr_val == NULL)) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  PROPERTY interrupts offset %x, Error %d\n",
+                            "\n       PROPERTY interrupts offset %x, Error %d",
                             offset,
                             prop_len);
               return;
@@ -391,11 +391,11 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
 
           interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
           pal_print_msg(ACS_PRINT_DEBUG,
-                        "  interrupt_cell  %d\n",
+                        "\n       interrupt_cell  %d",
                         interrupt_cell);
           if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
               pal_print_msg(ACS_PRINT_ERR,
-                            "  Invalid interrupt cell : %d\n",
+                            "\n       Invalid interrupt cell : %d",
                             interrupt_cell);
               return;
           }
@@ -434,7 +434,7 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
           {
             case IRQ_TYPE_NONE:
               pal_print_msg(ACS_PRINT_DEBUG,
-                            "  interrupt type none\n");
+                            "\n       interrupt type none");
               wd_mode = INTERRUPT_IS_LEVEL_TRIGGERED; /* Set default*/
               wd_polarity = INTERRUPT_IS_ACTIVE_HIGH;
               break;
@@ -456,7 +456,7 @@ pal_wd_create_info_table_dt(WD_INFO_TABLE *WdTable)
               break;
             default:
               pal_print_msg(ACS_PRINT_ERR,
-                            "  interrupt type invalid :%X\n",
+                            "\n       interrupt type invalid :%X",
                             fdt32_to_cpu(Pintr_val[2]));
               return;
           }
@@ -497,7 +497,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   dt_ptr = pal_get_dt_ptr();
   if (dt_ptr == 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    " dt_ptr is NULL\n");
+                    "\n       dt_ptr is NULL");
       return;
   }
 
@@ -526,16 +526,16 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   /* Return if Timer node not found*/
   if (offset < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  timer node offset not found\n");
+                    "\n       timer node offset not found");
       return;
   }
   interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  interrupt_cell  %d\n",
+                "\n       interrupt_cell  %d",
                 interrupt_cell);
   if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid interrupt cell : %d\n",
+                    "\n       Invalid interrupt cell : %d",
                     interrupt_cell);
       return;
   }
@@ -544,18 +544,18 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   Pintr = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "interrupts", 10, &prop_len);
   if ((prop_len < 0) || (Pintr == NULL)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  PROPERTY interrupts offset %x, Error %d\n",
+                    "\n       PROPERTY interrupts offset %x, Error %d",
                     offset,
                     prop_len);
       return;
   }
   else {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  PROPERTY Interrupts Size %d\n",
+                    "\n       PROPERTY Interrupts Size %d",
                     prop_len);
       num_interrupts = prop_len/(interrupt_cell * 4);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  No of interrupts defined in Property %d\n",
+                    "\n       No of interrupts defined in Property %d",
                     num_interrupts);
   }
 
@@ -566,7 +566,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
               TimerTable->header.s_el1_timer_gsiv = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
               pal_print_msg(ACS_PRINT_WARN,
-                            "  Secure EL1 Phy Timer interrupt Type is not PPI\n");
+                            "\n       Secure EL1 Phy Timer interrupt Type is not PPI");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -579,7 +579,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
               TimerTable->header.ns_el1_timer_gsiv = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
               pal_print_msg(ACS_PRINT_WARN,
-                            "  EL1 NS phy timer interrupt Type is not PPI\n");
+                            "\n       EL1 NS phy timer interrupt Type is not PPI");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -592,7 +592,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
               TimerTable->header.virtual_timer_gsiv  = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
               pal_print_msg(ACS_PRINT_WARN,
-                            "  Virtual timer interrupt Type is not PPI\n");
+                            "\n       Virtual timer interrupt Type is not PPI");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -605,7 +605,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
               TimerTable->header.el2_timer_gsiv      = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
               pal_print_msg(ACS_PRINT_WARN,
-                            "  EL2 NS phy timer interrupt Type is not PPI\n");
+                            "\n       EL2 NS phy timer interrupt Type is not PPI");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -618,7 +618,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
               TimerTable->header.el2_virt_timer_gsiv = fdt32_to_cpu(Pintr[index++]) + PPI_OFFSET;
           else {
               pal_print_msg(ACS_PRINT_WARN,
-                            "  EL2 Virtual timer interrupt Type is not PPI\n");
+                            "\n       EL2 Virtual timer interrupt Type is not PPI");
               index++;
           }
           index++; /* Skip interrupt flag*/
@@ -660,7 +660,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   }
   else
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  PROPERTY always-on not found\n");
+                    "\n       PROPERTY always-on not found");
 
   /* Search for mem mapped timers*/
   for (i = 0; i < sizeof(memtimer_dt_arr)/MEMTIMER_COMPATIBLE_STR_LEN ; i++) {
@@ -670,34 +670,34 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   }
   if (offset < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  MEM timer node offset not found\n");
+                    "\n       MEM timer node offset not found");
       return;
   }
 
   /* Get Address_cell & Size_cell length to parse reg property of timer*/
   parent_offset = fdt_parent_offset((const void *) dt_ptr, offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  Parent Node offset %d\n",
+                "\n       Parent Node offset %d",
                 offset);
 
   size_cell = fdt_size_cells((const void *) dt_ptr, parent_offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  size cell %d\n",
+                "\n       size cell %d",
                 size_cell);
   if (size_cell < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid size cell :%d\n",
+                    "\n       Invalid size cell :%d",
                     size_cell);
       return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, parent_offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  addr cell %d\n",
+                "\n       addr cell %d",
                 addr_cell);
   if (addr_cell < 1 || addr_cell > 2) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid address cell : %d\n",
+                    "\n       Invalid address cell : %d",
                     addr_cell);
       return;
   }
@@ -706,7 +706,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, offset, "reg", 3, &prop_len);
   if ((prop_len < 0) || (Preg == NULL)) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  PROPERTY REG offset %x, Error %d\n",
+                    "\n       PROPERTY REG offset %x, Error %d",
                     offset,
                     prop_len);
       return;
@@ -722,22 +722,22 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   /* Get Address_cell & Size_cell length to parse reg property of frame*/
   size_cell = fdt_size_cells((const void *) dt_ptr, offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  size cell %d\n",
+                "\n       size cell %d",
                 size_cell);
   if (size_cell < 0) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid size cell for timer node :%d\n",
+                    "\n       Invalid size cell for timer node :%d",
                     size_cell);
       return;
   }
 
   addr_cell = fdt_address_cells((const void *) dt_ptr, offset);
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  addr cell %d\n",
+                "\n       addr cell %d",
                 addr_cell);
   if (addr_cell < 1 || addr_cell > 2) {
       pal_print_msg(ACS_PRINT_ERR,
-                    "  Invalid address cell for timer node: %d\n",
+                    "\n       Invalid address cell for timer node: %d",
                     addr_cell);
       return;
   }
@@ -746,7 +746,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
   subnode_offset = fdt_subnode_offset((const void *)dt_ptr, offset, "frame");
   if (subnode_offset < 0) {
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  frame node offset not found %d\n",
+                    "\n       frame node offset not found %d",
                     subnode_offset);
       return;
   }
@@ -755,14 +755,14 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
       /* Get frame number*/
       frame_number = fdt_frame_number((const void *)dt_ptr, subnode_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  Frame number is  %d\n",
+                    "\n       Frame number is  %d",
                     frame_number);
 
       /* Get reg property from frame to update GtCntBase */
       Preg = (UINT32 *)fdt_getprop_namelen((void *)dt_ptr, subnode_offset, "reg", 3, &prop_len);
       if ((prop_len < 0) || (Preg == NULL)) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  PROPERTY REG offset %x, Error %d\n",
+                        "\n       PROPERTY REG offset %x, Error %d",
                         offset,
                         prop_len);
           return;
@@ -773,7 +773,7 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
               fdt_getprop_namelen((void *)dt_ptr, subnode_offset, "interrupts", 10, &prop_len);
       if ((prop_len < 0) || (Pintr == NULL)) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  PROPERTY interrupts offset %x, Error %d\n",
+                        "\n       PROPERTY interrupts offset %x, Error %d",
                         offset,
                         prop_len);
           return;
@@ -781,11 +781,11 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
 
       interrupt_cell = fdt_interrupt_cells((const void *)dt_ptr, subnode_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  interrupt_cell for subnode  %d\n",
+                    "\n       interrupt_cell for subnode  %d",
                     interrupt_cell);
       if (interrupt_cell < INTERRUPT_CELLS_MIN || interrupt_cell > INTERRUPT_CELLS_MAX) {
           pal_print_msg(ACS_PRINT_ERR,
-                        "  Invalid interrupt cell subnode: %d\n",
+                        "\n       Invalid interrupt cell subnode: %d",
                         interrupt_cell);
           return;
       }
@@ -840,11 +840,11 @@ pal_timer_create_info_table_dt(TIMER_INFO_TABLE *TimerTable)
 
       subnode_offset = fdt_next_subnode((const void *)dt_ptr, subnode_offset);
       pal_print_msg(ACS_PRINT_DEBUG,
-                    "  timer-mem-fram next node offset %d\n",
+                    "\n       timer-mem-fram next node offset %d",
                     subnode_offset);
   }
   pal_print_msg(ACS_PRINT_DEBUG,
-                "  GT block timer count %d\n",
+                "\n       GT block timer count %d",
                 GtEntry->timer_count);
   TimerTable->header.num_platform_timer = GtEntry->timer_count;
 

--- a/test_pool/drtm/dl002.c
+++ b/test_pool/drtm/dl002.c
@@ -85,7 +85,7 @@ payload(uint32_t num_pe)
     val_set_status(index, RESULT_FAIL(6));
     goto free_dlme_region;
   }
-  val_print(TRACE, "\n       Get Error code 0x%x\n", feat1);
+  val_print(TRACE, "\n       Get Error code 0x%x", feat1);
 
   /* Part 3 : Call unprotect memory again, it should return DENIED as no memory protected */
   status = val_drtm_unprotect_memory();

--- a/test_pool/drtm/dl005.c
+++ b/test_pool/drtm/dl005.c
@@ -32,54 +32,54 @@ static DRTM_DLME_DATA_HDR *dlme_data_header;
 static void print_dlme_data_header(DRTM_DLME_DATA_HDR *dlme_data_header)
 {
   val_print(DEBUG, "\n       DLME Data Header");
-  val_print(DEBUG, "\n         Revision                  = 0x%08lx",
+  val_print(DEBUG, "\n       Revision                  = 0x%08lx",
                                                 dlme_data_header->revision);
-  val_print(DEBUG, "\n         Size                      = %d Bytes",
+  val_print(DEBUG, "\n       Size                      = %d Bytes",
                                                 dlme_data_header->size);
-  val_print(DEBUG, "\n         DLME_data_size            = %d Bytes",
+  val_print(DEBUG, "\n       DLME_data_size            = %d Bytes",
                                                 dlme_data_header->dlme_data_size);
-  val_print(DEBUG, "\n         Protected Regions Size    = %d Bytes",
+  val_print(DEBUG, "\n       Protected Regions Size    = %d Bytes",
                                                 dlme_data_header->protected_regions_size);
-  val_print(DEBUG, "\n         Address Map Size          = %d Bytes",
+  val_print(DEBUG, "\n       Address Map Size          = %d Bytes",
                                                 dlme_data_header->address_map_size);
-  val_print(DEBUG, "\n         DRTM Event Log Size       = %d Bytes",
+  val_print(DEBUG, "\n       DRTM Event Log Size       = %d Bytes",
                                                 dlme_data_header->drtm_event_log_size);
-  val_print(DEBUG, "\n         TCB Hash Table Size       = %d Bytes",
+  val_print(DEBUG, "\n       TCB Hash Table Size       = %d Bytes",
                                                 dlme_data_header->tcb_hash_table_size);
-  val_print(DEBUG, "\n         ACPI Table Region Size    = %d Bytes",
+  val_print(DEBUG, "\n       ACPI Table Region Size    = %d Bytes",
                                                 dlme_data_header->acpi_table_region_size);
-  val_print(DEBUG, "\n         Implementation Region Size= %d Bytes",
+  val_print(DEBUG, "\n       Implementation Region Size= %d Bytes",
                                                 dlme_data_header->implementation_region_size);
 }
 
 static void print_protected_region_info(void)
 {
-  val_print(DEBUG, "\n\n       Protected Region");
-  val_print(DEBUG, "\n         Revision          : 0x%08lx",
+  val_print(DEBUG, "\n       Protected Region");
+  val_print(DEBUG, "\n       Revision          : 0x%08lx",
                                             prot_region->header.revision);
-  val_print(DEBUG, "\n         Number of Regions : 0x%08lx",
+  val_print(DEBUG, "\n       Number of Regions : 0x%08lx",
                                             prot_region->header.num_regions);
   for (uint32_t i = 0; i < prot_region->header.num_regions; i++) {
-    val_print(DEBUG, "\n           Region           : 0x%lx", i);
-    val_print(DEBUG, "\n           Start Address    : 0x%08lx",
+    val_print(DEBUG, "\n       Region           : 0x%lx", i);
+    val_print(DEBUG, "\n       Start Address    : 0x%08lx",
                                             prot_region->regions[i].start_addr);
-    val_print(DEBUG, "\n           Region Size/Type : 0x%08lx",
+    val_print(DEBUG, "\n       Region Size/Type : 0x%08lx",
                                             prot_region->regions[i].size_type);
   }
 }
 
 static void print_address_map_info(void)
 {
-  val_print(DEBUG, "\n\n       Address Map");
-  val_print(DEBUG, "\n         Revision          : 0x%08lx",
+  val_print(DEBUG, "\n       Address Map");
+  val_print(DEBUG, "\n       Revision          : 0x%08lx",
                                             addr_map->header.revision);
-  val_print(DEBUG, "\n         Number of Regions : 0x%08lx",
+  val_print(DEBUG, "\n       Number of Regions : 0x%08lx",
                                             addr_map->header.num_regions);
   for (uint32_t i = 0; i < addr_map->header.num_regions; i++) {
-    val_print(DEBUG, "\n           Region           : 0x%lx", i);
-    val_print(DEBUG, "\n           Start Address    : 0x%08lx",
+    val_print(DEBUG, "\n       Region           : 0x%lx", i);
+    val_print(DEBUG, "\n       Start Address    : 0x%08lx",
                                             addr_map->regions[i].start_addr);
-    val_print(DEBUG, "\n           Region Size/Type : 0x%08lx",
+    val_print(DEBUG, "\n       Region Size/Type : 0x%08lx",
                                             addr_map->regions[i].size_type);
   }
 }
@@ -111,20 +111,20 @@ static void print_dlme_data_info(uint64_t dlme_data_address)
   print_address_map_info();
 
   if (dlme_data_header->tcb_hash_table_size != 0) {
-    val_print(DEBUG, "\n\n       TCB Hash Table");
+    val_print(DEBUG, "\n       TCB Hash Table");
     tcb_hash_table = (DRTM_TCB_HASH_TABLE *)(tcb_hash_address);
-    val_print(DEBUG, "\n         Revision          : 0x%08lx",
+    val_print(DEBUG, "\n       Revision          : 0x%08lx",
                                             tcb_hash_table->header.revision);
-    val_print(DEBUG, "\n         Number of Hashes  : 0x%08lx",
+    val_print(DEBUG, "\n       Number of Hashes  : 0x%08lx",
                                             tcb_hash_table->header.num_hashes);
-    val_print(DEBUG, "\n         Hash Algorithm    : 0x%08lx",
+    val_print(DEBUG, "\n       Hash Algorithm    : 0x%08lx",
                                             tcb_hash_table->header.hash_algo);
     for (uint32_t i = 0; i < tcb_hash_table->header.num_hashes; i++) {
-      val_print(DEBUG, "\n           HASH Index : 0x%lx", i);
-      val_print(DEBUG, "\n             HASH ID    : 0x%08lx",
+      val_print(DEBUG, "\n       HASH Index : 0x%lx", i);
+      val_print(DEBUG, "\n       HASH ID    : 0x%08lx",
                                             tcb_hash_table->hashes[i].hash_id);
       for (uint32_t j = 0; j < 32; j = j+4) {
-        val_print(DEBUG, "\n             HASH Val   : ");
+        val_print(DEBUG, "\n       HASH Val   : ");
         val_print(DEBUG, "%02x ", (tcb_hash_table->hashes[i]).hash_val[j]);
         val_print(DEBUG, "%02x ", (tcb_hash_table->hashes[i]).hash_val[j+1]);
         val_print(DEBUG, "%02x ", (tcb_hash_table->hashes[i]).hash_val[j+2]);
@@ -135,8 +135,8 @@ static void print_dlme_data_info(uint64_t dlme_data_address)
 
   if (dlme_data_header->acpi_table_region_size != 0) {
     /* Print the XSDT Address and Present Tables */
-    val_print(DEBUG, "\n\n       ACPI Tables");
-    val_print(DEBUG, "\n         Signature : %llx",
+    val_print(DEBUG, "\n       ACPI Tables");
+    val_print(DEBUG, "\n       Signature : %llx",
                                             (uint32_t)(*((uint64_t *)acpi_region_address)));
     if ((uint32_t)(*((uint64_t *)acpi_region_address)) == ACS_ACPI_SIGNATURE('X', 'S', 'D', 'T')) {
       /* Print all Present ACPI Tables */

--- a/test_pool/drtm/dl006.c
+++ b/test_pool/drtm/dl006.c
@@ -28,15 +28,15 @@ void
 print_dlme_region(DRTM_PARAMETERS *drtm_params)
 {
   val_print(DEBUG, "\n       DLME Region : ");
-  val_print(DEBUG, "\n         Alloc address      : 0x%lx",
+  val_print(DEBUG, "\n       Alloc address      : 0x%lx",
                             drtm_params->dlme_region_address);
-  val_print(DEBUG, "\n         Region size        : 0x%lx",
+  val_print(DEBUG, "\n       Region size        : 0x%lx",
                             drtm_params->dlme_region_size);
-  val_print(DEBUG, "\n         Free space 1 size  : 0x%lx",
+  val_print(DEBUG, "\n       Free space 1 size  : 0x%lx",
                             drtm_params->dlme_image_start);
-  val_print(DEBUG, "\n         Image size         : 0x%lx",
+  val_print(DEBUG, "\n       Image size         : 0x%lx",
                             drtm_params->dlme_image_size);
-  val_print(DEBUG, "\n         Data size          : 0x%lx\n",
+  val_print(DEBUG, "\n       Data size          : 0x%lx",
                            (drtm_params->dlme_region_size - drtm_params->dlme_data_offset));
 }
 
@@ -45,23 +45,23 @@ void
 print_dlme_data_header(DRTM_DLME_DATA_HDR *dlme_data_header)
 {
   val_print(DEBUG, "\n       DLME Data Header :");
-  val_print(DEBUG, "\n         Revision                   : 0x%08lx",
+  val_print(DEBUG, "\n       Revision                   : 0x%08lx",
                                                 dlme_data_header->revision);
-  val_print(DEBUG, "\n         Size                       : %d Bytes",
+  val_print(DEBUG, "\n       Size                       : %d Bytes",
                                                 dlme_data_header->size);
-  val_print(DEBUG, "\n         DLME_data_size             : %d Bytes",
+  val_print(DEBUG, "\n       DLME_data_size             : %d Bytes",
                                                 dlme_data_header->dlme_data_size);
-  val_print(DEBUG, "\n         Protected Regions Size     : %d Bytes",
+  val_print(DEBUG, "\n       Protected Regions Size     : %d Bytes",
                                                 dlme_data_header->protected_regions_size);
-  val_print(DEBUG, "\n         Address Map Size           : %d Bytes",
+  val_print(DEBUG, "\n       Address Map Size           : %d Bytes",
                                                 dlme_data_header->address_map_size);
-  val_print(DEBUG, "\n         DRTM Event Log Size        : %d Bytes",
+  val_print(DEBUG, "\n       DRTM Event Log Size        : %d Bytes",
                                                 dlme_data_header->drtm_event_log_size);
-  val_print(DEBUG, "\n         TCB Hash Table Size        : %d Bytes",
+  val_print(DEBUG, "\n       TCB Hash Table Size        : %d Bytes",
                                                 dlme_data_header->tcb_hash_table_size);
-  val_print(DEBUG, "\n         ACPI Table Region Size     : %d Bytes",
+  val_print(DEBUG, "\n       ACPI Table Region Size     : %d Bytes",
                                                 dlme_data_header->acpi_table_region_size);
-  val_print(DEBUG, "\n        Implementation Region Size : %d Bytes\n",
+  val_print(DEBUG, "\n       Implementation Region Size : %d Bytes",
                                                 dlme_data_header->implementation_region_size);
 }
 
@@ -75,40 +75,40 @@ print_event_spec(TCG_EFI_SPECID_EVENT *event_spec)
   uint8_t *vendor_data;
 
   val_print(DEBUG, "\n       TCG Spec ID :");
-  val_print(DEBUG, "\n         Signature            : %a",
+  val_print(DEBUG, "\n       Signature            : %a",
                                          (uint64_t)event_spec->signature);
-  val_print(DEBUG, "\n         Platform Class       : 0x%x", event_spec->platform_class);
-  val_print(DEBUG, "\n         Spec Version Minor   : %d",
+  val_print(DEBUG, "\n       Platform Class       : 0x%x", event_spec->platform_class);
+  val_print(DEBUG, "\n       Spec Version Minor   : %d",
                                          event_spec->spec_version_minor);
-  val_print(DEBUG, "\n         Spec Version Major   : %d",
+  val_print(DEBUG, "\n       Spec Version Major   : %d",
                                          event_spec->spec_version_major);
-  val_print(DEBUG, "\n         Spec Errata          : %d", event_spec->spec_errata);
-  val_print(DEBUG, "\n         Uintn Size           : %d", event_spec->uintn_size);
-  val_print(DEBUG, "\n         Number Of Algorithms : %d\n",
+  val_print(DEBUG, "\n       Spec Errata          : %d", event_spec->spec_errata);
+  val_print(DEBUG, "\n       Uintn Size           : %d", event_spec->uintn_size);
+  val_print(DEBUG, "\n       Number Of Algorithms : %d",
                               event_spec->number_of_algorithms);
 
   /* Check Event Signature */
   if (val_strncmp((char8_t *)event_spec->signature, "Spec ID Event03", EVENT_SPEC_ID_STR_LEN)) {
-    val_print(ERROR, " Event Specification mismatch");
+    val_print(ERROR, "\n       Event Specification mismatch");
     return ACS_STATUS_FAIL;
   }
 
   digest_algo = (TCG_EFI_SPECID_EVENT_ALGO_SIZE *)event_spec->digest_sizes;
   for (index = 0; index < event_spec->number_of_algorithms; index++) {
-    val_print(DEBUG, "\n         Digest(%d)",   index);
-    val_print(DEBUG, "\n           Algorithm Id       : %d",
+    val_print(DEBUG, "\n       Digest(%d)",   index);
+    val_print(DEBUG, "\n       Algorithm Id       : %d",
                                            digest_algo[index].algorithm_id);
-    val_print(DEBUG, "\n           Digest Size        : %d\n",
+    val_print(DEBUG, "\n       Digest Size        : %d",
                                       digest_algo[index].digest_size);
   }
 
   vendor_info = (VENDOR_INFO *)(&digest_algo[event_spec->number_of_algorithms]);
 
-  val_print(DEBUG, "\n         Vendor Info Size     : %d",
+  val_print(DEBUG, "\n       Vendor Info Size     : %d",
                                          vendor_info->vendor_info_size);
 
   vendor_data = (uint8_t *)&vendor_info->vendor_info[0];
-  val_print(DEBUG, "\n         Vendor Info          : ");
+  val_print(DEBUG, "\n       Vendor Info          : ");
   for (index = 0; index < vendor_info->vendor_info_size; index++) {
     val_print(DEBUG, "%c",   vendor_data[index]);
   }
@@ -124,25 +124,25 @@ print_tcg_event_header(TCG_PCR_EVENT *event_head)
   uint32_t index;
 
   val_print(DEBUG, "\n       EVENT LOG HEADER:");
-  val_print(DEBUG, "\n         PCR Index         : %d",    event_head->pcr_index);
+  val_print(DEBUG, "\n       PCR Index         : %d",    event_head->pcr_index);
   /* Check Event Log Header PCRIndex should be zero */
   if (event_head->pcr_index != 0) {
     val_print(ERROR, "\n       Event Log Header should have PCRIndex as zero");
     return ACS_STATUS_FAIL;
   }
 
-  val_print(DEBUG, "\n         Event Type        : 0x%x",  event_head->event_type);
+  val_print(DEBUG, "\n       Event Type        : 0x%x",  event_head->event_type);
   /* Check Event Log Header EventType should be EV_NO_ACTION */
   if (event_head->event_type != EV_NO_ACTION) {
     val_print(ERROR, "\n       Event Log Header should have EventType as EV_NO_ACTION");
     return ACS_STATUS_FAIL;
   }
 
-  val_print(DEBUG, "\n         Digest - ");
+  val_print(DEBUG, "\n       Digest - ");
   for (index = 0; index < sizeof(TCG_DIGEST); index++) {
     val_print(DEBUG, "%02x ",  event_head->digest.digest[index]);
   }
-  val_print(DEBUG, "\n         Event Size        : 0x%x\n",  event_head->event_size);
+  val_print(DEBUG, "\n       Event Size        : 0x%x",  event_head->event_size);
 
   return ACS_STATUS_PASS;
 }
@@ -251,9 +251,9 @@ payload(uint32_t num_pe)
       break;
     }
     val_print(DEBUG, "\n       EVENT2 : ");
-    val_print(DEBUG, "\n         PCR Index       : %d",    event->pcr_index);
-    val_print(DEBUG, "\n         Event Type      : 0x%x",  event->event_type);
-    val_print(DEBUG, "\n         Digest Count    : 0x%x",  event->digests.count);
+    val_print(DEBUG, "\n       PCR Index       : %d",    event->pcr_index);
+    val_print(DEBUG, "\n       Event Type      : 0x%x",  event->event_type);
+    val_print(DEBUG, "\n       Digest Count    : 0x%x",  event->digests.count);
 
     if (event->event_type == DRTM_EVTYPE_ARM_SEPARATOR) {
       arm_separator++;
@@ -262,7 +262,7 @@ payload(uint32_t num_pe)
     /* Print Digest values for all hash algorithms */
     digest = (TPMT_HA *)&event->digests.digests[0];
     for (digest_index = 0; digest_index < event->digests.count; digest_index++) {
-      val_print(DEBUG, "\n         Hash Alg        : 0x%x",
+      val_print(DEBUG, "\n       Hash Alg        : 0x%x",
                                              digest[digest_index].hashalg);
       /* R48000 : Validate the hash algorithm used for DRTM event measurements
        * based on TPM capabilities */
@@ -285,11 +285,11 @@ payload(uint32_t num_pe)
         }
       }
 
-      val_print(DEBUG, "\n         Digest(%02d)      :",  digest_index);
+      val_print(DEBUG, "\n       Digest(%02d)      :",  digest_index);
       digest_buffer = (uint8_t *)(digest[digest_index].digest);
       for (i = 0; i < SHA256_DIGEST_SIZE; i++) {
         if ((!(i % 8)) && (i != 0))
-          val_print(DEBUG, "\n                          ");
+          val_print(DEBUG, "\n       ");
         val_print(DEBUG, " %02x",  digest_buffer[i]);
       }
     }
@@ -300,8 +300,8 @@ payload(uint32_t num_pe)
     }
 
     event_data = (EVENT_DATA *)((uint8_t *)&digest[--digest_index].digest[SHA256_DIGEST_SIZE]);
-    val_print(DEBUG, "\n         Event Size      : 0x%x",  event_data->event_size);
-    val_print(DEBUG, "\n         Event Data      : ");
+    val_print(DEBUG, "\n       Event Size      : 0x%x",  event_data->event_size);
+    val_print(DEBUG, "\n       Event Data      : ");
     data = (uint8_t *)((uint8_t *)event_data + sizeof(uint32_t));
     for (i = 0; i < event_data->event_size; i++) {
       val_print(DEBUG, " %x",  data[i]);
@@ -317,14 +317,14 @@ payload(uint32_t num_pe)
   }
   /* R45300 : EVTYPE_ARM_SEPARATOR is must in in event log */
   if (!arm_separator) {
-    val_print(ERROR, "\n         Event type EVTYPE_ARM_SEPARATOR Not found");
+    val_print(ERROR, "\n       Event type EVTYPE_ARM_SEPARATOR Not found");
     val_set_status(index, RESULT_FAIL(7));
   }
 
   /* R48000 : Validate the hash algorithm used for DRTM event measurements
   * based on TPM capabilities */
   if (!drtm_hash_valid) {
-    val_print(ERROR, "\n         Invalid hash algorithm used in DRTM measurement");
+    val_print(ERROR, "\n       Invalid hash algorithm used in DRTM measurement");
     val_set_status(index, RESULT_FAIL(8));
     goto free_dlme_region;
   }

--- a/test_pool/drtm/dl012.c
+++ b/test_pool/drtm/dl012.c
@@ -30,7 +30,7 @@ check_event_spec_signature(TCG_EFI_SPECID_EVENT *event_spec)
 
   /* Check Event Signature */
   if (val_strncmp((char8_t *)event_spec->signature, "Spec ID Event03", EVENT_SPEC_ID_STR_LEN)) {
-    val_print(ERROR, " Event Specification mismatch");
+    val_print(ERROR, "\nEvent Specification mismatch");
     return ACS_STATUS_FAIL;
   }
 
@@ -140,9 +140,9 @@ payload(uint32_t num_pe)
       break;
     }
     val_print(DEBUG, "\n       EVENT2 : ");
-    val_print(DEBUG, "\n         PCR Index       : %d",    event->pcr_index);
-    val_print(DEBUG, "\n         Event Type      : 0x%x",  event->event_type);
-    val_print(DEBUG, "\n         Digest Count    : 0x%x",  event->digests.count);
+    val_print(DEBUG, "\n       PCR Index       : %d",    event->pcr_index);
+    val_print(DEBUG, "\n       Event Type      : 0x%x",  event->event_type);
+    val_print(DEBUG, "\n       Digest Count    : 0x%x",  event->digests.count);
 
     if (event->event_type == DRTM_EVTYPE_ARM_DLME) {
       dlme_image_auth = ACS_STATUS_PASS;

--- a/test_pool/drtm/dl017.c
+++ b/test_pool/drtm/dl017.c
@@ -45,7 +45,7 @@ static void print_hex_dump(uint64_t address, uint64_t size)
   uint32_t i;
 
   for (offset = 0; offset < size; offset += 16) {
-    val_print(DEBUG, "\n         %08llx :", offset);
+    val_print(DEBUG, "\n       %08llx :", offset);
     for (i = 0; (i < 16) && ((offset + i) < size); i++)
       val_print(DEBUG, " %02x", data[offset + i]);
   }
@@ -85,56 +85,56 @@ static void print_acpi_table_debug(uint64_t acpi_addr, uint64_t acpi_size)
   uint64_t acpi_end;
   uint32_t i;
 
-  val_print(DEBUG, "\n\n       DL017 ACPI Table Region Debug");
-  val_print(DEBUG, "\n         Base Address : 0x%llx", acpi_addr);
-  val_print(DEBUG, "\n         Region Size  : %ld Bytes", acpi_size);
+  val_print(DEBUG, "\n       DL017 ACPI Table Region Debug");
+  val_print(DEBUG, "\n       Base Address : 0x%llx", acpi_addr);
+  val_print(DEBUG, "\n       Region Size  : %ld Bytes", acpi_size);
 
   if (acpi_size == 0) {
-    val_print(DEBUG, "\n         ACPI table region is not present");
+    val_print(DEBUG, "\n       ACPI table region is not present");
     return;
   }
 
   if (acpi_size < ACPI_HEADER_SIZE) {
-    val_print(DEBUG, "\n         ACPI table region smaller than ACPI header");
+    val_print(DEBUG, "\n       ACPI table region smaller than ACPI header");
     print_hex_dump(acpi_addr, acpi_size);
     return;
   }
 
   acpi_end = acpi_addr + acpi_size;
   if (acpi_end < acpi_addr) {
-    val_print(DEBUG, "\n         ACPI table region address overflow");
+    val_print(DEBUG, "\n       ACPI table region address overflow");
     return;
   }
 
   sig = *(uint32_t *)acpi_addr;
-  val_print(DEBUG, "\n         Region Signature:");
+  val_print(DEBUG, "\n       Region Signature:");
   print_sig(sig);
-  val_print(DEBUG, "\n         Raw ACPI Region Data:");
+  val_print(DEBUG, "\n       Raw ACPI Region Data:");
   print_hex_dump(acpi_addr, acpi_size);
 
   if (sig != ACS_ACPI_SIGNATURE('X', 'S', 'D', 'T')) {
-    val_print(DEBUG, "\n         ACPI region does not start with XSDT");
+    val_print(DEBUG, "\n       ACPI region does not start with XSDT");
     return;
   }
 
   xsdt_len = *((uint32_t *)(acpi_addr + ACPI_HEADER_LEN_OFFSET));
-  val_print(DEBUG, "\n\n         XSDT Length  : %d Bytes", xsdt_len);
+  val_print(DEBUG, "\n       XSDT Length  : %d Bytes", xsdt_len);
 
   if ((xsdt_len < ACPI_HEADER_SIZE) || (xsdt_len > acpi_size)) {
-    val_print(DEBUG, "\n         XSDT length is outside ACPI table region");
+    val_print(DEBUG, "\n       XSDT length is outside ACPI table region");
     return;
   }
 
   num_entries = (xsdt_len - ACPI_HEADER_SIZE) >> 3;
-  val_print(DEBUG, "\n         XSDT Entries : %d", num_entries);
+  val_print(DEBUG, "\n       XSDT Entries : %d", num_entries);
 
   for (i = 0; i < num_entries; i++) {
     next_table_addr = *((uint64_t *)(acpi_addr + ACPI_HEADER_SIZE + (i * 8)));
-    val_print(DEBUG, "\n           Entry[%d] Address : 0x%llx", i, next_table_addr);
-    val_print(DEBUG, "\n           Entry[%d] Signature:", i);
+    val_print(DEBUG, "\n       Entry[%d] Address : 0x%llx", i, next_table_addr);
+    val_print(DEBUG, "\n       Entry[%d] Signature:", i);
     if (!val_drtm_is_range_valid((uint8_t *)acpi_addr, (uint8_t *)acpi_end,
                                  (uint8_t *)next_table_addr, ACPI_HEADER_SIZE)) {
-      val_print(DEBUG, "\n           Entry[%d] outside ACPI region", i);
+      val_print(DEBUG, "\n       Entry[%d] outside ACPI region", i);
       continue;
     }
 
@@ -145,23 +145,23 @@ static void print_acpi_table_debug(uint64_t acpi_addr, uint64_t acpi_size)
 static void print_dlme_layout_debug(uint64_t dlme_data_address, uint64_t tcb_hash_address,
                                     uint64_t acpi_table_address)
 {
-  val_print(DEBUG, "\n\n       DL017 DLME Layout Debug");
-  val_print(DEBUG, "\n         DLME Data Address          : 0x%llx", dlme_data_address);
-  val_print(DEBUG, "\n         DLME Header Size           : %d Bytes",
+  val_print(DEBUG, "\n       DL017 DLME Layout Debug");
+  val_print(DEBUG, "\n       DLME Data Address          : 0x%llx", dlme_data_address);
+  val_print(DEBUG, "\n       DLME Header Size           : %d Bytes",
             dlme_data_header->size);
-  val_print(DEBUG, "\n         Protected Regions Size     : %ld Bytes",
+  val_print(DEBUG, "\n       Protected Regions Size     : %ld Bytes",
             dlme_data_header->protected_regions_size);
-  val_print(DEBUG, "\n         Address Map Size           : %ld Bytes",
+  val_print(DEBUG, "\n       Address Map Size           : %ld Bytes",
             dlme_data_header->address_map_size);
-  val_print(DEBUG, "\n         DRTM Event Log Size        : %ld Bytes",
+  val_print(DEBUG, "\n       DRTM Event Log Size        : %ld Bytes",
             dlme_data_header->drtm_event_log_size);
-  val_print(DEBUG, "\n         TCB Hash Table Address     : 0x%llx", tcb_hash_address);
-  val_print(DEBUG, "\n         TCB Hash Table Size        : %ld Bytes",
+  val_print(DEBUG, "\n       TCB Hash Table Address     : 0x%llx", tcb_hash_address);
+  val_print(DEBUG, "\n       TCB Hash Table Size        : %ld Bytes",
             dlme_data_header->tcb_hash_table_size);
-  val_print(DEBUG, "\n         ACPI Table Region Address  : 0x%llx", acpi_table_address);
-  val_print(DEBUG, "\n         ACPI Table Region Size     : %ld Bytes",
+  val_print(DEBUG, "\n       ACPI Table Region Address  : 0x%llx", acpi_table_address);
+  val_print(DEBUG, "\n       ACPI Table Region Size     : %ld Bytes",
             dlme_data_header->acpi_table_region_size);
-  val_print(DEBUG, "\n         Implementation Region Size : %ld Bytes",
+  val_print(DEBUG, "\n       Implementation Region Size : %ld Bytes",
             dlme_data_header->implementation_region_size);
 }
 
@@ -173,29 +173,29 @@ static void print_tcb_hash_debug(DRTM_TCB_HASH_TABLE *tbl, uint64_t tbl_size)
   uint64_t entry_offset;
   uint32_t i;
 
-  val_print(DEBUG, "\n\n       DL017 TCB Hash Table Debug");
-  val_print(DEBUG, "\n         Base Address : 0x%llx", (uint64_t)tbl);
-  val_print(DEBUG, "\n         Table Size   : %ld Bytes", tbl_size);
+  val_print(DEBUG, "\n       DL017 TCB Hash Table Debug");
+  val_print(DEBUG, "\n       Base Address : 0x%llx", (uint64_t)tbl);
+  val_print(DEBUG, "\n       Table Size   : %ld Bytes", tbl_size);
 
   if (tbl_size == 0) {
-    val_print(DEBUG, "\n         TCB hash table is not present");
+    val_print(DEBUG, "\n       TCB hash table is not present");
     return;
   }
 
   if (tbl_size < sizeof(DRTM_TCB_HASH_TABLE_HDR)) {
-    val_print(DEBUG, "\n         TCB hash table smaller than header");
+    val_print(DEBUG, "\n       TCB hash table smaller than header");
     print_hex_dump((uint64_t)tbl, tbl_size);
     return;
   }
 
   digest_size = val_drtm_get_digest_size(tbl->header.hash_algo);
-  val_print(DEBUG, "\n         Revision     : 0x%x", tbl->header.revision);
-  val_print(DEBUG, "\n         Num Hashes   : %d", tbl->header.num_hashes);
-  val_print(DEBUG, "\n         Hash Algo    : 0x%x", tbl->header.hash_algo);
-  val_print(DEBUG, "\n         Digest Size  : %d Bytes", digest_size);
+  val_print(DEBUG, "\n       Revision     : 0x%x", tbl->header.revision);
+  val_print(DEBUG, "\n       Num Hashes   : %d", tbl->header.num_hashes);
+  val_print(DEBUG, "\n       Hash Algo    : 0x%x", tbl->header.hash_algo);
+  val_print(DEBUG, "\n       Digest Size  : %d Bytes", digest_size);
 
   if (digest_size == 0) {
-    val_print(DEBUG, "\n         Unsupported hash algorithm, raw table dump:");
+    val_print(DEBUG, "\n       Unsupported hash algorithm, raw table dump:");
     print_hex_dump((uint64_t)tbl, tbl_size);
     return;
   }
@@ -207,13 +207,13 @@ static void print_tcb_hash_debug(DRTM_TCB_HASH_TABLE *tbl, uint64_t tbl_size)
 
     if ((entry_offset > tbl_size) ||
         ((tbl_size - entry_offset) < (sizeof(hash->hash_id) + digest_size))) {
-      val_print(DEBUG, "\n         Hash[%d] extends beyond table size", i);
+      val_print(DEBUG, "\n       Hash[%d] extends beyond table size", i);
       return;
     }
 
-    val_print(DEBUG, "\n           Hash[%d] Offset : 0x%llx", i, entry_offset);
-    val_print(DEBUG, "\n           Hash[%d] ID     : 0x%08x", i, hash->hash_id);
-    val_print(DEBUG, "\n           Hash[%d] Value  :", i);
+    val_print(DEBUG, "\n       Hash[%d] Offset : 0x%llx", i, entry_offset);
+    val_print(DEBUG, "\n       Hash[%d] ID     : 0x%08x", i, hash->hash_id);
+    val_print(DEBUG, "\n       Hash[%d] Value  :", i);
     print_hex_dump((uint64_t)hash->hash_val, digest_size);
 
     hash_entry += sizeof(hash->hash_id) + digest_size;

--- a/test_pool/exerciser/e003.c
+++ b/test_pool/exerciser/e003.c
@@ -239,7 +239,7 @@ cfgspace_transactions_order_check(void)
     /* If exerciser doesn't have PCI_CAP skip the bdf */
     if (val_pcie_find_capability(bdf, PCIE_CAP, CID_PCIECS, &cid_offset) == PCIE_CAP_NOT_FOUND) {
         val_print(DEBUG,
-            "\n        PCIe Express Capability not found. Skipping exerciser 0x%x", bdf);
+            "\n       PCIe Express Capability not found. Skipping exerciser 0x%x", bdf);
         continue;
     }
 

--- a/test_pool/exerciser/e004.c
+++ b/test_pool/exerciser/e004.c
@@ -67,7 +67,7 @@ payload (void)
   index = val_pe_get_index_mpid (val_pe_get_mpid());
 
   if (val_gic_get_info(GIC_INFO_NUM_ITS) == 0) {
-      val_print(DEBUG, "\n       No ITS, Skipping Test.\n");
+      val_print(DEBUG, "\n       No ITS, Skipping Test.");
       val_set_status(index, RESULT_SKIP(1));
       return;
   }

--- a/test_pool/exerciser/e007.c
+++ b/test_pool/exerciser/e007.c
@@ -83,7 +83,7 @@ uint32_t test_sequence2(void *dram_buf1_virt, void *dram_buf1_phys, uint32_t ins
 
   /* Compare the contents of ddr_buf1 and ddr_buf2 for NEW_DATA */
   if (val_memory_compare(dram_buf1_virt, dram_buf2_virt, dma_len)) {
-      val_print(ERROR, "\n        I/O coherency failure for Exerciser %4x", instance);
+      val_print(ERROR, "\n       I/O coherency failure for Exerciser %4x", instance);
       return 1;
   }
 
@@ -124,7 +124,7 @@ uint32_t test_sequence1(void *dram_buf1_virt, void *dram_buf1_phys, uint32_t ins
 
   /* Compare the contents of ddr_buf1 and ddr_buf2 for NEW_DATA */
   if (val_memory_compare(dram_buf1_virt, dram_buf2_virt, dma_len)) {
-      val_print(ERROR, "\n        I/O coherency failure for Exerciser %4x", instance);
+      val_print(ERROR, "\n       I/O coherency failure for Exerciser %4x", instance);
       return 1;
   }
 

--- a/test_pool/exerciser/e013.c
+++ b/test_pool/exerciser/e013.c
@@ -108,7 +108,7 @@ payload (void)
   index = val_pe_get_index_mpid (val_pe_get_mpid());
 
   if (val_gic_get_info(GIC_INFO_NUM_ITS) == 0) {
-      val_print(DEBUG, "\n       No ITS, Skipping Test.\n");
+      val_print(DEBUG, "\n       No ITS, Skipping Test.");
       val_set_status(index, RESULT_SKIP(1));
       return;
   }

--- a/test_pool/exerciser/e024.c
+++ b/test_pool/exerciser/e024.c
@@ -103,7 +103,7 @@ save_config_space(uint32_t rp_bdf)
       val_print(WARN, "\n WARNING: Memory is allocated only for %d devices", MAX_DEVICES);
       val_print(WARN, "\n The number of PCIe devices is %d", bdf_tbl_ptr->num_entries);
       val_print(WARN, "\n for which the additional memory is not allocated");
-      val_print(WARN, "\n and test may fail\n");
+      val_print(WARN, "\n       and test may fail");
   }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)
@@ -255,7 +255,7 @@ err_check:
           /* Save the config space of all the devices connected to the RP
            to restore after Secondary Bus Reset (SBR)*/
           save_config_space(erp_bdf);
-          val_print(TRACE, "       EP BDF : 0x%x\n", e_bdf);
+          val_print(TRACE, "\n       EP BDF : 0x%x", e_bdf);
 
           irq_pending = 1;
           /* Enable DPC */

--- a/test_pool/exerciser/e025.c
+++ b/test_pool/exerciser/e025.c
@@ -163,7 +163,7 @@ check_p2p_sequence(uint64_t dma_src, uint32_t tgt_instance, uint32_t req_instanc
   {
       val_print(ERROR,
                 "\n       Data mismatch for target exerciser instance: %x", tgt_instance);
-      val_print(ERROR, " with value: %x\n", transaction_data);
+      val_print(ERROR, " with value: %x", transaction_data);
       return ACS_STATUS_FAIL;
   }
 
@@ -235,7 +235,7 @@ host_dma_test(uint32_t req_instance, uint64_t dma_src, uint64_t dma_dst)
   uint32_t test_fail = 0;
   uint32_t count = (sizeof(datasizes)/sizeof(datasizes[0]));
 
-  val_print(DEBUG, "\n   Testing endpoint to Host DMA\n");
+  val_print(DEBUG, "\n       Testing endpoint to Host DMA");
   while (req_instance-- != 0)
   {
       /* if init fail moves to next exerciser */
@@ -243,7 +243,7 @@ host_dma_test(uint32_t req_instance, uint64_t dma_src, uint64_t dma_dst)
           continue;
 
       req_e_bdf = val_exerciser_get_bdf(req_instance);
-      val_print(DEBUG, "       Requester exerciser BDF - 0x%x\n", req_e_bdf);
+      val_print(DEBUG, "\n       Requester exerciser BDF - 0x%x", req_e_bdf);
 
       for (i = 0; i < count; i++)
       {
@@ -251,7 +251,7 @@ host_dma_test(uint32_t req_instance, uint64_t dma_src, uint64_t dma_dst)
           if (ret_status != ACS_STATUS_PASS)
           {
               val_print(ERROR,
-                    "       Failed for %dByte host memory transaction from exerciser: %x\n",
+                    "\n       Failed for %dByte host memory transaction from exerciser: %x",
                      datasizes[i], req_instance);
               // Continue running the tests even if this fails
               test_fail++;
@@ -264,7 +264,7 @@ host_dma_test(uint32_t req_instance, uint64_t dma_src, uint64_t dma_dst)
       ret_status = ACS_STATUS_FAIL;
   }
   // else test is either skip or pass
-  val_print(INFO, "Endpoint to Host DMA test  %s\n", printStatus(ret_status));
+  val_print(INFO, "\n       Endpoint to Host DMA test  %s", printStatus(ret_status));
   return ret_status;
 }
 
@@ -282,7 +282,7 @@ p2p_dma_test(uint32_t req_instance, uint64_t dma_src)
   uint32_t count = (sizeof(datasizes)/sizeof(datasizes[0]));
 
 
-  val_print(DEBUG, "\n   Testing endpoint to endpoint DMA\n");
+  val_print(DEBUG, "\n       Testing endpoint to endpoint DMA");
 
   while (req_instance-- != 0)
   {
@@ -291,7 +291,7 @@ p2p_dma_test(uint32_t req_instance, uint64_t dma_src)
           continue;
 
       req_e_bdf = val_exerciser_get_bdf(req_instance);
-      val_print(DEBUG, "       Requester exerciser BDF - 0x%x\n", req_e_bdf);
+      val_print(DEBUG, "\n       Requester exerciser BDF - 0x%x", req_e_bdf);
 
       /* Get RP of the exerciser */
       if (val_pcie_get_rootport(req_e_bdf, &req_rp_bdf))
@@ -311,7 +311,7 @@ p2p_dma_test(uint32_t req_instance, uint64_t dma_src)
           if (ret_status != ACS_STATUS_PASS)
           {
               val_print(ERROR,
-                      "       Failed for %dBytes transaction from exerciser: %x\n",
+                      "\n       Failed for %dBytes transaction from exerciser: %x",
                            datasizes[i], req_instance);
               test_fail++;
           }
@@ -324,7 +324,7 @@ p2p_dma_test(uint32_t req_instance, uint64_t dma_src)
       ret_status = ACS_STATUS_FAIL;
   }
   // else test is either skip or pass
-  val_print(INFO, "Endpoint to Endpoint DMA test  %s\n", printStatus(ret_status));
+  val_print(INFO, "\n       Endpoint to Endpoint DMA test  %s", printStatus(ret_status));
   return ret_status;
 }
 
@@ -371,7 +371,7 @@ payload(void)
       test_dma_src_buffer[0] = TEST_DMA_PATTERN;
       val_pe_cache_clean_invalidate_range((uint64_t)test_dma_src_buffer, 8);
 
-      val_print(DEBUG, "\nPerforming Endpoint to Host DMA transfer\n");
+      val_print(DEBUG, "\n       Performing Endpoint to Host DMA transfer");
       test_status = host_dma_test(req_instance,
                                    (uint64_t) test_dma_src_buffer,
                                    (uint64_t) test_dma_dst_buffer);
@@ -380,27 +380,27 @@ payload(void)
           break;
       }
       else {
-          val_print(DEBUG, "Endpoint to Host DMA transfer Success\n");
+          val_print(DEBUG, "\n       Endpoint to Host DMA transfer Success");
       }
 
       /* Check If PCIe Hierarchy supports P2P. */
       p2p_status = val_pcie_p2p_support();
       if (p2p_status == ACS_STATUS_PASS)
       {
-          val_print(DEBUG, "Platform supports PCIe P2P dma transfer ");
-          val_print(DEBUG, "performing Endpoint to Endpoint transfer\n");
+          val_print(DEBUG, "\n       Platform supports PCIe P2P dma transfer ");
+          val_print(DEBUG, "\n       performing Endpoint to Endpoint transfer");
           test_status = p2p_dma_test(req_instance, (uint64_t)test_dma_src_buffer);
           if (test_status != ACS_STATUS_PASS) {
               set_status(pe_index, test_status, 2);
               break;
           }
           else {
-              val_print(DEBUG, "Endpoint to Endpoint DMA transfer Success\n");
+              val_print(DEBUG, "\n       Endpoint to Endpoint DMA transfer Success");
           }
       }
       else
       {
-          val_print(DEBUG, "Platform do not support PCIe P2P dma transfer\n");
+          val_print(DEBUG, "\n       Platform do not support PCIe P2P dma transfer");
       }
   } while (0);
 

--- a/test_pool/exerciser/e027.c
+++ b/test_pool/exerciser/e027.c
@@ -102,7 +102,7 @@ save_config_space(uint32_t rp_bdf)
       val_print(WARN, "\n WARNING: Memory is allocated only for %d devices", MAX_DEVICES);
       val_print(WARN, "\n The number of PCIe devices is %d", bdf_tbl_ptr->num_entries);
       val_print(WARN, "\n for which the additional memory is not allocated");
-      val_print(WARN, "\n and test may fail\n");
+      val_print(WARN, "\n       and test may fail");
   }
 
   while (tbl_index < bdf_tbl_ptr->num_entries)

--- a/test_pool/exerciser/e033.c
+++ b/test_pool/exerciser/e033.c
@@ -64,7 +64,7 @@ payload (void)
   index = val_pe_get_index_mpid (val_pe_get_mpid());
 
   if (val_gic_get_info(GIC_INFO_NUM_ITS) == 0) {
-      val_print(DEBUG, "\n       No ITS, Skipping Test.\n");
+      val_print(DEBUG, "\n       No ITS, Skipping Test.");
       val_set_status(index, RESULT_SKIP(1));
       return;
   }

--- a/test_pool/gic/g005.c
+++ b/test_pool/gic/g005.c
@@ -83,7 +83,7 @@ payload()
         }
         else {
             val_print(DEBUG,
-                "\n       GICR_ISENABLER0: %X\n ", data);
+                "\n       GICR_ISENABLER0: %X", data);
             val_print(ERROR,
                 "\n       INTID 0 - 7 not implemented as non-secure SGIs");
             val_set_status(index, RESULT_FAIL(3));
@@ -101,7 +101,7 @@ payload()
         }
         else {
             val_print(DEBUG,
-                "\n       GICD_IENABLER<n>: %X\n ", data);
+                "\n       GICD_IENABLER<n>: %X", data);
             val_print(ERROR,
                 "\n       INTID 0 - 7 not implemented as non-secure SGIs");
             val_set_status(index, RESULT_FAIL(4));

--- a/test_pool/gic/its004.c
+++ b/test_pool/gic/its004.c
@@ -77,7 +77,7 @@ payload()
       curr_grp_its_id = 0xFFFFFFFF;
       curr_smmu_id = 0xFFFFFFFF;
       curr_seg_num = 0xFFFFFFFF;
-      val_print(TRACE, "\n   BDF is  : 0x%x\n", bdf);
+      val_print(TRACE, "\n       BDF is  : 0x%x", bdf);
 
       smmu_id = val_iovirt_get_rc_smmu_index(seg_num, PCIE_CREATE_BDF_PACKED(bdf));
       if (smmu_id == ACS_INVALID_INDEX) {

--- a/test_pool/memory_map/m005.c
+++ b/test_pool/memory_map/m005.c
@@ -117,7 +117,8 @@ static void payload_check_peripheral_addr_64kb_apart(void)
 
             if (addr_diff < MEM_SIZE_64KB) {
                 val_print(WARN,
-                         "\n  Peripheral base addresses isn't atleast 64Kb apart %llx", addr_diff);
+                         "\n       Peripheral base addresses isn't"
+                         "atleast 64Kb apart %llx", addr_diff);
                 warn_cnt++;
             }
         }

--- a/test_pool/mpam/error002.c
+++ b/test_pool/mpam/error002.c
@@ -66,7 +66,7 @@ void payload(void)
         if (status == ACS_STATUS_SKIP) {
             /* Restore MPAM2_EL2 settings */
             val_mpam_reg_write(MPAM2_EL2, mpam2_el2_temp);
-            val_print(WARN, "\n       MSC PARTID range exceeds PE PARTID range \n");
+            val_print(WARN, "\n       MSC PARTID range exceeds PE PARTID range");
             continue;
         }
 

--- a/test_pool/mpam/error014.c
+++ b/test_pool/mpam/error014.c
@@ -80,7 +80,7 @@ payload(void)
         /* CSU/MBWU monitors are required to generate the second error.
            Skip MSC if mon not present */
         if (mon_count == 0) {
-            val_print(WARN, "\n       Cannot generate second error. Skipping MSC\n");
+            val_print(WARN, "\n       Cannot generate second error. Skipping MSC");
             continue;
         }
 

--- a/test_pool/mpam/mem001.c
+++ b/test_pool/mpam/mem001.c
@@ -144,7 +144,7 @@ void payload(void)
         return;
     }
 
-    val_print(DEBUG, "\n       MinMax PARTID = %d\n", minmax_partid);
+    val_print(DEBUG, "\n       MinMax PARTID = %d", minmax_partid);
 
     /* Disable all types of partitioning for all other nodes */
     for (msc_index = 0; msc_index < total_nodes; msc_index++) {
@@ -285,7 +285,7 @@ void payload(void)
                 };
 
                 start_count = val_mpam_memory_mbwumon_read_count(msc_index);
-                val_print(INFO, "\n        Start count is %llx", start_count);
+                val_print(INFO, "\n       Start count is %llx", start_count);
 
                 /* perform memory operation */
                 val_memcpy(src_buf, dest_buf, buf_size);
@@ -297,7 +297,7 @@ void payload(void)
                 };
 
                 end_count = val_mpam_memory_mbwumon_read_count(msc_index);
-                val_print(INFO, "\n        End count is %llx", end_count);
+                val_print(INFO, "\n       End count is %llx", end_count);
 
                 /* read the memory bandwidth usage monitor */
                 counter[enabled_scenarios++][msc_index][rsrc_index] =

--- a/test_pool/mpam/mem002.c
+++ b/test_pool/mpam/mem002.c
@@ -77,7 +77,7 @@ static int wait_for_secondary_off(uint32_t primary_pe_index)
         for (pe_index = 0; pe_index < num_pe_cont; pe_index++) {
 
             if ((pe_index != primary_pe_index) && IS_RESULT_PENDING(val_get_status(pe_index))) {
-                val_print(ERROR, " Secondary PE %x OFF time-out \n", pe_index);
+                val_print(ERROR, "\n       Secondary PE %x OFF time-out", pe_index);
             }
         }
         return 1;

--- a/test_pool/mpam/mem003.c
+++ b/test_pool/mpam/mem003.c
@@ -143,7 +143,7 @@ void payload(void)
         return;
     }
 
-    val_print(DEBUG, "\n       MinMax PARTID = %d\n", minmax_partid);
+    val_print(DEBUG, "\n       MinMax PARTID = %d", minmax_partid);
 
     /* Disable all types of partitioning for all other nodes */
     for (msc_index = 0; msc_index < total_nodes; msc_index++) {
@@ -284,7 +284,7 @@ void payload(void)
                 };
 
                 start_count = val_mpam_memory_mbwumon_read_count(msc_index);
-                val_print(INFO, "\n        Start count is %llx", start_count);
+                val_print(INFO, "\n       Start count is %llx", start_count);
 
                 /* perform memory operation */
                 val_memcpy(src_buf, dest_buf, buf_size);
@@ -296,7 +296,7 @@ void payload(void)
                 };
 
                 end_count = val_mpam_memory_mbwumon_read_count(msc_index);
-                val_print(INFO, "\n        End count is %llx", end_count);
+                val_print(INFO, "\n       End count is %llx", end_count);
 
                 /* read the memory bandwidth usage monitor */
                 counter[enabled_scenarios++][msc_index][rsrc_index] =

--- a/test_pool/mpam/mpam007.c
+++ b/test_pool/mpam/mpam007.c
@@ -128,7 +128,7 @@ static void payload(void)
     }
 
     /* test mem-side cache for cpor support */
-    val_print(DEBUG, "\n\n       Testing mem-side caches for CPOR support");
+    val_print(DEBUG, "\n       Testing mem-side caches for CPOR support");
     pe_prox_domain = val_srat_get_info(SRAT_GICC_PROX_DOMAIN, val_pe_get_uid(index));
     /* visit each MSC node and check for mem cache resources */
     for (msc_index = 0; msc_index < msc_node_cnt; msc_index++) {

--- a/test_pool/nist_sts/test_n001.c
+++ b/test_pool/nist_sts/test_n001.c
@@ -68,8 +68,8 @@ check_prerequisite_nist(void)
       snprintf(file_name[i], 20, "tmp_%d.txt", i);
       fp[i] = fopen(file_name[i], "wb");
       if (fp[i] == NULL) {
-          val_print(ERROR, "\nMax # of opened files has been reached. "
-                                   "NIST prerequistite failed: %d", i);
+          val_print(ERROR, "\n       Max # of opened files has been reached."
+                           "NIST prerequistite failed: %d", i);
           status = ACS_STATUS_FAIL;
           break;
       }
@@ -99,7 +99,7 @@ print_nist_result(void)
   fptr = fopen(filename, "r");
   if (fptr == NULL)
   {
-      val_print(ERROR, "Cannot open file\n");
+      val_print(ERROR, "\n       Cannot open file");
       return ACS_STATUS_FAIL;
   }
 
@@ -115,7 +115,7 @@ print_nist_result(void)
 
       /* Print line read on cosole*/
       //ToDo: Print using val_print
-      //val_print(INFO, "%s\n", buffer);
+      //val_print(INFO, "\n       %s", buffer);
       printf("%s\n", buffer);
   }
 

--- a/test_pool/pcie/p003.c
+++ b/test_pool/pcie/p003.c
@@ -109,12 +109,12 @@ payload(void)
 
           status = func_ecam_is_rp_ecam(bdf);
           if (status) {
-              val_print(ERROR, "  dp_type: 0x%x ", dp_type);
+              val_print(ERROR, "\n  dp_type: 0x%x ", dp_type);
 
               if (status == PCIE_RP_NOT_FOUND)
-                  val_print(ERROR, "  No RP found to the EP");
+                  val_print(ERROR, "\n  No RP found to the EP");
               else
-                  val_print(ERROR, "  RP and EP does not share same ECAM region");
+                  val_print(ERROR, "\n  RP and EP does not share same ECAM region");
 
               fail_cnt++;
           }

--- a/test_pool/pcie/p004.c
+++ b/test_pool/pcie/p004.c
@@ -230,12 +230,12 @@ payload(void)
 
            val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
            ur_status = val_pcie_is_urd(bdf);
-           val_print(DEBUG, "       Value read is 0x%llx, UR status is %d", value, ur_status);
+           val_print(DEBUG, "\n       Value read is 0x%llx, UR status is %d", value, ur_status);
            if (!ur_status)
            {
                val_print(ERROR,
                      "\n       UR response not obtained for out of range access on bdf 0x%x", bdf);
-               val_print(ERROR, " Range register value 0x%x", read_value);
+               val_print(ERROR, "\n Range register value 0x%x", read_value);
                val_print(ERROR, "\n       Out of range 0x%llx",
                                     (new_mem_lim + MEM_OFFSET_SMALL));
                val_set_status(pe_index, RESULT_FAIL(03));

--- a/test_pool/pcie/p005.c
+++ b/test_pool/pcie/p005.c
@@ -189,7 +189,7 @@ payload(void)
         if ((mem_base + mem_offset) > mem_lim)
         {
             val_print(ERROR,
-                    "\n        Memory offset + base 0x%llx", mem_base + mem_offset);
+                    "\n       Memory offset + base 0x%llx", mem_base + mem_offset);
             val_print(ERROR, " exceeds the memory limit 0x%llx", mem_lim);
             val_set_status(pe_index, RESULT_FAIL(02));
             return;
@@ -211,7 +211,7 @@ payload(void)
              val_pcie_is_urd(bdf)) {
           val_print(DEBUG, "\n       Value written into memory - 0x%x", KNOWN_DATA);
           val_print(DEBUG, "\n       Value in memory after write - 0x%x", read_value);
-          val_print(ERROR, "\n       Memory access check failed for BDF  0x%x\n", bdf);
+          val_print(ERROR, "\n       Memory access check failed for BDF  0x%x", bdf);
           val_set_status(pe_index, RESULT_FAIL(02));
           val_pcie_clear_urd(bdf);
           return;
@@ -243,7 +243,7 @@ payload(void)
                val_pcie_write_cfg(bdf, TYPE1_P_MEM_LU, (mem_base >> 32));
 
            mem_base = ((uint32_t)mem_base) | ((uint32_t)mem_base >> 16);
-           val_print(TRACE, "       mem_base new is 0x%llx", mem_base);
+           val_print(TRACE, "\n       mem_base new is 0x%llx", mem_base);
            val_pcie_write_cfg(bdf, TYPE1_P_MEM, mem_base);
 
            val_pcie_read_cfg(bdf, TYPE1_P_MEM, &read_value);
@@ -263,12 +263,12 @@ payload(void)
 
            val_pcie_bar_mem_read(bdf, new_mem_lim + MEM_OFFSET_SMALL, &value);
            ur_status = val_pcie_is_urd(bdf);
-           val_print(DEBUG, "       Value read is 0x%llx, UR status is %d", value, ur_status);
+           val_print(DEBUG, "\n       Value read is 0x%llx, UR status is %d", value, ur_status);
            if (!ur_status)
            {
                val_print(ERROR,
                      "\n       UR response not obtained for out of range access on bdf 0x%x", bdf);
-               val_print(ERROR, " Range 0x%llx - 0x%llx",
+               val_print(ERROR, "\n Range 0x%llx - 0x%llx",
                                             updated_mem_base, updated_mem_lim);
                val_print(ERROR, "\n       Out of range 0x%llx",
                                          (new_mem_lim + MEM_OFFSET_SMALL));

--- a/test_pool/pcie/p011.c
+++ b/test_pool/pcie/p011.c
@@ -84,7 +84,7 @@ payload(void)
 
         if ((ecam_cr != ecam_cr_8) || (ecam_cr_8 != ecam_cr_16))
         {
-          val_print(ERROR, "\n        Byte Enable Read Failed for Bdf: 0x%x", bdf);
+          val_print(ERROR, "\n       Byte Enable Read Failed for Bdf: 0x%x", bdf);
           test_fail++;
         }
 
@@ -100,7 +100,7 @@ payload(void)
             ecam_cr_new = val_mmio_read8(ecam_base + busnum_offset + i);
             if (write_value != ecam_cr_new)
             {
-              val_print(ERROR, "\n        8 Bit Write Failed for Bdf: 0x%x", bdf);
+              val_print(ERROR, "\n       8 Bit Write Failed for Bdf: 0x%x", bdf);
               test_fail++;
             }
         }
@@ -116,7 +116,7 @@ payload(void)
         ecam_cr_new = val_mmio_read16(ecam_base + busnum_offset);
         if (write_value != ecam_cr_new)
         {
-          val_print(ERROR, "\n        16 Bit Write Failed for Bdf: 0x%x", bdf);
+          val_print(ERROR, "\n       16 Bit Write Failed for Bdf: 0x%x", bdf);
           test_fail++;
         }
 

--- a/test_pool/pcie/p021.c
+++ b/test_pool/pcie/p021.c
@@ -35,7 +35,7 @@ payload(void)
   pe_index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   if (val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0) == 0) {
-      val_print(DEBUG, "\n        No ECAMs discovered, Skipping test");
+      val_print(DEBUG, "\n       No ECAMs discovered, Skipping test");
       val_set_status(pe_index, RESULT_SKIP(1));
       return;
   }

--- a/test_pool/pcie/p046.c
+++ b/test_pool/pcie/p046.c
@@ -103,7 +103,7 @@ payload (void)
       /* Get BDF of a device */
       dev_bdf = val_peripheral_get_info (ANY_BDF, count - 1);
       if (dev_bdf) {
-        val_print (TRACE, "       Checking PCI device with BDF %4X\n", dev_bdf);
+        val_print (TRACE, "\n       Checking PCI device with BDF %4X", dev_bdf);
         /* Read MSI(X) vectors */
         ret = val_get_msi_vectors (dev_bdf, &dev_mvec);
 
@@ -118,12 +118,12 @@ payload (void)
           while(mvec) {
               if(mvec->vector.vector_irq_base < LPI_BASE) {
                  val_print(ERROR,
-                    "       MSI vector irq %llx is not an LPI\n", mvec->vector.vector_irq_base);
+                    "\n       MSI vector irq %llx is not an LPI", mvec->vector.vector_irq_base);
                  val_set_status (index, RESULT_FAIL(mvec->vector.vector_irq_base));
                  status = 1;
               }else {
                 val_print(DEBUG,
-                    "       MSI vector irq %llx is an LPI\n", mvec->vector.vector_irq_base);
+                    "\n       MSI vector irq %llx is an LPI", mvec->vector.vector_irq_base);
               }
               mvec = mvec->next;
           }
@@ -137,7 +137,7 @@ payload (void)
   }
 
   if (test_skip) {
-    val_print(DEBUG, "\n       No MSI vectors found ");
+    val_print(DEBUG, "\n       No MSI vectors found");
     val_set_status (index, RESULT_SKIP(0));
   } else if (!status) {
     val_set_status (index, RESULT_PASS);

--- a/test_pool/pcie/p061.c
+++ b/test_pool/pcie/p061.c
@@ -84,7 +84,7 @@ payload(void *arg)
       /* Valid payload size between 000b (129-bytes) to 101b (4096 bytes) */
       if (!((max_payload_value >= 0x00) && (max_payload_value <= 0x05)))
       {
-          val_print(ERROR, "\n        BDF 0x%x", bdf);
+          val_print(ERROR, "\n       BDF 0x%x", bdf);
           val_print(ERROR, " Cap Ptr Value: 0x%x", max_payload_value);
           test_fails++;
       }

--- a/test_pool/pcie/p072.c
+++ b/test_pool/pcie/p072.c
@@ -110,13 +110,13 @@ payload(void)
       bdf = bdf_tbl_ptr->device[tbl_index++].bdf;
       dp_type = val_pcie_device_port_type(bdf);
       if (dp_type == iEP_EP) {
-          val_print(DEBUG, "\n        BDF - 0x%x ", bdf);
+          val_print(DEBUG, "\n       BDF - 0x%x ", bdf);
           /* If test runs for atleast an endpoint */
           test_skip = 0;
 
           if (func_ecam_is_rp_ecam(bdf))
           {
-              val_print(ERROR, "dp_type: 0x%x ", dp_type);
+              val_print(ERROR, "\ndp_type: 0x%x ", dp_type);
               fail_cnt++;
           }
       }

--- a/test_pool/pcie/p084.c
+++ b/test_pool/pcie/p084.c
@@ -60,9 +60,9 @@ payload(void)
                 (RCEC_SUB_CLASS != ((reg_value >> CC_SUB_SHIFT) & CC_SUB_MASK)) ||
                 (RCEC_PGMING_IF != ((reg_value >> CC_PGM_IF_SHIFT) & CC_PGM_IF_MASK)))
           {
-              val_print(ERROR, "       Class code mismatch for bdf: 0x%x\n", bdf);
-              val_print(ERROR, "       dp_type: 0x%x\n", dp_type);
-              val_print(ERROR, "       CCR: 0x%x\n", reg_value);
+              val_print(ERROR, "\n       Class code mismatch for bdf: 0x%x", bdf);
+              val_print(ERROR, "\n       dp_type: 0x%x", dp_type);
+              val_print(ERROR, "\n       CCR: 0x%x", reg_value);
               fail_cnt++;
           }
 

--- a/test_pool/pcie/p095.c
+++ b/test_pool/pcie/p095.c
@@ -59,8 +59,8 @@ payload(void)
           iommu_flag++;
           val_dma_device_get_dma_addr(target_dev_index, &dma_addr, &dma_len);
           if (dma_addr == 0 || dma_len == 0) {
-             val_print(ERROR, "\n        No active or valid ata command or "
-                                      "scatterlist for device at index : %d", target_dev_index);
+             val_print(ERROR, "\n       No active or valid ata command or"
+                              "scatterlist for device at index : %d", target_dev_index);
              continue;
           }
           status = val_smmu_ops(SMMU_CHECK_DEVICE_IOVA, &target_dev_index, &dma_addr);
@@ -69,7 +69,7 @@ payload(void)
                 goto test_warn_unimplemented;
             }
             val_print(ERROR, "\n       The DMA address %lx used by device ", dma_addr);
-            val_print(ERROR, "\n       is not present in the SMMU IOVA table\n");
+            val_print(ERROR, "\n       is not present in the SMMU IOVA table");
             val_set_status(index, RESULT_FAIL(target_dev_index));
             return;
           }

--- a/test_pool/pcie/p096.c
+++ b/test_pool/pcie/p096.c
@@ -125,12 +125,12 @@ payload (void)
                 if (irq_map->legacy_irq_map[current_irq_pin].irq_list[ccnt] ==
                     irq_map->legacy_irq_map[next_irq_pin].irq_list[ncnt]) {
                   status = 7;
-                  val_print(ERROR, "\n        BDF : %x", dev_bdf);
+                  val_print(ERROR, "\n       BDF : %x", dev_bdf);
                   val_print(ERROR, " Legacy interrupt %c",
                                              pin_name(current_irq_pin));
                   val_print(ERROR, "(%d) routing", current_irq_pin);
 
-                  val_print(ERROR, "\n        is same as the %c",
+                  val_print(ERROR, "\n       is same as the %c",
                                              pin_name(next_irq_pin));
                   val_print(ERROR, "(%d) routing", next_irq_pin);
                 }

--- a/test_pool/pcie/p097.c
+++ b/test_pool/pcie/p097.c
@@ -140,7 +140,7 @@ payload (void)
 
       val_pcie_read_cfg(bdf, TYPE01_RIDR, &class_code);
       val_print(DEBUG, "\n     Primary  BDF is 0x%x", bdf);
-      val_print(DEBUG, "\n         Class code is 0x%x", class_code);
+      val_print(DEBUG, "\n       Class code is 0x%x", class_code);
 
       base_cc = class_code >> TYPE01_BCC_SHIFT;
 
@@ -156,14 +156,14 @@ payload (void)
         if (skip_by_flag)
           skip_due_to_flag = true;
         tbl_index++;
-        val_print(DEBUG, "\n        Skipping DP/NIC/MAS/RES device.");
+        val_print(DEBUG, "\n       Skipping DP/NIC/MAS/RES device.");
         continue;
       }
 
       dp_type = val_pcie_device_port_type(bdf);
       /* Check entry is EP. Else move to next BDF. */
       if (dp_type == EP) {
-        val_print(DEBUG, "\n        Continuing... device is EP");
+        val_print(DEBUG, "\n       Continuing... device is EP");
         current_dev_bdf = bdf;
         if (!check_msi_status(current_dev_bdf))
         {
@@ -202,7 +202,7 @@ payload (void)
                 {
                   if (skip_by_flag)
                     skip_due_to_flag = true;
-                  val_print(DEBUG, "\n        Skipping DP/NIC/MAS/RES device.");
+                  val_print(DEBUG, "\n       Skipping DP/NIC/MAS/RES device.");
                   tbl_index_next++;
                   continue;
                 }
@@ -211,7 +211,7 @@ payload (void)
                 /* Check entry is EP. Else move to next BDF. */
                 if (dp_type == EP)
                 {
-                  val_print(DEBUG, "\n        Continuing...device is EP");
+                  val_print(DEBUG, "\n       Continuing...device is EP");
                   next_dev_bdf = bdf;
                   if (!check_msi_status(next_dev_bdf))
                   {

--- a/test_pool/pcie/p105.c
+++ b/test_pool/pcie/p105.c
@@ -68,7 +68,7 @@ payload(void)
             }
             val_print(ERROR, "\n       The DMA addr allocated to device %d ",
                     target_dev_index);
-            val_print(ERROR, "\n       is not present in the SMMU IOVA table\n");
+            val_print(ERROR, "\n       is not present in the SMMU IOVA table");
             val_set_status(index, RESULT_FAIL(target_dev_index));
             return;
           }

--- a/test_pool/pe/pe001.c
+++ b/test_pool/pe/pe001.c
@@ -353,7 +353,7 @@ payload(uint32_t num_pe)
   g_pe_reg_info = (pe_reg_info *) val_memory_calloc(num_pe, sizeof(pe_reg_info));
 
   if (g_pe_reg_info == NULL) {
-      val_print(ERROR, "\n       Allocation for secondary PE Registers Failed \n");
+      val_print(ERROR, "\n       Allocation for secondary PE Registers Failed");
       val_set_status(my_index, RESULT_FAIL(1));
       return;
   }
@@ -372,8 +372,8 @@ payload(uint32_t num_pe)
       }
   }
 
-  val_print(INFO, "\n       Primary PE Index     %d", my_index);
-  val_print(INFO, "\n       Primary PE MIDR_EL1  0x%08llx", rd_data_array[1]);
+  val_print(INFO, "\n          Primary PE Index     %d", my_index);
+  val_print(INFO, "\n          Primary PE MIDR_EL1  0x%08llx", rd_data_array[1]);
 
   for (i = 0; i < num_pe; i++) {
       uint32_t unique = 1;
@@ -388,11 +388,11 @@ payload(uint32_t num_pe)
           }
           if (unique == 1 && rd_data_array[1] != pe_buffer->reg_data[1]) {
               if (t == 0) {
-                  val_print(INFO, "\n       Other Cores          0x%08llx      ",
+                  val_print(INFO, "\n          Other Cores          0x%08llx      ",
                                                                         pe_buffer->reg_data[1]);
                   t = 1;
               } else {
-                  val_print(INFO, "\n                             0x%08llx      ",
+                  val_print(INFO, "\n          0x%08llx      ",
                                                                         pe_buffer->reg_data[1]);
                 }
            }
@@ -400,7 +400,7 @@ payload(uint32_t num_pe)
   }
 
   if (t == 0) {
-      val_print(INFO, "\n       Other Cores          Identical       ");
+      val_print(INFO, "\n          Other Cores          Identical       ");
   }
 
   pe_buffer = NULL;
@@ -413,20 +413,20 @@ payload(uint32_t num_pe)
              if (!(pe_buffer->cache_status[cache_index]) &&
                                                     (pe_buffer->pe_cache[cache_index] != 0))
              {
-                 val_print(TRACE, "\n        PE Index %d", i);
+                 val_print(TRACE, "\n       PE Index %d", i);
                  val_print(TRACE, ", cache index %d", cache_index);
                  val_print(TRACE, ", size read 0x%016llx",
                                                              pe_buffer->pe_cache[cache_index]);
              }
              else if (pe_buffer->pe_cache[cache_index] != 0)
              {
-                   val_print(ERROR, "\n        PE Index %d", i);
+                   val_print(ERROR, "\n       PE Index %d", i);
                    val_print(ERROR, ", cache index %d", cache_index);
-                   val_print(ERROR, ", size read 0x%016llx     FAIL\n",
+                   val_print(ERROR, ", size read 0x%016llx     FAIL",
                                                              pe_buffer->pe_cache[cache_index]);
-                   val_print(ERROR, "          Masked Primary PE Value  0x%016llx \n",
+                   val_print(ERROR, "\n       Masked Primary PE Value  0x%016llx",
                                               cache_list[cache_index] & (~reg_list[0].reg_mask));
-                   val_print(ERROR, "          Masked Current PE Value  0x%016llx ",
+                   val_print(ERROR, "\n       Masked Current PE Value  0x%016llx",
                                       pe_buffer->pe_cache[cache_index] & (~reg_list[0].reg_mask));
                    cache_fail = cache_fail + 1;
              }
@@ -434,28 +434,28 @@ payload(uint32_t num_pe)
 
           for (int reg_index = 1; reg_index < NUM_OF_REGISTERS; reg_index++) {
              if (!(pe_buffer->reg_status[reg_index])) {
-                 val_print(TRACE, "\n        PE Index %d, ", i);
+                 val_print(TRACE, "\n       PE Index %d, ", i);
                  val_print(TRACE, reg_list[reg_index].reg_desc);
                  if (reg_list[reg_index].dependency == AA32)
                      val_print(TRACE, "   0x%08llx", pe_buffer->reg_data[reg_index]);
                  else
                      val_print(TRACE, "   0x%016llx", pe_buffer->reg_data[reg_index]);
              } else  {
-                 val_print(ERROR, "\n        PE Index %d, ", i);
+                 val_print(ERROR, "\n       PE Index %d, ", i);
                  val_print(ERROR, reg_list[reg_index].reg_desc);
                  if (reg_list[reg_index].dependency == AA32) {
-                     val_print(ERROR, "    0x%08llx    FAIL\n",
+                     val_print(ERROR, "    0x%08llx    FAIL",
                                                         pe_buffer->reg_data[reg_index]);
-                     val_print(ERROR, "          Masked Primary PE Value  0x%08llx \n",
+                     val_print(ERROR, "\n       Masked Primary PE Value  0x%08llx",
                                        rd_data_array[reg_index] & (~reg_list[reg_index].reg_mask));
-                     val_print(ERROR, "          Masked Current PE Value  0x%08llx ",
+                     val_print(ERROR, "\n       Masked Current PE Value  0x%08llx",
                                  pe_buffer->reg_data[reg_index] & (~reg_list[reg_index].reg_mask));
                  } else {
-                     val_print(ERROR, "    0x%016llx    FAIL\n",
+                     val_print(ERROR, "    0x%016llx    FAIL",
                                                         pe_buffer->reg_data[reg_index]);
-                     val_print(ERROR, "          Masked Primary PE Value  0x%016llx \n",
+                     val_print(ERROR, "\n       Masked Primary PE Value  0x%016llx",
                                        rd_data_array[reg_index] & (~reg_list[reg_index].reg_mask));
-                     val_print(ERROR, "          Masked Current PE Value  0x%016llx ",
+                     val_print(ERROR, "\n       Masked Current PE Value  0x%016llx",
                                  pe_buffer->reg_data[reg_index] & (~reg_list[reg_index].reg_mask));
                    }
                  reg_fail = reg_fail + 1;
@@ -468,7 +468,7 @@ payload(uint32_t num_pe)
   }
 
   if (total_fail) {
-      val_print(ERROR, "\n\n    Total Register and cache fail for all PE %d \n",
+      val_print(ERROR, "\n       Total Register and cache fail for all PE %d",
                                                                              total_fail);
       val_set_status(my_index, RESULT_FAIL(4));
   }

--- a/test_pool/pe/pe016.c
+++ b/test_pool/pe/pe016.c
@@ -172,7 +172,7 @@ pe016_entry(uint32_t num_pe)
 
   smbios_slots = val_get_num_smbios_slots();
   if (smbios_slots == 0) {
-    val_print(WARN, "\n       SMBIOS Table Not Found, Skipping the test\n");
+    val_print(WARN, "\n       SMBIOS Table Not Found, Skipping the test");
     status = ACS_STATUS_SKIP;
     val_set_status(index, RESULT_SKIP(1));
 
@@ -205,7 +205,7 @@ pe016_entry(uint32_t num_pe)
       } else {
         val_print(DEBUG, "\n       ID_AA64ZFR0_EL1.SVEver 0x%llx PASS", reg_buffer->data);
         if (reg_buffer->vector_len_bits)
-          val_print(INFO, "\n       PE[%d] VL = %u bits", i, reg_buffer->vector_len_bits);
+          val_print(DEBUG, "\n       PE[%d] VL = %u bits", i, reg_buffer->vector_len_bits);
         else
           val_print(DEBUG, "\n       PE[%d] VL probe skipped or not accessible", i);
       }

--- a/test_pool/peripherals/d002.c
+++ b/test_pool/peripherals/d002.c
@@ -54,19 +54,19 @@ payload()
           ret = val_pcie_read_cfg(bdf, 0x8, &interface);
           interface = (interface >> 8) & 0xFF;
           if (ret == PCIE_NO_MAPPING || interface != 0x01) {
-              val_print(TRACE, "       WARN: SATA CTRL ECAM access failed %x\n",
+              val_print(TRACE, "\n       WARN: SATA CTRL ECAM access failed %x",
                         interface);
-              val_print(TRACE, "       Re-checking SATA CTRL using PciIo protocol\n");
+              val_print(TRACE, "\n       Re-checking SATA CTRL using PciIo protocol");
               ret = val_pcie_io_read_cfg(bdf, 0x8, &interface);
               if (ret == PCIE_NO_MAPPING) {
-                  val_print(DEBUG, "       Reading device class code using PciIo"
-                            " protocol failed\n");
+                  val_print(DEBUG, "\n       Reading device class code using PciIo"
+                            " protocol failed");
                   val_set_status(index, RESULT_FAIL(2));
                   return;
               }
               interface = (interface >> 8) & 0xFF;
               if (interface != 0x01) {
-                  val_print(DEBUG, " Detected SATA CTRL not AHCI\n");
+                  val_print(DEBUG, "\n       Detected SATA CTRL not AHCI");
                   val_set_status(index, RESULT_FAIL(1));
                   return;
               }

--- a/test_pool/peripherals/d003.c
+++ b/test_pool/peripherals/d003.c
@@ -204,15 +204,14 @@ check_uart_16550()
       if (uart_is_16550(interface_type)) {
           test_skip = 0;
           val_print(DEBUG,
-              "\n         UART 16550 found with instance: %x",
+              "\n       UART 16550 found with instance: %x",
               count - 1);
 
           /* Check the I/O base address */
           uart_base = val_peripheral_get_info(UART_BASE0, count - 1);
           if (uart_base == 0)
           {
-              val_print(ERROR, "\n         UART base must be specified"
-                                       " for instance: %x", count - 1);
+              val_print(ERROR, "\n       UART base must be specified for instance: %x", count - 1);
               return TEST_FAIL;
           }
 
@@ -220,8 +219,8 @@ check_uart_16550()
           access_width = val_peripheral_get_info(UART_WIDTH, count - 1);
           if (val_peripheral_uart_16550_width_to_access(access_width, &reg_shift,
                                                         &width_mask)) {
-              val_print(ERROR, "\n         UART access width must be specified"
-                                       " for instance: %x", count - 1);
+              val_print(ERROR, "\n       UART access width must be specified for "
+                               "instance: %x", count - 1);
               return TEST_FAIL;
           }
 
@@ -231,8 +230,7 @@ check_uart_16550()
           {
               if (baud_rate != 0)
               {
-                  val_print(ERROR, "\n         Baud rate %d outside"
-                                           " supported range", baud_rate);
+                  val_print(ERROR, "\n       Baud rate %d outside supported range", baud_rate);
                   val_print(ERROR, " for instance %x", count - 1);
                   test_fail = 1;
               }
@@ -249,8 +247,8 @@ check_uart_16550()
           val_peripheral_uart_16550_reg_write(uart_base, LCR, reg_shift, width_mask, lcr_reg);
           if ((lcr_scratch2 != 0) || (lcr_scratch3 != 0xFF))
           {
-              val_print(ERROR, "\n   LCR register are not read/write"
-                                       " for instance: %x", count - 1);
+              val_print(ERROR, "\n       LCR register are not read/write for "
+                               "instance: %x", count - 1);
               test_fail = 1;
           }
 
@@ -265,8 +263,8 @@ check_uart_16550()
           val_peripheral_uart_16550_reg_write(uart_base, IER, reg_shift, width_mask, ier_reg);
           if ((ier_scratch2 != 0) || (ier_scratch3 != 0xF))
           {
-              val_print(ERROR, "\n   IER register[0:3] are not read/write"
-                                       " for instance: %x", count - 1);
+              val_print(ERROR, "\n       IER register[0:3] are not read/write for "
+                               "instance: %x", count - 1);
               test_fail = 1;
           }
 
@@ -279,8 +277,7 @@ check_uart_16550()
           val_peripheral_uart_16550_reg_write(uart_base, MCR, reg_shift, width_mask, mcr_reg);
           if ((msr_status & 0xF0) != CTS_DCD_EN)
           {
-              val_print(ERROR, "\n   Loopback test mode failed"
-                                       " for instance: %x", count - 1);
+              val_print(ERROR, "\n       Loopback test mode failed for instance: %x", count - 1);
               test_fail = 1;
           }
 

--- a/test_pool/peripherals/d004.c
+++ b/test_pool/peripherals/d004.c
@@ -82,8 +82,7 @@ payload_check_dma_mem_attribute(void)
             goto test_warn_unimplemented;
           }
           val_print(ERROR,
-                    "\n       DMA controller %d: Failed to get"
-                    " memory attributes\n",
+                    "\n       DMA controller %d: Failed to get memory attributes",
                     target_dev_index);
           val_set_status(index, RESULT_FAIL(1));
           flag_fail = 1;
@@ -96,8 +95,7 @@ payload_check_dma_mem_attribute(void)
           MEM_DEVICE(attr)))              /* Check Device type */
       {
           val_print(TRACE,
-                    "\n       DMA controller %d: DMA memory must be inner/outer writeback inner "
-                    "shareable, inner/outer non-cacheable, or device type\n",
+                    "\n       DMA controller %d: DMA memory must be inner/outer writeback inner shareable, inner/outer non-cacheable, or device type",
           target_dev_index);
           val_set_status(index, RESULT_FAIL(2));
           flag_fail = 1;
@@ -154,7 +152,7 @@ payload_check_io_coherent_dma_mem_attribute(void)
                 goto test_warn_unimplemented;
             } else if (ret) {
                 val_print(ERROR,
-                            "\n       DMA controller %d: Failed to get memory attributes\n",
+                            "\n       DMA controller %d: Failed to get memory attributes",
                             target_dev_index);
                 val_set_status(index, RESULT_FAIL(1));
                 flag_fail = 1;
@@ -164,10 +162,10 @@ payload_check_io_coherent_dma_mem_attribute(void)
             if (!(MEM_NORMAL_WB_IN_OUT(attr) && MEM_SH_INNER(sh)))
             {
                 val_print(TRACE,
-                            "\n       DMA controller %d: I/O Coherent DMA memory must\n",
+                            "\n       DMA controller %d: I/O Coherent DMA memory must",
                             target_dev_index);
                 val_print(TRACE,
-                            "       be inner/outer writeback, inner shareable\n");
+                            "\n       be inner/outer writeback, inner shareable");
                 val_set_status(index, RESULT_FAIL(2));
                 flag_fail = 1;
             }

--- a/test_pool/pfdi/pfdi002.c
+++ b/test_pool/pfdi/pfdi002.c
@@ -55,7 +55,7 @@ static void payload_all_pe_version_check(void *arg)
   /* Allocate memory to save all PFDI Versions or status for all PE's */
   g_pfdi_version_details = (PFDI_RET_PARAMS *) val_memory_calloc(num_pe, sizeof(PFDI_RET_PARAMS));
   if (g_pfdi_version_details == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Version Details Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Version Details Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi003.c
+++ b/test_pool/pfdi/pfdi003.c
@@ -59,7 +59,7 @@ static void payload_functions_check(void *arg)
   /* Allocate memory to save all PFDI features status for all PE's */
   g_pfdi_feature_details = (feature_details *) val_memory_calloc(num_pe, sizeof(feature_details));
   if (g_pfdi_feature_details == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Feature Details Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Feature Details Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi006.c
+++ b/test_pool/pfdi/pfdi006.c
@@ -53,7 +53,7 @@ static void payload_pe_test_info_check(void *arg)
   g_pfdi_pe_test_support_info =
         (PFDI_RET_PARAMS *)val_memory_calloc(num_pe, sizeof(PFDI_RET_PARAMS));
   if (g_pfdi_pe_test_support_info == NULL) {
-      val_print(ERROR, "\n       Allocation for PFDI PE Test Support Info Failed \n");
+      val_print(ERROR, "\n       Allocation for PFDI PE Test Support Info Failed");
       return;
   }
 

--- a/test_pool/pfdi/pfdi021.c
+++ b/test_pool/pfdi/pfdi021.c
@@ -84,7 +84,7 @@ static void payload_invalid_pe_version_check(void *arg)
   g_pfdi_invalid_version = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_version == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Version Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Version Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi022.c
+++ b/test_pool/pfdi/pfdi022.c
@@ -78,7 +78,7 @@ static void payload_invalid_pe_feature_check(void *arg)
   g_pfdi_invalid_feature = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_feature == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Feature Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Feature Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi023.c
+++ b/test_pool/pfdi/pfdi023.c
@@ -84,7 +84,7 @@ static void payload_invalid_pe_test_id_check(void *arg)
   g_pfdi_invalid_pe_test_id = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_pe_test_id == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid PE Test ID Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid PE Test ID Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi024.c
+++ b/test_pool/pfdi/pfdi024.c
@@ -84,7 +84,7 @@ static void payload_invalid_pe_test_part_count_check(void *arg)
   g_pfdi_invalid_test_part_count = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_test_part_count == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Test Part Count Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Test Part Count Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi025.c
+++ b/test_pool/pfdi/pfdi025.c
@@ -84,7 +84,7 @@ static void payload_invalid_pe_test_result_check(void *arg)
   g_pfdi_invalid_test_result = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_test_result == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Test Result Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Test Result Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi026.c
+++ b/test_pool/pfdi/pfdi026.c
@@ -84,7 +84,7 @@ static void payload_invalid_pe_fw_check(void *arg)
   g_pfdi_invalid_fw_check = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_fw_check == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Firmware Check Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Firmware Check Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi029.c
+++ b/test_pool/pfdi/pfdi029.c
@@ -74,7 +74,7 @@ static void payload_invalid_run_check(void *arg)
   g_pfdi_invalid_run = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_run == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Test Run Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Test Run Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi030.c
+++ b/test_pool/pfdi/pfdi030.c
@@ -74,7 +74,7 @@ static void payload_invalid_force_error_check(void *arg)
   g_pfdi_invalid_force_error = (PFDI_INVAL_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_RETURNS));
   if (g_pfdi_invalid_force_error == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Force Error Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Force Error Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/pfdi/pfdi031.c
+++ b/test_pool/pfdi/pfdi031.c
@@ -70,7 +70,7 @@ static void payload_force_error_invalid_fn_check(void *arg)
   g_pfdi_force_error_invalid_fn = (PFDI_INVAL_FUNC_RETURNS *)
                             val_memory_calloc(num_pe, sizeof(PFDI_INVAL_FUNC_RETURNS));
   if (g_pfdi_force_error_invalid_fn == NULL) {
-    val_print(ERROR, "\n       Allocation for PFDI Invalid Force Error Failed \n");
+    val_print(ERROR, "\n       Allocation for PFDI Invalid Force Error Failed");
     val_set_status(index, RESULT_FAIL(1));
     return;
   }

--- a/test_pool/power_wakeup/u001.c
+++ b/test_pool/power_wakeup/u001.c
@@ -33,7 +33,7 @@ isr1()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_timer_set_phy_el1(0);
-  val_print(TRACE, "       Received EL1 PHY interrupt\n");
+  val_print(TRACE, "\n       Received EL1 PHY interrupt");
   g_el1phy_int_received = 1;
   val_set_status(index, RESULT_PASS);
   intid = val_timer_get_info(TIMER_INFO_PHY_EL1_INTID, 0);

--- a/test_pool/power_wakeup/u002.c
+++ b/test_pool/power_wakeup/u002.c
@@ -34,7 +34,7 @@ isr_failsafe()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_timer_set_phy_el1(0);
-  val_print(ERROR, "       Received Failsafe interrupt\n");
+  val_print(ERROR, "\n       Received Failsafe interrupt");
   g_failsafe_int_rcvd = 1;
 
   /* On some system the failsafe is rcvd just after test interrupt and resulting
@@ -77,13 +77,13 @@ isr2()
 
   /* We received our interrupt, so disable timer from generating further interrupts */
   val_timer_set_vir_el1(0);
-  val_print(TRACE, "       Received EL1 VIRT interrupt\n");
+  val_print(TRACE, "\n       Received EL1 VIRT interrupt");
   g_el1vir_int_received = 1;
   val_set_status(index, RESULT_PASS);
   intid = val_timer_get_info(TIMER_INFO_VIR_EL1_INTID, 0);
   val_gic_end_of_interrupt(intid);
   val_timer_set_phy_el1(0);
-  val_print(DEBUG, "       Clear Failsafe interrupt\n");
+  val_print(DEBUG, "\n       Clear Failsafe interrupt");
 }
 
 static

--- a/test_pool/power_wakeup/u003.c
+++ b/test_pool/power_wakeup/u003.c
@@ -34,7 +34,7 @@ isr_failsafe()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_timer_set_phy_el1(0);
-  val_print(ERROR, "       Received Failsafe interrupt\n");
+  val_print(ERROR, "\n       Received Failsafe interrupt");
   g_failsafe_int_rcvd = 1;
   /* On some system the failsafe is rcvd just after test interrupt and resulting
      in incorrect fail, to avoid this ensure set test as fail only when failsafe
@@ -57,13 +57,13 @@ isr3()
 
   /* We received our interrupt, so disable timer from generating further interrupts */
   val_timer_set_phy_el2(0);
-  val_print(TRACE, "       Received EL2 Physical interrupt\n");
+  val_print(TRACE, "\n       Received EL2 Physical interrupt");
   g_el2phy_int_rcvd = 1;
   val_set_status(index, RESULT_PASS);
   intid = val_timer_get_info(TIMER_INFO_PHY_EL2_INTID, 0);
   val_gic_end_of_interrupt(intid);
   val_timer_set_phy_el1(0);
-  val_print(DEBUG, "       Clear Failsafe interrupt\n");
+  val_print(DEBUG, "\n       Clear Failsafe interrupt");
 }
 
 static

--- a/test_pool/power_wakeup/u004.c
+++ b/test_pool/power_wakeup/u004.c
@@ -35,7 +35,7 @@ isr_failsafe()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_timer_set_phy_el1(0);
-  val_print(ERROR, "       Received Failsafe interrupt\n");
+  val_print(ERROR, "\n       Received Failsafe interrupt");
   g_failsafe_int_received = 1;
   /* On some system the failsafe is rcvd just after test interrupt and resulting
      in incorrect fail, to avoid this ensure set test as fail only when failsafe
@@ -56,12 +56,12 @@ isr4()
   uint32_t intid;
 
   val_wd_set_ws0(wd_num, 0);
-  val_print(TRACE, "       Received WS0 interrupt\n");
+  val_print(TRACE, "\n       Received WS0 interrupt");
   g_wd_int_received = 1;
   intid = val_wd_get_info(wd_num, WD_INFO_GSIV);
   val_gic_end_of_interrupt(intid);
   val_timer_set_phy_el1(0);
-  val_print(DEBUG, "       Clear Failsafe interrupt\n");
+  val_print(DEBUG, "\n       Clear Failsafe interrupt");
 }
 
 static
@@ -171,7 +171,7 @@ payload4()
   }
 
   if (!ns_wdg) {
-      val_print(DEBUG, "       No non-secure watchdog implemented\n");
+      val_print(DEBUG, "\n       No non-secure watchdog implemented");
       val_set_status(index, RESULT_SKIP(2));
       return;
   }

--- a/test_pool/power_wakeup/u005.c
+++ b/test_pool/power_wakeup/u005.c
@@ -35,7 +35,7 @@ isr_failsafe()
   uint32_t intid;
 
   val_timer_set_phy_el1(0);
-  val_print(ERROR, "       Received Failsafe interrupt\n");
+  val_print(ERROR, "\n       Received Failsafe interrupt");
   g_failsafe_int_rcvd = 1;
   /* On some system the failsafe is rcvd just after test interrupt and resulting
      in incorrect fail, to avoid this ensure set test as fail only when failsafe
@@ -59,13 +59,13 @@ isr5()
   uint64_t cnt_base_n = val_timer_get_info(TIMER_INFO_SYS_CNT_BASE_N, timer_num);
 
   val_timer_disable_system_timer((addr_t)cnt_base_n);
-  val_print(TRACE, "       Received Sys timer interrupt\n");
+  val_print(TRACE, "\n       Received Sys timer interrupt");
   g_timer_int_rcvd = 1;
   val_set_status(index, RESULT_PASS);
   intid = val_timer_get_info(TIMER_INFO_SYS_INTID, timer_num);
   val_gic_end_of_interrupt(intid);
   val_timer_set_phy_el1(0);
-  val_print(DEBUG, "       Clear Failsafe interrupt\n");
+  val_print(DEBUG, "\n       Clear Failsafe interrupt");
 }
 
 static
@@ -116,14 +116,14 @@ payload5()
       //Read CNTACR to determine whether access permission from NS state is permitted
       status = val_timer_skip_if_cntbase_access_not_allowed(timer_num);
       if (status == ACS_STATUS_SKIP) {
-          val_print(DEBUG, "       Timer cntbase can't accessed\n");
+          val_print(DEBUG, "\n       Timer cntbase can't accessed");
           val_set_status(index, RESULT_SKIP(2));
           return;
       }
 
       cnt_base_n = val_timer_get_info(TIMER_INFO_SYS_CNT_BASE_N, timer_num);
       if (cnt_base_n == 0) {
-          val_print(DEBUG, "       Timer cntbase is invalid\n");
+          val_print(DEBUG, "\n       Timer cntbase is invalid");
           val_set_status(index, RESULT_SKIP(3));
           return;
       }
@@ -174,7 +174,7 @@ payload5()
   }
 
   if (!ns_timer) {
-      val_print(WARN, "       No non-secure systimer implemented\n");
+      val_print(WARN, "\n       No non-secure systimer implemented");
       val_set_status(index, RESULT_SKIP(5));
       return;
   }

--- a/test_pool/ras/ras009.c
+++ b/test_pool/ras/ras009.c
@@ -79,7 +79,7 @@ payload()
 
   val_print(TRACE,
             "\n       FEAT_ANERR not implemented."
-            " Proceeding to synchronous Data Abort test.\n");
+            " Proceeding to synchronous Data Abort test.");
 
   /* get number of nodes with RAS functionality */
   status = val_ras_get_info(RAS_INFO_NUM_NODES, 0, &num_node);

--- a/test_pool/ras/ras018.c
+++ b/test_pool/ras/ras018.c
@@ -110,13 +110,13 @@ payload()
 
         if (!dev_addr) {
             val_print(ERROR,
-                      "\n       Failed to obtain Device memory address.\n");
+                      "\n       Failed to obtain Device memory address.");
             val_set_status(index, RESULT_FAIL(01));
             return;
         }
 
         val_print(TRACE,
-                  "\n       Using Device memory address: 0x%llx\n", dev_addr);
+                  "\n       Using Device memory address: 0x%llx", dev_addr);
 
         /* Install sync and async handlers to handle exceptions.*/
         status = val_pe_install_esr(EXCEPT_AARCH64_SYNCHRONOUS_EXCEPTIONS, esr);
@@ -183,7 +183,7 @@ payload()
 
     if (usable_node_cnt == 0) {
         val_print(TRACE,
-                  "\n       No usable MMIO RAS nodes -- skipping test.\n");
+                  "\n       No usable MMIO RAS nodes -- skipping test.");
         val_set_status(index, RESULT_SKIP(01));
         return;
     }

--- a/test_pool/smmu/i001.c
+++ b/test_pool/smmu/i001.c
@@ -49,7 +49,7 @@ payload()
       }
   }
   if ((smmuv2_flag) && (smmuv3_flag)) {
-      val_print(ERROR, "\n       ALL SMMUs are not of the same Architecture version\n");
+      val_print(ERROR, "\n       ALL SMMUs are not of the same Architecture version");
       val_set_status(index, RESULT_FAIL(1));
       return;
   }

--- a/test_pool/smmu/i007.c
+++ b/test_pool/smmu/i007.c
@@ -59,7 +59,7 @@ payload()
       data = val_smmu_read_cfg(SMMUv3_IDR0, num_smmu);
       // Check I/O coherent access
       if (VAL_EXTRACT_BITS(data, 4, 4) == 0)      {
-          val_print(ERROR, "\n\t IO-Coherent access not supported  ");
+          val_print(ERROR, "\n       IO-Coherent access not supported  ");
           val_set_status(index, RESULT_FAIL(3));
           return;
       }

--- a/test_pool/smmu/i022.c
+++ b/test_pool/smmu/i022.c
@@ -48,7 +48,7 @@ payload()
                     val_iovirt_get_pcie_rc_info(RC_SEGMENT_NUM, i));
       val_print(DEBUG, "\n       CCA attribute  : 0x%x",
                     val_iovirt_get_pcie_rc_info(RC_MEM_ATTRIBUTE, i));
-      val_print(DEBUG, "\n       SMMU base addr : 0x%llx\n",
+      val_print(DEBUG, "\n       SMMU base addr : 0x%llx",
                     val_iovirt_get_pcie_rc_info(RC_SMMU_BASE, i));
 
       if (val_iovirt_get_pcie_rc_info(RC_MEM_ATTRIBUTE, i) == 0x1 &&
@@ -70,7 +70,7 @@ payload()
                     (char8_t *)val_iovirt_get_named_comp_info(NAMED_COMP_DEV_OBJ_NAME, i));
       val_print(DEBUG, "\n       CCA attribute    : 0x%x",
                     val_iovirt_get_named_comp_info(NAMED_COMP_CCA_ATTR, i));
-      val_print(DEBUG, "\n       SMMU base addr   : 0x%llx\n",
+      val_print(DEBUG, "\n       SMMU base addr   : 0x%llx",
                     val_iovirt_get_named_comp_info(NAMED_COMP_SMMU_BASE, i));
       if (val_iovirt_get_named_comp_info(NAMED_COMP_CCA_ATTR, i) == 0x1 &&
                                     val_iovirt_get_named_comp_info(NAMED_COMP_SMMU_BASE, i) == 0) {

--- a/test_pool/timer/t002.c
+++ b/test_pool/timer/t002.c
@@ -43,8 +43,7 @@ payload()
         (val_timer_get_info(TIMER_INFO_VIR_EL1_FLAGS, 0) & BSA_TIMER_FLAG_ALWAYS_ON)) {
           val_set_status(index, RESULT_PASS);
       } else {
-          val_print(ERROR, "\n       PE Timers are not always-on\n"
-                                   "       And no system wake up timer");
+          val_print(ERROR, "\n       PE Timers are not always-on And no system wake up timer");
           val_set_status(index, RESULT_FAIL(1));
       }
   } else {

--- a/test_pool/watchdog/w002.c
+++ b/test_pool/watchdog/w002.c
@@ -40,11 +40,11 @@ isr()
 {
     val_wd_set_ws0(wd_num, 0);
     g_wd_int_received = 1;
-    val_print(DEBUG, "\n       Received WS0 interrupt                ");
+    val_print(DEBUG, "\n       Received WS0 interrupt");
     val_gic_end_of_interrupt(int_id);
 
     val_timer_set_phy_el1(0);
-    val_print(DEBUG, "       Clear Failsafe interrupt\n");
+    val_print(DEBUG, "\n       Clear Failsafe interrupt");
 }
 
 static
@@ -55,7 +55,7 @@ isr_failsafe()
   uint32_t index = val_pe_get_index_mpid(val_pe_get_mpid());
 
   val_timer_set_phy_el1(0);
-  val_print(ERROR, "       Received Failsafe interrupt\n");
+  val_print(ERROR, "\n       Received Failsafe interrupt");
   g_failsafe_int_received = 1;
 
   /* On some system the failsafe is rcvd just after test interrupt and resulting

--- a/val/driver/gic/acs_exception.c
+++ b/val/driver/gic/acs_exception.c
@@ -55,7 +55,7 @@ static void default_irq_handler(uint64_t exception_type, void *context)
 
 void bsa_gic_vector_table_init(void)
 {
-  val_print(DEBUG, "  GIC_INIT: Setting Up Vector Table...\n");
+  val_print(DEBUG, "\nGIC_INIT: Setting Up Vector Table...");
 
   /* Setting Up Vector Table */
   bsa_gic_set_el2_vector_table();

--- a/val/driver/gic/gic.c
+++ b/val/driver/gic/gic.c
@@ -141,11 +141,11 @@ val_gic_max_espi_val(void)
                                                                     GICD_TYPER_ESPI_RANGE_MASK;
       max_espi_val = (32 * (espi_range + 1) + 4095);
 
-      val_print(TRACE, "\n    max ESPI value %d  ", max_espi_val);
+      val_print(TRACE, "\n       max ESPI value %d", max_espi_val);
       return max_espi_val;
   }
   else {
-      val_print(TRACE, "\n    max ESPI value %d  ", max_espi_val);
+      val_print(TRACE, "\n       max ESPI value %d", max_espi_val);
       return 0;
   }
 }

--- a/val/driver/gic/its/acs_gic_its.c
+++ b/val/driver/gic/its/acs_gic_its.c
@@ -110,7 +110,7 @@ ArmGicSetItsCommandQueueBase(
   Address = (uint64_t)val_aligned_alloc(SIZE_64KB, (NUM_PAGES_8 * SIZE_4KB));
 
   if (!Address) {
-    val_print(ERROR,  "ITS : Could Not Allocate Memory CmdQ. Test may not pass.\n");
+    val_print(ERROR, "\nITS : Could Not Allocate Memory CmdQ. Test may not pass.");
     return 1;
   }
 
@@ -227,14 +227,14 @@ static uint32_t ArmGicSetItsTables(uint32_t its_index)
       // level 1 needs 64 bits i.e 8 bytes
       TableSize = (1 << (lvl1_bits))*ARM_GITS_BASER_INDIRECT_LVL1_ENTRY_SIZE;
       if (TableSize > max_page_size*ARM_GITS_BASER_MAX_PAGES) {
-        val_print(WARN,  "ITS : Level 1 table size exceeded limit");
-        val_print(WARN, "max did size will not be supported..\n");
+        val_print(WARN, "\nITS : Level 1 table size exceeded limit");
+        val_print(WARN, "\nmax did size will not be supported..");
         TableSize = max_page_size*ARM_GITS_BASER_MAX_PAGES;
       }
     } else {
-      val_print(WARN, "ITS : Multilevel table not supported and single level table\n");
-      val_print(WARN, "size exceeded limit settings support only upto 24 bit \n");
-      val_print(WARN, "(if entry_size is 8 bytes)");
+      val_print(WARN, "\nITS : Multilevel table not supported and single level table");
+      val_print(WARN, "\nsize exceeded limit settings support only upto 24 bit ");
+      val_print(WARN, "\n(if entry_size is 8 bytes)");
       TableSize = max_page_size*ARM_GITS_BASER_MAX_PAGES;
     }
   }
@@ -250,7 +250,7 @@ static uint32_t ArmGicSetItsTables(uint32_t its_index)
   Address = (uint64_t)val_aligned_alloc(max_page_size, TableSize);
 
   if (!Address) {
-      val_print(ERROR,  "ITS : Could Not Allocate Memory DT/CT. Test may not pass.\n");
+      val_print(ERROR, "\nITS : Could Not Allocate Memory DT/CT. Test may not pass.");
       return 1;
   }
 
@@ -284,7 +284,7 @@ static uint32_t ArmGicSetItsTables(uint32_t its_index)
   Address = (uint64_t)val_aligned_alloc(SIZE_64KB, (NUM_PAGES_8 * SIZE_4KB));
 
   if (!Address) {
-    val_print(ERROR,  "ITS : Could Not Allocate Memory For ITT. Test may not pass.\n");
+    val_print(ERROR, "\nITS : Could Not Allocate Memory For ITT. Test may not pass.");
     return 1;
   }
 
@@ -631,7 +631,7 @@ uint32_t val_its_init(void)
                                                 sizeof(uint32_t) * (g_gic_its_info->GicNumIts));
 
   if (g_cwriter_ptr == NULL) {
-    val_print(ERROR, "ITS : Could Not Allocate Memory CWriteR. Test may not pass.\n");
+    val_print(ERROR, "\nITS : Could Not Allocate Memory CWriteR. Test may not pass.");
     return 0;
   }
 
@@ -666,12 +666,12 @@ uint32_t val_its_init(void)
 
   g_its_setup_done = 1;
 
-  val_print(TRACE, "  ITS : Info Block\n");
+  val_print(TRACE, "\nITS : Info Block");
   for (index = 0; index < g_gic_its_info->GicNumIts; index++)
   {
-      val_print(TRACE, "  GIC ITS Index: %x", g_gic_its_info->GicIts[index].its_index);
+      val_print(TRACE, "\nGIC ITS Index: %x", g_gic_its_info->GicIts[index].its_index);
       val_print(TRACE, " ID: %x", g_gic_its_info->GicIts[index].ID);
-      val_print(TRACE, " Base: %x\n", g_gic_its_info->GicIts[index].Base);
+      val_print(TRACE, " Base: %x", g_gic_its_info->GicIts[index].Base);
   }
 
   return 0;

--- a/val/driver/gic/its/acs_gic_redistributor.c
+++ b/val/driver/gic/its/acs_gic_redistributor.c
@@ -43,7 +43,7 @@ ArmGicSetItsConfigTableBase(
   Address = (uint64_t)val_aligned_alloc(SIZE_4KB, PAGES_TO_SIZE(Pages));
 
   if (!Address) {
-    val_print(ERROR,  "ITS : Could Not get Mem Config Table. Test may not pass.\n");
+    val_print(ERROR, "\nITS : Could Not get Mem Config Table. Test may not pass.");
     return 1;
   }
 
@@ -89,7 +89,7 @@ ArmGicSetItsPendingTableBase(
   Address = (uint64_t)val_aligned_alloc(SIZE_64KB, PAGES_TO_SIZE(Pages));
 
   if (!Address) {
-    val_print(ERROR, "ITS : Could Not get Memory Pending Table. Test may not pass.\n");
+    val_print(ERROR, "\nITS : Could Not get Memory Pending Table. Test may not pass.");
     return 1;
   }
 

--- a/val/driver/gic/v2/gic_v2.c
+++ b/val/driver/gic/v2/gic_v2.c
@@ -107,9 +107,9 @@ v2_Init(void)
   /* Get the max interrupt */
   max_num_interrupts = val_get_max_intid();
 
-  val_print(DEBUG, "  GIC_INIT: D base %x\n", gicd_base);
-  val_print(DEBUG, "  GIC_INIT: CPU IF base %x\n", cpuif_base);
-  val_print(DEBUG, "  GIC_INIT: Interrupts %d\n", max_num_interrupts);
+  val_print(DEBUG, "\nGIC_INIT: D base %x", gicd_base);
+  val_print(DEBUG, "\nGIC_INIT: CPU IF base %x", cpuif_base);
+  val_print(DEBUG, "\nGIC_INIT: Interrupts %d", max_num_interrupts);
 
   /* Disable all interrupt */
   for (index = 0; index < max_num_interrupts; index++) {

--- a/val/driver/gic/v3/gic_v3.c
+++ b/val/driver/gic/v3/gic_v3.c
@@ -377,8 +377,8 @@ v3_Init(void)
   /* Get the max interrupt */
   max_num_interrupts = val_get_max_intid();
 
-  val_print(DEBUG, "  GIC_INIT: D base %x\n", gicd_base);
-  val_print(DEBUG, "  GIC_INIT: Interrupts %d\n", max_num_interrupts);
+  val_print(DEBUG, "\nGIC_INIT: D base %x", gicd_base);
+  val_print(DEBUG, "\nGIC_INIT: Interrupts %d", max_num_interrupts);
 
 #if defined(TARGET_SIMULATION)
   /* Fast-sim: disable in register chunks (32 IRQs per write) */
@@ -406,7 +406,7 @@ v3_Init(void)
   /* Set ARI bits for v3 mode */
   val_mmio_write(gicd_base + GICD_CTLR, val_mmio_read(gicd_base + GICD_CTLR) | GIC_ARE_ENABLE);
   val_mmio_write(gicd_base + GICD_CTLR, val_mmio_read(gicd_base + GICD_CTLR) | 0x2);
-  val_print(DEBUG, "  GIC_INIT: GICD_CTLR value 0x%08x\n",
+  val_print(DEBUG, "\nGIC_INIT: GICD_CTLR value 0x%08x",
                              val_mmio_read(gicd_base + GICD_CTLR));
 
 #if defined(TARGET_SIMULATION)

--- a/val/driver/gic/v3/gic_v3_extended.c
+++ b/val/driver/gic/v3/gic_v3_extended.c
@@ -287,8 +287,8 @@ v3_extended_init(void)
   max_num_espi_interrupts = val_gic_max_espi_val();
   max_num_eppi_interrupts = val_gic_max_eppi_val();
 
-  val_print(DEBUG, "\n GIC_INIT: Extended SPI Interrupts %d\n", max_num_espi_interrupts);
-  val_print(DEBUG, "\n GIC_INIT: Extended PPI Interrupts %d\n", max_num_eppi_interrupts);
+  val_print(DEBUG, "\n       GIC_INIT: Extended SPI Interrupts %d", max_num_espi_interrupts);
+  val_print(DEBUG, "\n       GIC_INIT: Extended PPI Interrupts %d", max_num_eppi_interrupts);
 
 #if defined(TARGET_SIMULATION)
   /* Fast-sim: bulk disable in 32-interrupt chunks */

--- a/val/driver/pcie/pcie.c
+++ b/val/driver/pcie/pcie.c
@@ -50,7 +50,7 @@ uint32_t pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
         val_pcie_read_cfg(bdf, HEADER_OFFSET, &header_value);
         if (PCIE_HEADER_TYPE(header_value) == TYPE1_HEADER)
         {
-            val_print(TRACE, " TYPE1 HEADER found\n");
+            val_print(TRACE, "\nTYPE1 HEADER found");
             val_pcie_write_cfg(bdf, BUS_NUM_REG_OFFSET, BUS_NUM_REG_CFG(0xFF, sec_bus, bus));
             sub_bus = pcie_enumerate_device(sec_bus, (sec_bus+1));
             val_pcie_write_cfg(bdf, BUS_NUM_REG_OFFSET, BUS_NUM_REG_CFG(sub_bus, sec_bus, bus));
@@ -59,7 +59,7 @@ uint32_t pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
 
         if (PCIE_HEADER_TYPE(header_value) == TYPE0_HEADER)
         {
-            val_print(TRACE, " END POINT found\n");
+            val_print(TRACE, "\nEND POINT found");
             sub_bus = sec_bus - 1;
         }
 
@@ -77,6 +77,6 @@ uint32_t pcie_enumerate_device(uint32_t bus, uint32_t sec_bus)
 **/
 void val_bsa_pcie_enumerate(void)
 {
-  val_print(TRACE, "\n Starting Enumeration\n");
+  val_print(TRACE, "\n       Starting Enumeration");
   pcie_enumerate_device(PRI_BUS, SEC_BUS);
 }

--- a/val/driver/smmu_v3/smmu_v3.c
+++ b/val/driver/smmu_v3/smmu_v3.c
@@ -271,7 +271,7 @@ static uint32_t smmu_evnt_queue_init(smmu_dev_t *smmu)
     evntq_size = (evntq_size < 64)?64:evntq_size;
     evntq->base_ptr = val_memory_calloc (1, evntq_size);
     if (!evntq->base_ptr) {
-        val_print(ERROR, "\n      Failed to allocate Event queue struct.     ");
+        val_print(ERROR, "\n       Failed to allocate Event queue struct.");
         return 0;
     }
 
@@ -476,64 +476,64 @@ static int smmu_handle_evt(uint64_t *event)
 {
         switch (BITFIELD_GET(EVTQ_0_ID, event[0])) {
         case EVT_ID_UUT:
-                val_print(INFO, "\n\n    Unsupported Upstream Transaction     ");
+                val_print(INFO, "\n       Unsupported Upstream Transaction");
                 break;
         case EVT_ID_TRANSID_FAULT:
-                val_print(INFO, "\n\n    Transaction StreamID out of range     ");
+                val_print(INFO, "\n       Transaction StreamID out of range");
                 break;
         case EVT_ID_STE_FETCH_FAULT:
-                val_print(INFO, "\n\n    Fetch of STE caused external abort     ");
+                val_print(INFO, "\n       Fetch of STE caused external abort");
                 break;
         case EVT_ID_BAD_STE:
-                val_print(INFO, "\n\n    Used STE invalid     ");
+                val_print(INFO, "\n       Used STE invalid");
                 break;
         case EVT_ID_BAD_ATS_TREQ:
-                val_print(INFO, "\n\n    Address Translation Request disallowed   ");
+                val_print(INFO, "\n       Address Translation Request disallowed");
                 break;
         case EVT_ID_STREAM_DISABLED:
-                val_print(INFO, "\n\n    Non-substream transactions disabled     ");
+                val_print(INFO, "\n       Non-substream transactions disabled");
                 break;
         case EVT_ID_TRANSL_FORBIDDEN:
-                val_print(INFO, "\n\n    Forbidden translation     ");
+                val_print(INFO, "\n       Forbidden translation");
                 break;
         case EVT_ID_BAD_SSID:
-                val_print(INFO, "\n\n    Bad Substream ID     ");
+                val_print(INFO, "\n       Bad Substream ID");
                 break;
         case EVT_ID_CD_FETCH_FAULT:
-                val_print(INFO, "\n\n    Fetch of CD caused external abort     ");
+                val_print(INFO, "\n       Fetch of CD caused external abort");
                 break;
         case EVT_ID_BAD_CD:
-                val_print(INFO, "\n\n    Fetched CD invalid     ");
+                val_print(INFO, "\n       Fetched CD invalid");
                 break;
         case EVT_ID_WALK_EABT:
-                val_print(INFO, "\n\n    Fetch of TTD caused external abort");
+                val_print(INFO, "\n       Fetch of TTD caused external abort");
                 break;
         case EVT_ID_TRANSLATION_FAULT:
-                val_print(INFO, "\n\n    SMMU_FAULT_REASON_PTE_FETCH     ");
+                val_print(INFO, "\n       SMMU_FAULT_REASON_PTE_FETCH");
                 break;
         case EVT_ID_ADDR_SIZE_FAULT:
-                val_print(INFO, "\n\n    SMMU_FAULT_REASON_OOR_ADDRESS     ");
+                val_print(INFO, "\n       SMMU_FAULT_REASON_OOR_ADDRESS");
                 break;
         case EVT_ID_ACCESS_FAULT:
-                val_print(INFO, "\n\n    SMMU_FAULT_REASON_ACCESS     ");
+                val_print(INFO, "\n       SMMU_FAULT_REASON_ACCESS");
                 break;
         case EVT_ID_PERMISSION_FAULT:
-                val_print(INFO, "\n\n    SMMU_FAULT_REASON_PERMISSION     ");
+                val_print(INFO, "\n       SMMU_FAULT_REASON_PERMISSION");
                 break;
         case EVT_ID_TLB_CONFLICT:
-                val_print(INFO, "\n\n    TLB conflict occurred     ");
+                val_print(INFO, "\n       TLB conflict occurred");
                 break;
         case EVT_ID_CFG_CONFLICT:
-                val_print(INFO, "\n\n    Configuration cache conflict occurred    ");
+                val_print(INFO, "\n       Configuration cache conflict occurred");
                 break;
         case EVT_ID_PAGE_REQUEST:
-                val_print(INFO, "\n\n    Speculation Page Req hint     ");
+                val_print(INFO, "\n       Speculation Page Req hint");
                 break;
         case EVT_ID_VMS_FETCH:
-                val_print(INFO, "\n\n    Fetch of VMS caused external abort     ");
+                val_print(INFO, "\n       Fetch of VMS caused external abort");
                 break;
         default:
-                val_print(INFO, "\n\n    INVALID FAULT     ");
+                val_print(INFO, "\n       INVALID FAULT");
                 return 1;
         }
 
@@ -586,13 +586,13 @@ static uint32_t smmu_gerror_check(smmu_dev_t *smmu)
         active = gerror ^ gerrorn;
     if (active & SMMU_GERROR_MSI_EVTQ_ABT_ERR)
     {
-        val_print(DEBUG, "\n      EVTQ MSI write aborted     ");
+        val_print(DEBUG, "\n       EVTQ MSI write aborted");
         return 1;
     }
 
     if (active & SMMU_GERROR_EVTQ_ABT_ERR)
     {
-        val_print(DEBUG, "\n      EVTQ write aborted -- events may have been lost");
+        val_print(DEBUG, "\nEVTQ write aborted -- events may have been lost");
         return 1;
     }
 
@@ -610,7 +610,7 @@ static void smmu_evtq_thread(void)
     ret = smmu_gerror_check(smmu);
     if (ret)
     {
-        val_print(WARN, "\n    GERROR occurred. Eventq is not writable.     ");
+        val_print(WARN, "\n       GERROR occurred. Eventq is not writable.");
         return;
     }
 
@@ -618,23 +618,23 @@ static void smmu_evtq_thread(void)
         while (!smmu_queue_remove_raw(evntq, event)) {
             uint8_t id = BITFIELD_GET(EVTQ_0_ID, event[0]);
             ret = smmu_handle_evt(event);
-            val_print(INFO, "\n  event 0x%02x received: %d     ", id);
+            val_print(INFO, "\n       event 0x%02x received: %d", id);
             for (i = 0; i < ARRAY_SIZE(event); ++i)
             {
-                val_print(INFO, "\n  0x%016llx     ", (unsigned long long)event[i]);
+                val_print(INFO, "\n       0x%016llx", (unsigned long long)event[i]);
             }
 
-            val_print(TRACE, "\n  prod is: %x", val_mmio_read((uint64_t)evntq->prod_reg));
-            val_print(TRACE, "\n  cons is: %x", val_mmio_read((uint64_t)evntq->cons_reg));
+            val_print(TRACE, "\nprod is: %x", val_mmio_read((uint64_t)evntq->prod_reg));
+            val_print(TRACE, "\ncons is: %x", val_mmio_read((uint64_t)evntq->cons_reg));
         }
 
         if (queue_sync_prod_in(evntq))
-            val_print(WARN, "\n  EVTQ overflow detected -- events lost     ");
+            val_print(WARN, "\n       EVTQ overflow detected -- events lost");
     } while (!smmu_queue_empty(&evntq->queue));
 
     if (val_mmio_read((uint64_t)evntq->prod_reg) == val_mmio_read((uint64_t)evntq->cons_reg))
     {
-        val_print(INFO, "\n  No outstanding events in the queue. Queue Empty.\n");
+        val_print(INFO, "\n       No outstanding events in the queue. Queue Empty.");
     }
 
     evntq->queue.cons = ((queue->prod) & (1 << 31)) |
@@ -649,7 +649,7 @@ static int smmu_dev_disable(smmu_dev_t *smmu)
 
     ret = smmu_reg_write_sync(smmu, 0, SMMU_CR0_OFFSET, SMMU_CR0ACK_OFFSET);
     if (ret)
-        val_print(ERROR, "\n    failed to clear cr0     ");
+        val_print(ERROR, "\n       failed to clear cr0");
 
     return ret;
 }
@@ -713,7 +713,7 @@ static int smmu_reset(smmu_dev_t *smmu)
     ret = smmu_reg_write_sync(smmu, en, SMMU_CR0_OFFSET,
                       SMMU_CR0ACK_OFFSET);
     if (ret) {
-        val_print(ERROR, "\n      failed to enable event queue     ");
+        val_print(ERROR, "\n       failed to enable event queue");
         return ret;
     }
 
@@ -777,14 +777,14 @@ static uint32_t smmu_set_state(uint32_t smmu_index, uint32_t en)
 
     if (smmu_index >= g_num_smmus)
     {
-        val_print(ERROR, "  smmu_set_state: invalid smmu index\n");
+        val_print(ERROR, "\nsmmu_set_state: invalid smmu index");
         return 1;
     }
 
     smmu = &g_smmu[smmu_index];
     if (smmu->base == 0)
     {
-        val_print(ERROR, "  smmu_set_state: smmu unsupported\n");
+        val_print(ERROR, "\nsmmu_set_state: smmu unsupported");
         return 1;
     }
 
@@ -799,7 +799,7 @@ static uint32_t smmu_set_state(uint32_t smmu_index, uint32_t en)
                       SMMU_CR0ACK_OFFSET);
     if (ret)
     {
-        val_print(ERROR, "  smmu_set_state: failed to set SMMU state\n",
+        val_print(ERROR, "\nsmmu_set_state: failed to set SMMU state",
                                                                            0);
         return ret;
     }
@@ -863,7 +863,7 @@ static uint32_t smmu_probe(smmu_dev_t *smmu)
         smmu->supported.s2p = 1;
 
     if (!(data & (IDR0_S1P | IDR0_S2P))) {
-        val_print(ERROR, "  no translation support!\n ");
+        val_print(ERROR, "\nno translation support!");
         return 0;
     }
 
@@ -873,13 +873,13 @@ static uint32_t smmu_probe(smmu_dev_t *smmu)
     case IDR0_TTF_AARCH64:
         break;
     default:
-        val_print(ERROR, "  AArch64 table format not supported!\n");
+        val_print(ERROR, "\nAArch64 table format not supported!");
         return 0;
     }
 
     data = val_mmio_read(smmu->base + SMMU_IDR1_OFFSET);
     if (data & (IDR1_TABLES_PRESET | IDR1_QUEUES_PRESET)) {
-        val_print(ERROR, "  fixed table base addr not supported\n");
+        val_print(ERROR, "\nfixed table base addr not supported");
         return 0;
     }
 
@@ -891,8 +891,8 @@ static uint32_t smmu_probe(smmu_dev_t *smmu)
                      (BITFIELD_GET(IDR1_SIDSIZE, data)) : MAX_SID;
     smmu->ssid_bits = BITFIELD_GET(IDR1_SSIDSIZE, data);
 
-    val_print(TRACE, "  ssid_bits = %d", smmu->ssid_bits);
-    val_print(TRACE, " sid_bits = %d\n", smmu->sid_bits);
+    val_print(TRACE, "\nssid_bits = %d", smmu->ssid_bits);
+    val_print(TRACE, " sid_bits = %d", smmu->sid_bits);
 
     if (smmu->sid_bits <= STRTAB_SPLIT)
         smmu->supported.st_level_2lvl = 0;
@@ -901,15 +901,15 @@ static uint32_t smmu_probe(smmu_dev_t *smmu)
     data = val_mmio_read(smmu->base + SMMU_IDR5_OFFSET);
 
     if (BITFIELD_GET(IDR5_OAS, data) >= SMMU_OAS_MAX_IDX) {
-        val_print(ERROR, "  Unknown output address size\n");
+        val_print(ERROR, "\nUnknown output address size");
         return 0;
     }
 
     smmu->oas = smmu_oas[BITFIELD_GET(IDR5_OAS, data)];
     smmu->ias = get_max(smmu->ias, smmu->oas);
 
-    val_print(TRACE, "  ias %d-bit", smmu->ias);
-    val_print(TRACE, "  oas %d-bit\n", smmu->oas);
+    val_print(TRACE, "\nias %d-bit", smmu->ias);
+    val_print(TRACE, "  oas %d-bit", smmu->oas);
 
     return 1;
 }
@@ -931,8 +931,8 @@ static void dump_strtab(uint64_t *ste)
     int i;
 
     for (i = 0; i < 8; i++) {
-        val_print(TRACE, "ste[%d] = ", i);
-        val_print(TRACE, "%p\n", ste[i]);
+        val_print(TRACE, "\nste[%d] = ", i);
+        val_print(TRACE, "%p", ste[i]);
     }
 }
 
@@ -941,8 +941,8 @@ static void dump_cdtab(uint64_t *ctx_desc)
     int i;
 
     for (i = 0; i < 8; i++) {
-        val_print(TRACE, "ctx_desc[%d] = ", i);
-        val_print(TRACE, "%llx\n", ctx_desc[i]);
+        val_print(TRACE, "\nctx_desc[%d] = ", i);
+        val_print(TRACE, "%llx", ctx_desc[i]);
     }
 }
 
@@ -1412,16 +1412,16 @@ uint32_t val_smmu_init(void)
     g_smmu = val_memory_calloc(g_num_smmus, sizeof(smmu_dev_t));
     if (!g_smmu)
     {
-        val_print(ERROR, "\n  smmu_init memory allocation failure");
+        val_print(ERROR, "\nsmmu_init memory allocation failure");
         return ACS_STATUS_ERR;
     }
 
     for (g_smmu_index  = 0; g_smmu_index  < g_num_smmus; ++g_smmu_index) {
         smmu_version = val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, g_smmu_index);
         if (smmu_version != 3) {
-            val_print(ERROR, "  Only SMMUv3.x init supported\n");
-            val_print(ERROR, "  smmu %d version is", g_smmu_index);
-            val_print(ERROR, "  %d\n", smmu_version);
+            val_print(ERROR, "\nOnly SMMUv3.x init supported");
+            val_print(ERROR, "\nsmmu %d version is", g_smmu_index);
+            val_print(ERROR, " %d", smmu_version);
             continue;
         }
 
@@ -1429,7 +1429,7 @@ uint32_t val_smmu_init(void)
         g_smmu[g_smmu_index].page1_base = g_smmu[g_smmu_index].base + SMMU_PAGE1_BASE_OFFSET;
         if (smmu_init(&g_smmu[g_smmu_index]))
         {
-            val_print(ERROR, "  smmu_init: smmu %d init failed\n", g_smmu_index);
+            val_print(ERROR, "\nsmmu_init: smmu %d init failed", g_smmu_index);
             g_smmu[g_smmu_index].base = 0;
             return ACS_STATUS_ERR;
         }
@@ -1473,18 +1473,18 @@ val_smmu_get_info(SMMU_INFO_e type, uint32_t smmu_index)
 // This API checks if there are any outstanding events in the event queue.
 void val_smmu_dump_eventq(void)
 {
-    val_print(INFO, "\n      Eventq dump starting...    ");
+    val_print(INFO, "\n       Eventq dump starting...");
 
     for (g_smmu_index = 0; g_smmu_index < g_num_smmus; g_smmu_index++) {
         if (val_iovirt_get_smmu_info(SMMU_CTRL_ARCH_MAJOR_REV, g_smmu_index) != 3) {
-            val_print(ERROR, "\n only SMMUv3.x supported, skipping smmu %d", g_smmu_index);
+            val_print(ERROR, "\nonly SMMUv3.x supported, skipping smmu %d", g_smmu_index);
             continue;
         }
 
-        val_print(INFO, "\n      Eventq of SMMU index %x ", g_smmu_index);
+        val_print(INFO, "\n       Eventq of SMMU index %x", g_smmu_index);
         smmu_evtq_thread();
     }
 
-    val_print(INFO, "\n      Eventq dump finished...    ");
+    val_print(INFO, "\n       Eventq dump finished...");
     return;
 }

--- a/val/include/acs_app_defs.h
+++ b/val/include/acs_app_defs.h
@@ -36,10 +36,10 @@
 #define PCBSA_MAX_LEVEL_SUPPORTED 1
 
 #define LEVEL_PRINT_FORMAT(level, filter_mode, fr_level) ((filter_mode == LVL_FILTER_FR) ? \
-    "\n Starting tests for level FR " : \
+    "\nStarting tests for level FR " : \
     ((filter_mode == LVL_FILTER_ONLY) ? \
-    ((level == fr_level) ? "\n Starting tests for only level FR " \
-    : "\n Starting tests for only level %2d ") : \
-    ((level == fr_level) ? "\n Starting tests for level FR " : "\n Starting tests for level %2d ")))
+    ((level == fr_level) ? "\nStarting tests for only level FR " \
+    : "\nStarting tests for only level %2d ") : \
+    ((level == fr_level) ? "\nStarting tests for level FR " : "\nStarting tests for level %2d ")))
 
 #endif /* __ACS_APP_DEFS_H__ */

--- a/val/include/acs_execution_policy.h
+++ b/val/include/acs_execution_policy.h
@@ -37,6 +37,7 @@ typedef struct acs_execution_policy {
     bool     pcie_skip_dp_nic_ms;
     uint32_t print_level;
     uint32_t print_mmio;
+    uint32_t log_indent;
     uint32_t timeout_pass;
     uint32_t timeout_fail;
     uint32_t timer_timeout_us;
@@ -60,6 +61,8 @@ acs_execution_policy_t *acs_get_execution_policy_mut(void);
 const acs_execution_policy_t *acs_get_execution_policy(void);
 uint32_t acs_policy_get_print_level(void);
 uint32_t acs_policy_get_print_mmio(void);
+uint32_t acs_policy_get_log_indent(void);
+void acs_policy_set_log_indent(uint32_t indent);
 uint32_t acs_policy_get_pcie_p2p(void);
 uint32_t acs_policy_get_pcie_cache_present(void);
 bool acs_policy_get_pcie_skip_dp_nic_ms(void);

--- a/val/include/val_logger.h
+++ b/val/include/val_logger.h
@@ -28,6 +28,8 @@ typedef enum {
  *   @return   - SUCCESS((Any positive number for character written)/FAILURE(0))
 **/
 uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...);
+uint32_t val_log_get_indent(void);
+void val_log_set_indent(uint32_t indent);
 
 void val_mem_copy(char *dest, const char *src, size_t len);
 

--- a/val/src/acs_cxl.c
+++ b/val/src/acs_cxl.c
@@ -51,12 +51,12 @@ CXL_COMPONENT_ENTRY *
 val_cxl_get_component_entry(uint32_t component_index)
 {
   if (g_cxl_component_table == NULL) {
-    val_print(ERROR, " CXL: component table not initialised");
+    val_print(ERROR, "\n       CXL: component table not initialised");
     return NULL;
   }
 
   if (component_index >= g_cxl_component_table->num_entries) {
-    val_print(ERROR, " CXL: invalid component index %u", component_index);
+    val_print(ERROR, "\n       CXL: invalid component index %u", component_index);
     return NULL;
   }
 
@@ -159,7 +159,7 @@ val_cxl_print_component_summary(void)
   uint32_t idx;
 
   if (g_cxl_component_table == NULL) {
-    val_print(TRACE, " CXL_COMPONENT: Discovered 0 components");
+    val_print(TRACE, "\n       CXL_COMPONENT: Discovered 0 components");
     return;
   }
 
@@ -195,22 +195,22 @@ val_cxl_print_component_summary(void)
     }
   }
 
-  val_print(INFO, " CXL_INFO: Number of host bridges     :    %u\n",
+  val_print(INFO, "\n    CXL_INFO: Number of host bridges     :    %u",
              g_cxl_info_table->num_entries);
   val_print(INFO,
-            " CXL_INFO: Number of components       : %4u\n", (uint64_t)total);
+            "\n    CXL_INFO: Number of components       : %4u", (uint64_t)total);
   val_print(INFO,
-            " CXL_INFO: Root Ports                 : %4u\n", (uint64_t)role_root_port);
+            "\n    CXL_INFO: Root Ports                 : %4u", (uint64_t)role_root_port);
   val_print(INFO,
-            " CXL_INFO: Devices (Endpoints)        : %4u\n", (uint64_t)role_endpoint);
+            "\n    CXL_INFO: Devices (Endpoints)        : %4u", (uint64_t)role_endpoint);
   val_print(INFO,
-            " CXL_INFO: Type1 Devices              : %4u\n", (uint64_t)type1_devices);
+            "\n    CXL_INFO: Type1 Devices              : %4u", (uint64_t)type1_devices);
   val_print(INFO,
-            " CXL_INFO: Type2 Devices              : %4u\n", (uint64_t)type2_devices);
+            "\n    CXL_INFO: Type2 Devices              : %4u", (uint64_t)type2_devices);
   val_print(INFO,
-            " CXL_INFO: Type3 Devices              : %4u\n", (uint64_t)type3_devices);
+            "\n    CXL_INFO: Type3 Devices              : %4u", (uint64_t)type3_devices);
 
-  val_print(TRACE, " CXL_COMPONENT: Discovered %u components", (uint64_t)total);
+  val_print(TRACE, "\n       CXL_COMPONENT: Discovered %u components", (uint64_t)total);
 
   for (idx = 0; idx < g_cxl_component_table->num_entries; idx++) {
     const CXL_COMPONENT_ENTRY *entry = &g_cxl_component_table->component[idx];
@@ -218,17 +218,17 @@ val_cxl_print_component_summary(void)
     const char *dtype_str = val_cxl_device_type_name(entry->device_type);
 
     val_print(TRACE, "\n   Component Index : %u", (uint64_t)idx);
-    val_print(TRACE, "     BDF           : 0x%x", (uint64_t)entry->bdf);
-    val_print(TRACE, "     Role          : %a", (uint64_t)role_str);
-    val_print(TRACE, "     Device Type   : %a", (uint64_t)dtype_str);
+    val_print(TRACE, ", BDF   : 0x%x", (uint64_t)entry->bdf);
+    val_print(TRACE, ", Role  : %a", (uint64_t)role_str);
+    val_print(TRACE, ", Device Type : %a", (uint64_t)dtype_str);
 
     if (entry->component_reg_base) {
-      val_print(TRACE, "     CompReg Base  : 0x%llx", entry->component_reg_base);
-      val_print(TRACE, "     CompReg Len   : 0x%llx", entry->component_reg_length);
+      val_print(TRACE, ", CompReg Base  : 0x%llx", entry->component_reg_base);
+      val_print(TRACE, ", CompReg Len   : 0x%llx", entry->component_reg_length);
     }
 
 
-    val_print(TRACE, "   HDM Decoder Count  : %u", entry->hdm_decoder_count);
+    val_print(TRACE, ", HDM Decoder Count  : %u", entry->hdm_decoder_count);
   }
 }
 
@@ -255,7 +255,7 @@ val_cxl_find_capability(uint32_t bdf, uint32_t cid, uint32_t *cid_offset)
       dvsec_id = hdr2 & CXL_DVSEC_HDR2_ID_MASK;
       if (dvsec_id == cid)
       {
-          val_print(TRACE, " \nFound CXL DVSEC 0x%lx", dvsec_id);
+          val_print(TRACE, "\n       Found CXL DVSEC 0x%lx", dvsec_id);
           *cid_offset = next_cap_offset;
           return 0;
       }
@@ -372,7 +372,7 @@ val_cxl_get_component_info(CXL_COMPONENT_INFO_e type, uint32_t index)
 {
 
   if (g_cxl_component_table == NULL) {
-    val_print(ERROR, " GET_CXL_COMPONENT_INFO: component table not created");
+    val_print(ERROR, "\n       GET_CXL_COMPONENT_INFO: component table not created");
     return 0;
   }
 
@@ -380,7 +380,7 @@ val_cxl_get_component_info(CXL_COMPONENT_INFO_e type, uint32_t index)
     return g_cxl_component_table->num_entries;
 
   if (index >= g_cxl_component_table->num_entries) {
-    val_print(ERROR, " GET_CXL_COMPONENT_INFO: Invalid index %u", index);
+    val_print(ERROR, "\n       GET_CXL_COMPONENT_INFO: Invalid index %u", index);
     return 0;
   }
 
@@ -401,7 +401,7 @@ val_cxl_get_component_info(CXL_COMPONENT_INFO_e type, uint32_t index)
   case CXL_COMPONENT_INFO_HDM_COUNT:
     return entry->hdm_decoder_count;
   default:
-    val_print(ERROR, " GET_CXL_COMPONENT_INFO: Unsupported type %u", type);
+    val_print(ERROR, "\n       GET_CXL_COMPONENT_INFO: Unsupported type %u", type);
     break;
   }
 
@@ -644,7 +644,7 @@ void val_cxl_dump_reg_block(uint64_t base_pa,
     val_print(TRACE, (char8_t *)hdr_fmt, base_pa);
 
     if (block_len && block_len < CXL_CAP_HDR_SIZE) {
-        val_print(TRACE, " ERROR in CXL Summary :: Block length too small\n");
+        val_print(TRACE, "\n       ERROR in CXL Summary :: Block length too small");
         return;
     }
 
@@ -661,19 +661,19 @@ void val_cxl_dump_reg_block(uint64_t base_pa,
             hdr_cnt = max_cnt_by_len;
         }
 
-        val_print(TRACE, "   \nDevCap Array count=%ld", (uint64_t)hdr_cnt);
+        val_print(TRACE, "\n       DevCap Array count=%ld", (uint64_t)hdr_cnt);
         for (i = 0; i < hdr_cnt; ++i) {
         if (val_cxl_dev_cap_hdr_read(hdr_base, i, &id_local, &ver_local, &cap_off))
                 break;
             id = id_local; ver = ver_local;
-            val_print(TRACE, "   \nDevCap[%ld]: ", (uint64_t)i);
+            val_print(TRACE, "\n       DevCap[%ld]: ", (uint64_t)i);
             val_print(TRACE, "   ID=0x%x ", (uint64_t)id);
             val_print(TRACE, "   (%a) ", (uint64_t)val_cxl_dev_cap_name(id));
             val_print(TRACE, "   Ver=%d ", (uint64_t)ver);
             val_print(TRACE, "   Off=0x%x", (uint64_t)cap_off);
             /* Bounds check for capability structure */
             if (block_len && cap_off >= block_len) {
-                val_print(TRACE, " ERROR in CXL Summary:: -> Cap offset out of range");
+                val_print(TRACE, "\n       ERROR in CXL Summary:: -> Cap offset out of range");
             }
         }
         return;
@@ -684,8 +684,8 @@ void val_cxl_dump_reg_block(uint64_t base_pa,
     cap_ver      = CXL_CAP_HDR_VER(arr_hdr);
     cachemem_ver = CXL_CAP_HDR_CACHEMEM_VER(arr_hdr);
     arr_sz       = CXL_CAP_ARRAY_ENTRIES(arr_hdr);
-    val_print(TRACE,  "   \nCXL_Capability_Header: ID=0x%x", cap_id);
-    val_print(TRACE,  "   \nPrimary Array: CXL.cachemem v%ld",
+    val_print(TRACE,  "\n       CXL_Capability_Header: ID=0x%x", cap_id);
+    val_print(TRACE,  "\n       Primary Array: CXL.cachemem v%ld",
                 (uint64_t)cachemem_ver);
     val_print(TRACE,  "   CXL Cap v%ld", cap_ver);
     val_print(TRACE,  "   entries=%ld", arr_sz);
@@ -697,7 +697,7 @@ void val_cxl_dump_reg_block(uint64_t base_pa,
         ver = CXL_CAP_HDR_VER(cap_hdr);
         cap_ptr = CXL_CAP_HDR_POINTER(cap_hdr);
         cap_base = base_pa + cap_ptr;
-        val_print(TRACE, "   \nCapID=0x%x ", id);
+        val_print(TRACE, "\n       CapID=0x%x ", id);
         val_print(TRACE, "    (%a) ", (uint64_t)val_cxl_cap_name(id));
         val_print(TRACE, "    Ver=%d ", ver);
         val_print(TRACE, "    @+0x%llx", (idx * CXL_CAP_HDR_SIZE));
@@ -773,7 +773,7 @@ static void val_cxl_parse_register_locator(uint32_t bdf,
         val_cxl_assign_component_role(component, dp_type);
 
     if (val_pcie_read_cfg(bdf, ecap_off + CXL_DVSEC_HDR1_OFFSET, &dvsec_hdr1)) {
-        val_print(TRACE, " ERROR in CXL Summary :: DVSEC Header1 read failed");
+        val_print(TRACE, "\n       ERROR in CXL Summary :: DVSEC Header1 read failed");
         return;
     }
 
@@ -781,26 +781,26 @@ static void val_cxl_parse_register_locator(uint32_t bdf,
     dvsec_rev    = (dvsec_hdr1 >> CXL_DVSEC_HDR1_REV_SHIFT) & CXL_DVSEC_HDR1_REV_MASK;
     dvsec_len    = (dvsec_hdr1 >> CXL_DVSEC_HDR1_LEN_SHIFT) & CXL_DVSEC_HDR1_LEN_MASK;
 
-    val_print(TRACE, " \nDVSEC Header 1 : 0x%lx", dvsec_hdr1);
-    val_print(TRACE, "    \nVendor ID    : 0x%lx", dvsec_vendor);
+    val_print(TRACE, "\n       DVSEC Header 1 : 0x%lx", dvsec_hdr1);
+    val_print(TRACE, "\n       Vendor ID    : 0x%lx", dvsec_vendor);
     val_print(TRACE, "    Revision     : 0x%lx", dvsec_rev);
     val_print(TRACE, "    Length (B)   : 0x%lx", dvsec_len);
 
     if (dvsec_len < CXL_RL_REG_BLK_ENTRIES ||
         ((dvsec_len - CXL_RL_REG_BLK_ENTRIES) % CXL_RL_ENTRY_SIZE) != 0) {
-        val_print(TRACE, " ERROR in CXL Summary :: RL: Bad DVSEC Length 0x%lx",
+        val_print(TRACE, "\n       ERROR in CXL Summary :: RL: Bad DVSEC Length 0x%lx",
                   (uint64_t)dvsec_len);
         return;
     }
 
     num_entries = (dvsec_len - CXL_RL_REG_BLK_ENTRIES) / CXL_RL_ENTRY_SIZE;
-    val_print(TRACE, " \nRegister Locator: %ld entries", num_entries);
+    val_print(TRACE, "\n       Register Locator: %ld entries", num_entries);
 
     ent_off_cfg = ecap_off + CXL_RL_REG_BLK_ENTRIES;
     for (i = 0; i < num_entries; i++, ent_off_cfg += CXL_RL_ENTRY_SIZE) {
         if (val_pcie_read_cfg(bdf, ent_off_cfg + CXL_RL_REG_OFF_LOW, &reg0) ||
             val_pcie_read_cfg(bdf, ent_off_cfg + CXL_RL_REG_OFF_HIGH, &off)) {
-            val_print(TRACE, " ERROR in CXL Summary :: RL[%ld]: entry read failed", i);
+            val_print(TRACE, "\n       ERROR in CXL Summary :: RL[%ld]: entry read failed", i);
             continue;
         }
 
@@ -812,21 +812,21 @@ static void val_cxl_parse_register_locator(uint32_t bdf,
         {
             bar_st = val_cxl_get_mmio_bar_host_pa(bdf, bar_num, &bar_base, &bar_is64);
             if (bar_st != PCIE_SUCCESS) {
-                val_print(TRACE, " ERROR in CXL Summary :: RL[%ld]: ", i);
-                val_print(TRACE, " ERROR in CXL Summary :: BAR%ld not usable ",
+                val_print(TRACE, "\n       ERROR in CXL Summary :: RL[%ld]: ", i);
+                val_print(TRACE, "\n       ERROR in CXL Summary :: BAR%ld not usable ",
                             (uint64_t)bar_num);
                 switch (bar_st) {
                 case VAL_CXL_BAR_ERR_INVALID_INDEX:
-                    val_print(TRACE, " ERROR in CXL Summary :: Invalid BAR index");
+                    val_print(TRACE, "\n       ERROR in CXL Summary :: Invalid BAR index");
                     break;
                 case VAL_CXL_BAR_ERR_CFG_READ:
-                    val_print(TRACE, " ERROR in CXL Summary :: CFG read failed");
+                    val_print(TRACE, "\n       ERROR in CXL Summary :: CFG read failed");
                     break;
                 case VAL_CXL_BAR_ERR_NOT_MMIO:
-                    val_print(TRACE, " ERROR in CXL Summary :: BAR not MMIO type");
+                    val_print(TRACE, "\n       ERROR in CXL Summary :: BAR not MMIO type");
                     break;
                 case VAL_CXL_BAR_ERR_ZERO:
-                    val_print(TRACE, " ERROR in CXL Summary :: BAR is zero");
+                    val_print(TRACE, "\n       ERROR in CXL Summary :: BAR is zero");
                     break;
                 default:
                     break;
@@ -835,18 +835,18 @@ static void val_cxl_parse_register_locator(uint32_t bdf,
             }
         }
         block_pa = bar_base + reg_off;
-        val_print(TRACE, "  \nRL reg0=0x%lx ", reg0);
+        val_print(TRACE, "\n       RL reg0=0x%lx ", reg0);
         val_print(TRACE, "  off=0x%lx", off);
         val_print(TRACE, "  BlockID=0x%x ", block_id);
         val_print(TRACE, "  BIR=%d", CXL_RL_BAR_NUM(bir));
 
         blkname =
-            (block_id == CXL_REG_BLOCK_COMPONENT) ? "\nCXL Component Registers" :
+            (block_id == CXL_REG_BLOCK_COMPONENT) ? "\n       CXL Component Registers" :
             (block_id == CXL_REG_BLOCK_DEVICE)    ? "CXL Device Registers" :
             (block_id == CXL_REG_BLOCK_VENDOR_SPECIFIC) ? "Vendor-Specific Reg Block" :
                                                     "CXL Register Block";
 
-        val_print(TRACE, "  \nRL[%ld]: ", i);
+        val_print(TRACE, "\n       RL[%ld]: ", i);
         val_print(TRACE, "  BlockID=0x%x ", block_id);
         val_print(TRACE, "  (%a) ", (uint64_t)blkname);
         val_print(TRACE, "  BIR=%ld ", CXL_RL_BAR_NUM(bir));
@@ -957,7 +957,7 @@ val_cxl_assign_host_bridge_indices(void)
     }
 
     entry->host_bridge_index = host_index;
-    val_print(TRACE, "  \n host_index:%llx ", host_index);
+    val_print(TRACE, "\n       host_index:%llx ", host_index);
   }
 }
 
@@ -1146,7 +1146,7 @@ val_cxl_create_info_table(uint64_t *cxl_info_table)
   uint32_t window;
 
   if (cxl_info_table == NULL) {
-    val_print(ERROR, " CXL_INFO: Input table pointer is NULL ");
+    val_print(ERROR, "\n    CXL_INFO: Input table pointer is NULL ");
     return;
   }
   g_cxl_info_table = (CXL_INFO_TABLE *)cxl_info_table;
@@ -1155,7 +1155,7 @@ val_cxl_create_info_table(uint64_t *cxl_info_table)
 
   /* Print parsed informationi*/
   num_cxl_hb = g_cxl_info_table->num_entries;
-  val_print(TRACE, "\n CXL_INFO: Number of host bridges :    %u\n", num_cxl_hb);
+  val_print(TRACE, "\n    CXL_INFO: Number of host bridges :    %u", num_cxl_hb);
 
   if (num_cxl_hb == 0)
     return;
@@ -1165,24 +1165,23 @@ val_cxl_create_info_table(uint64_t *cxl_info_table)
 
     if (val_cxl_host_discover_capabilities(entry) != ACS_STATUS_PASS) {
       val_print(ERROR,
-                " CXL_INFO: Failed to map host bridge component window (UID 0x%x)",
+                "\n    CXL_INFO: Failed to map host bridge component window (UID 0x%x)",
                 entry->uid);
     }
 
-    val_print(TRACE, " \nCXL_INFO: Host Bridge[%u]\n", index);
-    val_print(TRACE, "   UID                : 0x%x\n", entry->uid);
-    val_print(TRACE, "   Structure Type     : 0x%x\n", entry->cxl_struct_type);
-    val_print(TRACE, "   Component Type     : 0x%x\n", entry->component_reg_type);
-    val_print(TRACE, "   Component Base     : 0x%llx\n", entry->component_reg_base);
-    val_print(TRACE, "   Component Length   : 0x%llx\n", entry->component_reg_length);
-    val_print(TRACE, "   Revision           : 0x%x\n", entry->cxl_version);
-
-    val_print(TRACE, "   CFMWS Count        : %u", entry->cfmws_count);
+    val_print(TRACE, "\n    CXL_INFO: Host Bridge[%u]", index);
+    val_print(TRACE, "\n       UID                : 0x%x", entry->uid);
+    val_print(TRACE, "\n       Structure Type     : 0x%x", entry->cxl_struct_type);
+    val_print(TRACE, "\n       Component Type     : 0x%x", entry->component_reg_type);
+    val_print(TRACE, "\n       Component Base     : 0x%llx", entry->component_reg_base);
+    val_print(TRACE, "\n       Component Length   : 0x%llx", entry->component_reg_length);
+    val_print(TRACE, "\n       Revision           : 0x%x", entry->cxl_version);
+    val_print(TRACE, "\n       CFMWS Count        : %u", entry->cfmws_count);
 
     for (window = 0; window < entry->cfmws_count && window < CXL_MAX_CFMWS_WINDOWS; window++) {
-      val_print(TRACE, "     CFMWS Index       : %u\n", window);
-      val_print(TRACE, "       Base            : 0x%llx\n", entry->cfmws_base[window]);
-      val_print(TRACE, "       Length          : 0x%llx\n", entry->cfmws_length[window]);
+      val_print(TRACE, "\n       CFMWS Index       : %u", window);
+      val_print(TRACE, "\n       Base            : 0x%llx", entry->cfmws_base[window]);
+      val_print(TRACE, "\n       Length          : 0x%llx", entry->cfmws_length[window]);
     }
   }
 
@@ -1215,12 +1214,12 @@ val_cxl_get_info(CXL_INFO_e type, uint32_t index)
 {
 
   if (g_cxl_info_table == NULL) {
-    val_print(ERROR, " GET_CXL_INFO: CXL info table is not created ");
+    val_print(ERROR, "\n       GET_CXL_INFO: CXL info table is not created ");
     return 0;
   }
 
   if ((type != CXL_INFO_NUM_DEVICES) && (index >= g_cxl_info_table->num_entries)) {
-    val_print(ERROR, " GET_CXL_INFO: Invalid index %d ", index);
+    val_print(ERROR, "\n       GET_CXL_INFO: Invalid index %d ", index);
     return 0;
   }
 
@@ -1242,7 +1241,7 @@ val_cxl_get_info(CXL_INFO_e type, uint32_t index)
   case CXL_INFO_VERSION:
     return g_cxl_info_table->device[index].cxl_version;
   default:
-    val_print(ERROR, " GET_CXL_INFO: Unsupported info type %d ", type);
+    val_print(ERROR, "\n       GET_CXL_INFO: Unsupported info type %d ", type);
     break;
   }
 
@@ -1356,7 +1355,7 @@ val_cxl_device_cache_capable(uint32_t bdf)
   uint32_t cxl_caps;
 
   if (val_cxl_find_capability(bdf, CXL_DVSEC_ID_DEVICE, &dvsec_off)) {
-      val_print(DEBUG, "DVSEC Capability not found for bdf 0x%x", bdf);
+      val_print(DEBUG, "\n       DVSEC Capability not found for bdf 0x%x", bdf);
       return 0;
   }
 

--- a/val/src/acs_dma.c
+++ b/val/src/acs_dma.c
@@ -40,7 +40,7 @@ val_dma_free_info_table(void)
     }
     else {
       val_print(ERROR,
-                  "\n WARNING: g_dma_info_table pointer is already NULL");
+                  "\n       g_dma_info_table pointer is already NULL");
     }
 }
 
@@ -56,16 +56,16 @@ val_dma_create_info_table(uint64_t *dma_info_ptr)
 {
 
   if (dma_info_ptr == NULL) {
-      val_print(ERROR, "Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return;
   }
-  val_print(TRACE, " Creating DMA INFO table\n");
+  val_print(TRACE, "\n       Creating DMA INFO table");
 
   g_dma_info_table = (DMA_INFO_TABLE *)dma_info_ptr;
 
   pal_dma_create_info_table(g_dma_info_table);
 
-  val_print(INFO, " DMA_INFO: Number of DMA CTRL in PCIe :    %x\n",
+  val_print(INFO, "\n    DMA_INFO: Number of DMA CTRL in PCIe :    %x",
                                                             val_dma_get_info(DMA_NUM_CTRL, 0));
 }
 
@@ -85,12 +85,12 @@ val_dma_get_info(DMA_INFO_e type, uint32_t index)
 
   if (g_dma_info_table == NULL)
   {
-      val_print(DEBUG, "GET_DMA_INFO: DMA info table is not created\n");
+      val_print(DEBUG, "\n       GET_DMA_INFO: DMA info table is not created");
       return 0;
   }
   if (index > g_dma_info_table->num_dma_ctrls)
   {
-      val_print(ERROR, "GET_DMA_INFO: Index (%d) is greater than num of DMA\n", index);
+      val_print(ERROR, "\n       GET_DMA_INFO: Index (%d) greater than num of DMA", index);
       return 0;
   }
 
@@ -118,7 +118,7 @@ val_dma_get_info(DMA_INFO_e type, uint32_t index)
           return ((uint64_t)g_dma_info_table->info[index].flags & (PCI_EP_MASK));
 
       default:
-          val_print(ERROR, "This DMA info option not supported %d\n", type);
+          val_print(ERROR, "\n       This DMA info option not supported %d", type);
           break;
   }
 

--- a/val/src/acs_execution_policy.c
+++ b/val/src/acs_execution_policy.c
@@ -53,6 +53,16 @@ uint32_t acs_policy_get_print_mmio(void)
     return g_execution_policy.print_mmio;
 }
 
+uint32_t acs_policy_get_log_indent(void)
+{
+    return g_execution_policy.log_indent;
+}
+
+void acs_policy_set_log_indent(uint32_t indent)
+{
+    g_execution_policy.log_indent = indent;
+}
+
 uint32_t acs_policy_get_pcie_p2p(void)
 {
     return g_execution_policy.pcie_p2p;

--- a/val/src/acs_exerciser.c
+++ b/val/src/acs_exerciser.c
@@ -70,7 +70,7 @@ uint32_t val_exerciser_create_info_table(void)
   num_ecam = (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
   if (num_ecam == 0)
   {
-      val_print(ERROR, "       No ECAMs discovered\n ");
+      val_print(ERROR, "\n       No ECAMs discovered");
       return 1;
   }
 
@@ -78,7 +78,7 @@ uint32_t val_exerciser_create_info_table(void)
   /* if no bdf table ptr return error */
   if (bdf_table->num_entries == 0)
   {
-      val_print(DEBUG, "\n       No BDFs discovered            ");
+      val_print(DEBUG, "\n       No BDFs discovered");
       return 1;
   }
 
@@ -104,15 +104,15 @@ uint32_t val_exerciser_create_info_table(void)
           g_exerciser_info_table.e_info[num_exerciser_info++].initialized = 0;
           vendor_id = (reg_value >> TYPE01_VIDR_SHIFT) & TYPE01_VIDR_MASK;
           vendor_name = lookup_vendor_name(vendor_id);
-          val_print(DEBUG, "    exerciser Bdf %x\n", Bdf);
-          val_print(DEBUG, "    Vendor ID: 0x%04x, ", vendor_id);
+          val_print(DEBUG, "\n       exerciser Bdf %x", Bdf);
+          val_print(DEBUG, "\n       Vendor ID: 0x%04x, ", vendor_id);
           val_print(DEBUG, "Vendor Name: ");
           val_print(DEBUG, vendor_name);
-          val_print(DEBUG, "\n\n");
+          val_print(DEBUG, "\n");
       }
   }
   g_exerciser_info_table.num_exerciser = num_exerciser_info;
-  val_print(INFO, "\n     PCIE_INFO: Number of exerciser cards  %4d \n",
+  val_print(INFO, "\nPCIE_INFO: Number of exerciser cards  %4d",
                                                              g_exerciser_info_table.num_exerciser);
   return 0;
 }
@@ -411,7 +411,7 @@ uint32_t val_exerciser_test_init(void)
     /* Build BDF table for all PCIe devices */
     if (val_pcie_create_device_bdf_table()) {
         val_print(WARN,
-                  "\n     Create BDF Table Failed, Skipping Exerciser tests...\n");
+                  "\n       Create BDF Table Failed, Skipping Exerciser tests...");
         status = ACS_STATUS_SKIP;
         g_exerciser_init_result = RESULT_SKIP(0);
         return status;

--- a/val/src/acs_gic.c
+++ b/val/src/acs_gic.c
@@ -38,10 +38,10 @@ val_gic_create_info_table(uint64_t *gic_info_table)
   uint32_t gic_version, num_msi_frame;
 
   if (gic_info_table == NULL) {
-      val_print(ERROR, "Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return ACS_STATUS_ERR;
   }
-  val_print(TRACE, " Creating GIC INFO table\n");
+  val_print(TRACE, "\n       Creating GIC INFO table");
 
   g_gic_info_table = (GIC_INFO_TABLE *)gic_info_table;
 
@@ -51,19 +51,19 @@ val_gic_create_info_table(uint64_t *gic_info_table)
   gic_version = val_gic_get_info(GIC_INFO_VERSION);
   num_msi_frame = val_gic_get_info(GIC_INFO_NUM_MSI_FRAME);
   if ((gic_version != 2) || (num_msi_frame == 0)) /* check if not a GICv2m system */
-      val_print(INFO, " GIC INFO: GIC version                :    v%d\n", gic_version);
+      val_print(INFO, "\nGIC_INFO: GIC version                :    v%d", gic_version);
   else
-      val_print(INFO, " GIC INFO: GIC version                :    v2m\n");
+      val_print(INFO, "\nGIC_INFO: GIC version                :    v2m");
 
-  val_print(INFO, " GIC_INFO: Number of GICD             : %4d\n",
+  val_print(INFO, "\nGIC_INFO: Number of GICD             : %4d",
                                                              g_gic_info_table->header.num_gicd);
-  val_print(INFO, " GIC_INFO: Number of GICR RD          : %4d\n",
+  val_print(INFO, "\nGIC_INFO: Number of GICR RD          : %4d",
                                                              g_gic_info_table->header.num_gicr_rd);
   if (g_gic_info_table->header.num_gicr_rd == 0) {
-      val_print(INFO, " GIC_INFO: Number of GICC RD          : %4d\n",
+      val_print(INFO, "\nGIC_INFO: Number of GICC RD          : %4d",
                                                              g_gic_info_table->header.num_gicc_rd);
   }
-  val_print(INFO, " GIC_INFO: Number of ITS              : %4d\n",
+  val_print(INFO, "\nGIC_INFO: Number of ITS              : %4d",
                                                              g_gic_info_table->header.num_its);
 
   if (g_gic_info_table->header.num_gicd == 0) {
@@ -114,7 +114,7 @@ val_get_gicd_base(void)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(ERROR, "GIC INFO table not available\n");
+      val_print(ERROR, "\n       GIC INFO table not available");
       return 0;
   }
 
@@ -172,7 +172,7 @@ val_gic_get_pe_rdbase(uint64_t mpidr)
   /* If System doesn't have GICR RD strcture, then use GICCC RD base */
   if (g_gic_info_table->header.num_gicr_rd == 0) {
       gicrd_base = val_get_gicr_base(&gicrd_baselen, 0);
-      val_print(DEBUG, "       gicrd_base 0x%lx\n", gicrd_base);
+      val_print(DEBUG, "\n       gicrd_base 0x%lx", gicrd_base);
 
       /* If information is present in GICC Structure */
       if (gicrd_baselen == 0)
@@ -188,13 +188,13 @@ val_gic_get_pe_rdbase(uint64_t mpidr)
   /* Use GICR RD base structure */
   while (gicr_rdindex < g_gic_info_table->header.num_gicr_rd) {
       gicrd_base = val_get_gicr_base(&gicrd_baselen, gicr_rdindex);
-      val_print(TRACE, "       gicr_rdindex %d", gicr_rdindex);
-      val_print(TRACE, "       gicrd_base 0x%lx\n", gicrd_base);
+      val_print(TRACE, "\n       gicr_rdindex %d", gicr_rdindex);
+      val_print(TRACE, "       gicrd_base 0x%lx", gicrd_base);
 
       pe_gicrd_base = gicrd_base;
       while (pe_gicrd_base < (gicrd_base + gicrd_baselen))
       {
-          val_print(TRACE, "       GICR_TYPER 0x%lx\n",
+          val_print(TRACE, "\n       GICR_TYPER 0x%lx",
                     val_mmio_read64(pe_gicrd_base + GICR_TYPER));
 
           affinity = (val_mmio_read64(pe_gicrd_base + GICR_TYPER) & GICR_TYPER_AFF) >> 32;
@@ -226,7 +226,7 @@ val_get_gicr_base(uint32_t *rdbase_len, uint32_t gicr_rd_index)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(ERROR, "GIC INFO table not available\n");
+      val_print(ERROR, "\n       GIC INFO table not available");
       return 0;
   }
   gic_entry = g_gic_info_table->gic_info;
@@ -264,7 +264,7 @@ val_get_gich_base(void)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(ERROR, "GIC INFO table not available\n");
+      val_print(ERROR, "\n       GIC INFO table not available");
       return 0;
   }
 
@@ -292,7 +292,7 @@ val_get_cpuif_base(void)
   GIC_INFO_ENTRY  *gic_entry;
 
   if (g_gic_info_table == NULL) {
-      val_print(ERROR, "GIC INFO table not available\n");
+      val_print(ERROR, "\n       GIC INFO table not available");
       return 0;
   }
 
@@ -331,7 +331,7 @@ val_gic_get_info(GIC_INFO_e type)
 
       case GIC_INFO_VERSION:
           if (g_gic_info_table->header.gic_version != 0) {
-             val_print(TRACE, "\n       gic version from info table = %d\n",
+             val_print(TRACE, "\n       gic version from info table = %d",
                        g_gic_info_table->header.gic_version);
              return g_gic_info_table->header.gic_version;
           }

--- a/val/src/acs_gic_support.c
+++ b/val/src/acs_gic_support.c
@@ -217,7 +217,7 @@ uint32_t val_gic_its_configure()
   /* Allocate memory to store ITS info */
   g_gic_its_info = (GIC_ITS_INFO *) val_aligned_alloc(MEM_ALIGN_4K, 1024);
   if (!g_gic_its_info) {
-      val_print(ERROR, "  ITS Configure: memory allocation failed\n");
+      val_print(ERROR, "\n       ITS Configure: memory allocation failed");
       return ACS_STATUS_ERR;
   }
 
@@ -250,13 +250,13 @@ uint32_t val_gic_its_configure()
 
   /* Return if no ITS */
   if (g_gic_its_info->GicNumIts == 0) {
-    val_print(DEBUG, "  ITS Configure: No ITS Found\n");
+    val_print(DEBUG, "\n       ITS Configure: No ITS Found");
     goto its_fail;
   }
 
   /* Base Address Check. */
   if ((g_gic_its_info->GicRdBase == 0) || (g_gic_its_info->GicDBase == 0)) {
-    val_print(DEBUG, "  ITS Configure: GICD/GICRD Base addr failed\n");
+    val_print(DEBUG, "\n       ITS Configure: GICD/GICRD Base addr failed");
     goto its_fail;
   }
 
@@ -264,11 +264,11 @@ uint32_t val_gic_its_configure()
       && val_its_gicr_lpi_support(g_gic_its_info->GicRdBase)) {
     Status = val_its_init();
     if ((Status)) {
-      val_print(DEBUG, "  ITS Configure: its_init failed\n");
+      val_print(DEBUG, "\n       ITS Configure: its_init failed");
       goto its_fail;
     }
   } else {
-    val_print(DEBUG, "  ITS Configure: LPI unsupported\n");
+    val_print(DEBUG, "\n       ITS Configure: LPI unsupported");
     goto its_fail;
   }
 
@@ -278,8 +278,8 @@ uint32_t val_gic_its_configure()
 
 its_fail:
 
-  val_print(DEBUG, "  ITS Init failed: ");
-  val_print(DEBUG, "LPI Interrupt related test may not pass\n");
+  val_print(DEBUG, "\n       ITS Init failed: ");
+  val_print(DEBUG, "LPI Interrupt related test may not pass");
   val_memory_free_aligned((void *)g_gic_its_info);
 
   return ACS_STATUS_ERR;

--- a/val/src/acs_gic_v2m.c
+++ b/val/src/acs_gic_v2m.c
@@ -39,7 +39,7 @@ uint32_t val_gic_v2m_parse_info(void)
   uint32_t i;
 
   if (g_gic_info_table == NULL) {
-      val_print(DEBUG, "GIC INFO table not available\n");
+      val_print(DEBUG, "\n       GIC INFO table not available");
       return ACS_STATUS_SKIP;
   }
 

--- a/val/src/acs_iovirt.c
+++ b/val/src/acs_iovirt.c
@@ -41,7 +41,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(ERROR, "GET_SMMU_INFO: iovirt info table is not created\n");
+      val_print(ERROR, "\n       iovirt info table is not created");
       return 0;
   }
 
@@ -66,7 +66,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
                   case SMMU_IOVIRT_BLOCK:
                       return (uint64_t)block;
                   default:
-                      val_print(ERROR, "This SMMU info option not supported %d\n", type);
+                      val_print(ERROR, "\n       This SMMU info option not supported %d", type);
                       return 0;
               }
           }
@@ -76,7 +76,7 @@ val_iovirt_get_smmu_info(SMMU_INFO_e type, uint32_t index)
 
   if (index > j-1)
   {
-      val_print(ERROR, "GET_SMMU_INFO: Index (%d) is greater than num of SMMU\n", index);
+      val_print(ERROR, "\n       Index (%d) is greater than num of SMMU", index);
       return 0;
   }
   return j;
@@ -99,7 +99,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(ERROR, "GET_PCIe_RC_INFO: iovirt info table is not created\n");
+      val_print(ERROR, "\n       GET_PCIe_RC_INFO: iovirt info table is not created");
       return 0;
   }
 
@@ -128,7 +128,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
                   case RC_SMMU_BASE:
                       return block->data.rc.smmu_base;
                   default:
-                      val_print(ERROR, "This PCIe RC info option not supported %d\n", type);
+                      val_print(ERROR, "\n       This PCIe RC info option not supported %d", type);
                       return 0;
               }
           }
@@ -137,7 +137,7 @@ val_iovirt_get_pcie_rc_info(PCIE_RC_INFO_e type, uint32_t index)
   }
   if (index > j-1)
   {
-      val_print(ERROR, "GET_PCIe_RC_INFO: Index (%d) is greater than num of PCIe-RC\n",
+      val_print(ERROR, "\n       GET_PCIe_RC_INFO: Index (%d) is greater than num of PCIe-RC",
                                                                                             index);
       return 0;
   }
@@ -270,10 +270,10 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
   if (iovirt_info_table == NULL)
   {
-      val_print(ERROR, "\n   Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return;
   }
-  val_print(TRACE, " Creating SMMU INFO table\n");
+  val_print(TRACE, "\n       Creating SMMU INFO table");
 
   g_iovirt_info_table = (IOVIRT_INFO_TABLE *)iovirt_info_table;
 
@@ -281,7 +281,7 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
   g_num_smmus = (uint32_t)val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   val_print(INFO,
-            " SMMU_INFO: Number of SMMU CTRL       :    %d\n", g_num_smmus);
+            "\nSMMU_INFO: Number of SMMU CTRL       :    %d", g_num_smmus);
   for (i = 0; i < g_num_smmus; i++) {
 
     smmu_base = val_smmu_get_info(SMMU_CTRL_BASE, i);
@@ -296,14 +296,13 @@ val_iovirt_create_info_table(uint64_t *iovirt_info_table)
 
     smmu_ver = val_smmu_get_info(SMMU_CTRL_ARCH_MAJOR_REV, i);
     val_print(INFO,
-            " SMMU_INFO: SMMU index %02d ", i);
+            "\nSMMU_INFO: SMMU index %02d ", i);
     val_print(INFO, "version     :    v%d", smmu_ver);
 
     if (smmu_ver == 3) {
       smmu_minor = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_AIDR, i), 0, 3);
       val_print(INFO, ".%d", smmu_minor);
     }
-    val_print(INFO, "\n", smmu_ver);
   }
 }
 
@@ -323,7 +322,7 @@ val_iovirt_free_info_table(void)
     }
     else {
       val_print(DEBUG,
-                  "\n g_iovirt_info_table pointer is already NULL");
+                  "\n       g_iovirt_info_table pointer is already NULL");
     }
 }
 
@@ -409,7 +408,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(ERROR, "GET_NAMED_COMP_INFO: iovirt info table is not created\n");
+      val_print(ERROR, "\n       GET_NAMED_COMP_INFO: iovirt info table is not created");
       return 0; /* imply no named components parsed */
   }
 
@@ -419,7 +418,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
   /* check if index in range */
   if (index > g_iovirt_info_table->num_named_components - 1) {
       val_print(ERROR,
-                "GET_NAMED_COMP_INFO: Index (%d) is greater than num of Named components\n",
+                "\n       GET_NAMED_COMP_INFO: Index (%d) is greater than num Named components",
                  index);
       return INVALID_NAMED_COMP_INFO;
   }
@@ -445,7 +444,7 @@ val_iovirt_get_named_comp_info(NAMED_COMP_INFO_e type, uint32_t index)
                       return block->data.named_comp.smmu_base;
                   default:
                       val_print(ERROR,
-                                "This Named component info option not supported %d\n", type);
+                                "\n       Named component info option not supported %d", type);
                       return INVALID_NAMED_COMP_INFO;
               }
           }
@@ -576,7 +575,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(ERROR, "GET_PMCG_INFO: iovirt info table is not created\n");
+      val_print(ERROR, "\n       GET_PMCG_INFO: iovirt info table not created");
       return 0;
   }
 
@@ -603,7 +602,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
                   case PMCG_NODE_SMMU_BASE:
                       return block->data.pmcg.smmu_base;
                   default:
-                      val_print(ERROR, "This PMCG info option not supported %d\n", type);
+                      val_print(ERROR, "\n       PMCG info option not supported %d", type);
                       return 0;
               }
           }
@@ -613,7 +612,7 @@ val_iovirt_get_pmcg_info(PMCG_INFO_e type, uint32_t index)
 
   if (index > j-1)
   {
-      val_print(ERROR, "GET_PMCG_INFO: Index (%d) is greater than num of PMCG\n", index);
+      val_print(ERROR, "\n       GET_PMCG_INFO: Index (%d) greater than num of PMCG", index);
       return 0;
   }
   return j;
@@ -627,7 +626,7 @@ val_iovirt_get_rc_index(uint32_t rc_seg_num)
 
   if (g_iovirt_info_table == NULL)
   {
-      val_print(ERROR, "GET_PCIe_RC_INFO: iovirt info table is not created\n");
+      val_print(ERROR, "\n       GET_PCIe_RC_INFO: iovirt info table not created");
       return 0;
   }
 
@@ -646,7 +645,7 @@ val_iovirt_get_rc_index(uint32_t rc_seg_num)
   }
   if (i >=  g_iovirt_info_table->num_blocks)
   {
-      val_print(ERROR, "GET_PCIe_RC_INFO: segemnt (%d) is not valid\n", rc_seg_num);
+      val_print(ERROR, "\n       GET_PCIe_RC_INFO: segemnt (%d) is not valid", rc_seg_num);
       return ACS_INVALID_INDEX;
   }
   return j;
@@ -674,11 +673,11 @@ val_iovirt_get_its_info(
 
 
   if (g_iovirt_info_table == NULL) {
-    val_print(ERROR, "GET_ITS_INFO: iovirt info table is not created\n");
+    val_print(ERROR, "\n       GET_ITS_INFO: iovirt info table is not created");
     return ACS_STATUS_ERR;
   }
   if (!return_value) {
-      val_print(ERROR, "GET_ITS_INFO: Return pointer is NULL\n");
+      val_print(ERROR, "\n       GET_ITS_INFO: Return pointer is NULL");
       return ACS_STATUS_ERR;
   }
 
@@ -732,7 +731,7 @@ val_iovirt_get_its_info(
                   /* ITS_ID not found in current group, return error */
                   return ACS_INVALID_INDEX;
                 default:
-                  val_print(ERROR, "This ITS info option not supported %d\n", type);
+                  val_print(ERROR, "\n       This ITS info option not supported %d", type);
                   return ACS_STATUS_ERR;
               }
               break;
@@ -741,7 +740,7 @@ val_iovirt_get_its_info(
       }
   }
 
-  val_print(ERROR, "GET_ITS_INFO: ITS Group not found %d\n", group_index);
+  val_print(ERROR, "\n       GET_ITS_INFO: ITS Group not found %d", group_index);
   return ACS_INVALID_INDEX;
 }
 

--- a/val/src/acs_memory.c
+++ b/val/src/acs_memory.c
@@ -83,7 +83,7 @@ val_memory_free_info_table(void)
     }
     else {
       val_print(ERROR,
-                  "\n WARNING: g_memory_info_table pointer is already NULL");
+                  "\n       g_memory_info_table pointer is already NULL");
     }
 }
 
@@ -102,7 +102,7 @@ val_memory_create_info_table(uint64_t *memory_info_table)
 {
 
   g_memory_info_table = (MEMORY_INFO_TABLE *)memory_info_table;
-  val_print(TRACE, " Creating MEMORY INFO table\n");
+  val_print(TRACE, "\n       Creating MEMORY INFO table");
 
   pal_memory_create_info_table(g_memory_info_table);
 
@@ -427,7 +427,7 @@ uint32_t val_memory_region_has_52bit_addr(void)
   uint32_t index = 0;
 
   while (g_memory_info_table->info[index].type != MEMORY_TYPE_LAST_ENTRY) {
-      val_print(TRACE, " \n       Mem Phy Addr %lx",
+      val_print(TRACE, "\n       Mem Phy Addr %lx",
                                    g_memory_info_table->info[index].phy_addr);
       if (CHECK_ADDR_52BIT(g_memory_info_table->info[index].phy_addr))
           return 1;

--- a/val/src/acs_mmu.c
+++ b/val/src/acs_mmu.c
@@ -182,7 +182,7 @@ val_mmu_add_entry(uint64_t base_addr, uint64_t size, uint64_t attr)
   pgt_desc.oas = oas_bit_arr[pgt_desc.tcr.ps];
   pgt_desc.ias = 64 - pgt_desc.tcr.tsz;
   val_print(DEBUG, "\n   Input addr size in bits (ias) = %d", pgt_desc.ias);
-  val_print(DEBUG, "\n   Output addr size in bits (oas) = %d\n", pgt_desc.oas);
+  val_print(DEBUG, "\n       Output addr size in bits (oas) = %d", pgt_desc.oas);
 
   /* populate mem descriptor structure with addr region to be mapped and attributes */
   mem_desc.virtual_address = base_addr;
@@ -197,7 +197,7 @@ val_mmu_add_entry(uint64_t base_addr, uint64_t size, uint64_t attr)
 
   /* update translation table entry(s) for addr region defined by memory descriptor structure  */
   if (val_pgt_create(&mem_desc, &pgt_desc)) {
-      val_print(ERROR, "   Failed to create MMU translation entry(s)\n");
+      val_print(ERROR, "\n       Failed to create MMU translation entry(s)");
       return 1;
   }
   return 0;
@@ -217,7 +217,7 @@ uint32_t val_mmu_update_entry(uint64_t address, uint32_t size, uint64_t attr)
 
   /* If entry is already present return success */
   if (!val_mmu_check_for_entry(address)) {
-      val_print(DEBUG, "\n   Address is already mapped\n");
+      val_print(DEBUG, "\n       Address is already mapped");
       return 0;
   }
 
@@ -305,7 +305,7 @@ void val_setup_mair_register(void)
         val_mair_write(mair_val, currentEL);
 
     val_print(DEBUG, "\n  Previous MAIR register value 0x%lx", current_mair);
-    val_print(DEBUG, "\n  Current MAIR register value 0x%lx\n", mair_val);
+    val_print(DEBUG, "\n       Current MAIR register value 0x%lx", mair_val);
     return;
 }
 
@@ -332,8 +332,8 @@ uint32_t val_setup_mmu(void)
     pgt_desc.pgt_base = (uint64_t) tt_l0_base;
     pgt_desc.stage = PGT_STAGE1;
 
-    val_print(DEBUG, "       mmu: ias=%d\n", pgt_desc.ias);
-    val_print(DEBUG, "       mmu: oas=%d\n", pgt_desc.oas);
+    val_print(DEBUG, "\n       mmu: ias=%d", pgt_desc.ias);
+    val_print(DEBUG, "\n       mmu: oas=%d", pgt_desc.oas);
 
     /* Map regions */
 
@@ -351,7 +351,7 @@ uint32_t val_setup_mmu(void)
 
         val_print(DEBUG, "\n       Creating page table for region  : 0x%lx",
                                                                         mem_desc->virtual_address);
-        val_print(DEBUG, "- 0x%lx\n", (mem_desc->virtual_address + mem_desc->length) - 1);
+        val_print(DEBUG, "- 0x%lx", (mem_desc->virtual_address + mem_desc->length) - 1);
 
         if (val_pgt_create(mem_desc, &pgt_desc))
         {
@@ -391,8 +391,8 @@ uint32_t val_enable_mmu(void)
 
     val_tcr_write(tcr, currentEL);
 
-    val_print(DEBUG, "       val_setup_mmu: TG0=0x%x\n", TCR_TG0);
-    val_print(DEBUG, "       val_setup_mmu: tcr=0x%lx\n", tcr);
+    val_print(DEBUG, "\n       val_setup_mmu: TG0=0x%x", TCR_TG0);
+    val_print(DEBUG, "\n       val_setup_mmu: tcr=0x%lx", tcr);
 
 /* Enable MMU */
     val_sctlr_write((1 << 0) |  // M=1 Enable the stage 1 MMU
@@ -401,8 +401,8 @@ uint32_t val_enable_mmu(void)
                     val_sctlr_read(currentEL),
                     currentEL);
 
-    val_print(DEBUG, "       val_enable_mmu: successful\n");
-    val_print(DEBUG, "       System Control EL2 is %llx", val_sctlr_read(currentEL));
+    val_print(DEBUG, "\n       val_enable_mmu: successful");
+    val_print(DEBUG, "\n       System Control EL2 is %llx", val_sctlr_read(currentEL));
 
     return ACS_STATUS_PASS;
 }

--- a/val/src/acs_mpam.c
+++ b/val/src/acs_mpam.c
@@ -177,7 +177,7 @@ val_mpam_get_info(MPAM_INFO_e type, uint32_t msc_index, uint32_t rsrc_index)
   }
 
   if (msc_index >= g_mpam_info_table->msc_count) {
-      val_print(ERROR, "Invalid MSC index = 0x%lx ", msc_index);
+      val_print(ERROR, "\n       Invalid MSC index = 0x%lx ", msc_index);
       return 0;
   }
 
@@ -1019,8 +1019,8 @@ val_mpam_create_info_table(uint64_t *mpam_info_table)
   pal_mpam_create_info_table(g_mpam_info_table);
 
   val_print(INFO,
-                " MPAM INFO: Number of MSC nodes       :    %d\n", g_mpam_info_table->msc_count);
-  val_print(DEBUG, "Memory mapping MSC nodes\n");
+                "\n    MPAM_INFO: Number of MSC nodes     :  %d", g_mpam_info_table->msc_count);
+  val_print(DEBUG, "\n       Memory mapping MSC nodes");
 
   /* TODO - Check if MSC memory mapping requires a flag/ cmdline option */
   memory_map_msc();
@@ -1039,7 +1039,7 @@ val_mpam_update_msc_device_names(void)
 {
 #ifndef TARGET_LINUX
   if (g_mpam_info_table == NULL) {
-    val_print(ERROR, "MPAM info table is not created\n");
+    val_print(ERROR, "\n       MPAM info table is not created");
     return;
   }
   pal_mpam_parse_dsdt_info(g_mpam_info_table);
@@ -1060,7 +1060,7 @@ val_mpam_free_info_table(void)
     }
     else {
       val_print(ERROR,
-                  "\n WARNING: g_mpam_info_table pointer is already NULL",
+                  "\n       g_mpam_info_table pointer is already NULL",
         0);
     }
 }
@@ -1081,15 +1081,15 @@ val_mpam_get_msc_device_info(uint32_t msc_index, uint32_t *device_id, uint32_t *
   MPAM_MSC_NODE *msc_node;
 
   if (g_mpam_info_table == NULL) {
-    val_print(ERROR, "MPAM info table is not created\n");
+    val_print(ERROR, "\n       MPAM info table is not created");
     return ACS_STATUS_ERR;
   }
   if (device_id == NULL) {
-    val_print(ERROR, "MPAM info invalid params\n");
+    val_print(ERROR, "\n       MPAM info invalid params");
     return ACS_STATUS_ERR;
   }
   if (msc_index >= g_mpam_info_table->msc_count) {
-    val_print(ERROR, "MPAM info invalid MSC index %d\n", msc_index);
+    val_print(ERROR, "\n       MPAM info invalid MSC index %d", msc_index);
     return ACS_STATUS_ERR;
   }
 
@@ -1100,20 +1100,20 @@ val_mpam_get_msc_device_info(uint32_t msc_index, uint32_t *device_id, uint32_t *
   identifier = msc_node->identifier;
   device_name = msc_node->device_obj_name;
   if (device_name[0] == '\0') {
-    val_print(ERROR, "MPAM info missing device name for MSC %d\n", msc_index);
+    val_print(ERROR, "\n       MPAM info missing device name for MSC %d", msc_index);
     return ACS_STATUS_ERR;
   }
 
   uint32_t status = val_iovirt_get_named_comp_device_info(device_name,
                                                           identifier, device_id, its_id);
   if (status == 0) {
-    val_print(TRACE, " MPAM MSC Device info: idx=%d", msc_index);
+    val_print(TRACE, "\n       MPAM MSC Device info: idx=%d", msc_index);
     val_print(TRACE, " id=0x%x", identifier);
     val_print(TRACE, " dev=0x%x", *device_id);
-    val_print(TRACE, " its=0x%x\n", its_id ? *its_id : 0);
+    val_print(TRACE, " its=0x%x", its_id ? *its_id : 0);
   } else {
-    val_print(ERROR, " MPAM MSC devinfo failed: idx=%d", msc_index);
-    val_print(ERROR, " id=0x%x\n", identifier);
+    val_print(ERROR, "\n       MPAM MSC devinfo failed: idx=%d", msc_index);
+    val_print(ERROR, " id=0x%x", identifier);
   }
   return status;
 }
@@ -1130,7 +1130,7 @@ void
 val_hmat_create_info_table(uint64_t *hmat_info_table)
 {
   if (hmat_info_table == NULL) {
-    val_print(ERROR, "\n Pre-allocated memory pointer is NULL\n");
+    val_print(ERROR, "\n       Pre-allocated memory pointer is NULL");
     return;
   }
 #ifndef TARGET_LINUX
@@ -1140,7 +1140,7 @@ val_hmat_create_info_table(uint64_t *hmat_info_table)
 
   if (g_hmat_info_table->num_of_mem_prox_domain != 0)
       val_print(INFO,
-                " HMAT INFO: Number of Prox domains    :    %d\n",
+                "\n    HMAT_INFO: Number of Prox domains    :    %d",
                                     g_hmat_info_table->num_of_mem_prox_domain);
 #endif
 }
@@ -1168,7 +1168,7 @@ void
 val_srat_create_info_table(uint64_t *srat_info_table)
 {
   if (srat_info_table == NULL) {
-    val_print(ERROR, "\n Pre-allocated memory pointer is NULL\n");
+    val_print(ERROR, "\n       Pre-allocated memory pointer is NULL");
     return;
   }
 #ifndef TARGET_LINUX
@@ -1178,7 +1178,7 @@ val_srat_create_info_table(uint64_t *srat_info_table)
 
   if (g_srat_info_table->num_of_mem_ranges != 0)
       val_print(INFO,
-                " SRAT INFO: Number of Memory Ranges   :    %d\n",
+                "\n    SRAT_INFO: Number of Memory Ranges   :    %d",
                                     g_srat_info_table->num_of_mem_ranges);
 #endif
 }
@@ -1957,7 +1957,7 @@ uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t buffer_size, uin
   buffer = (void *)val_memory_alloc(pe_count * sizeof(uint64_t));
 
   if (!buffer) {
-      val_print(ERROR, "Allocate Pool for shared memcpy buf failed\n");
+      val_print(ERROR, "\n       Allocate Pool for shared memcpy buf failed");
       return 0;
   }
 
@@ -1969,7 +1969,7 @@ uint32_t val_alloc_shared_memcpybuf(uint64_t mem_base, uint64_t buffer_size, uin
                                                     buffer_size);
 
       if (g_shared_memcpy_buffer[pe_index] == NULL) {
-          val_print(ERROR, "Alloc address for shared memcpy buffer failed %x\n", pe_index);
+          val_print(ERROR, "\n       Alloc address for shared memcpy buffer failed %x", pe_index);
           val_mem_free_shared_memcpybuf(pe_index);
           return 0;
       }

--- a/val/src/acs_pcie.c
+++ b/val/src/acs_pcie.c
@@ -324,7 +324,7 @@ val_pcie_print_device_info(void)
 
   if (bdf_tbl_ptr->num_entries == 0)
   {
-    val_print(ERROR, " PCIE_INFO: No entries in BDF Table\n");
+    val_print(ERROR, "\nPCIE_INFO: No entries in BDF Table");
     return;
   }
 
@@ -368,16 +368,16 @@ val_pcie_print_device_info(void)
       }
   }
 
-  val_print(INFO, " PCIE_INFO: Number of RCiEP           : %4d\n", num_rciep);
-  val_print(INFO, " PCIE_INFO: Number of RCEC            : %4d\n", num_rcec);
-  val_print(INFO, " PCIE_INFO: Number of EP              : %4d\n", num_ep);
-  val_print(INFO, " PCIE_INFO: Number of RP              : %4d\n", num_rp);
-  val_print(INFO, " PCIE_INFO: Number of iEP_EP          : %4d\n", num_iep);
-  val_print(INFO, " PCIE_INFO: Number of iEP_RP          : %4d\n", num_irp);
-  val_print(INFO, " PCIE_INFO: Number of UP of switch    : %4d\n", num_up);
-  val_print(INFO, " PCIE_INFO: Number of DP of switch    : %4d\n", num_dp);
-  val_print(INFO, " PCIE_INFO: Number of PCI/PCIe Bridge : %4d\n", num_pci_pcie);
-  val_print(INFO, " PCIE_INFO: Number of PCIe/PCI Bridge : %4d\n", num_pcie_pci);
+  val_print(INFO, "\nPCIE_INFO: Number of RCiEP           : %4d", num_rciep);
+  val_print(INFO, "\nPCIE_INFO: Number of RCEC            : %4d", num_rcec);
+  val_print(INFO, "\nPCIE_INFO: Number of EP              : %4d", num_ep);
+  val_print(INFO, "\nPCIE_INFO: Number of RP              : %4d", num_rp);
+  val_print(INFO, "\nPCIE_INFO: Number of iEP_EP          : %4d", num_iep);
+  val_print(INFO, "\nPCIE_INFO: Number of iEP_RP          : %4d", num_irp);
+  val_print(INFO, "\nPCIE_INFO: Number of UP of switch    : %4d", num_up);
+  val_print(INFO, "\nPCIE_INFO: Number of DP of switch    : %4d", num_dp);
+  val_print(INFO, "\nPCIE_INFO: Number of PCI/PCIe Bridge : %4d", num_pci_pcie);
+  val_print(INFO, "\nPCIE_INFO: Number of PCIe/PCI Bridge : %4d", num_pcie_pci);
 
   while (ecam_index < (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0))
   {
@@ -388,7 +388,7 @@ val_pcie_print_device_info(void)
       bdf_counter = 0;
 
       val_print(TRACE, "\n  ECAM %d:", ecam_index);
-      val_print(TRACE, "  Base 0x%llx\n", ecam_base);
+      val_print(TRACE, "  Base 0x%llx", ecam_base);
 
       while (tbl_index < bdf_tbl_ptr->num_entries)
       {
@@ -419,17 +419,17 @@ val_pcie_print_device_info(void)
           {
               bdf_counter = 1;
               bdf = PCIE_CREATE_BDF(seg_num, bus_num, dev_num, func_num);
-              val_print(TRACE, "  BDF: 0x%x\n", bdf);
-              val_print(TRACE, "  Seg: 0x%x, ", seg_num);
+              val_print(TRACE, "\n       BDF: 0x%x", bdf);
+              val_print(TRACE, "\n       Seg: 0x%x, ", seg_num);
               val_print(TRACE, "Bus: 0x%02x, ", bus_num);
               val_print(TRACE, "Dev: 0x%02x, ", dev_num);
               val_print(TRACE, "Func: 0x%x, ", func_num);
               val_print(TRACE, "Dev ID: 0x%04x, ", device_id);
-              val_print(TRACE, "Vendor ID: 0x%04x\n", vendor_id);
+              val_print(TRACE, "Vendor ID: 0x%04x", vendor_id);
           }
       }
       if (bdf_counter == 0)
-          val_print(TRACE, "  No BDF devices in ECAM region index %d\n", ecam_index);
+          val_print(TRACE, "\n       No BDF devices in ECAM region index %d", ecam_index);
 
       ecam_index++;
   }
@@ -450,17 +450,17 @@ val_pcie_create_info_table(uint64_t *pcie_info_table)
   uint32_t num_ecam;
 
   if (pcie_info_table == NULL) {
-      val_print(ERROR, "Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return;
   }
-  val_print(TRACE, " Creating PCIe INFO table\n");
+  val_print(TRACE, "\n       Creating PCIe INFO table");
 
   g_pcie_info_table = (PCIE_INFO_TABLE *)pcie_info_table;
 
   pal_pcie_create_info_table(g_pcie_info_table);
 
   num_ecam = (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
-  val_print(INFO, " PCIE_INFO: Number of ECAM regions    :    %ld\n", num_ecam);
+  val_print(INFO, "\nPCIE_INFO: Number of ECAM regions    :    %ld", num_ecam);
   if (num_ecam == 0)
       return;
 
@@ -468,14 +468,14 @@ val_pcie_create_info_table(uint64_t *pcie_info_table)
 
   /* Create the list of valid Pcie Device Functions */
   if (val_pcie_create_device_bdf_table()) {
-      val_print(ERROR, "   Create Bdf table failed.\n");
+      val_print(ERROR, "\n       Create Bdf table failed");
       return;
   }
 
   if (pal_pcie_check_device_list()) {
     pcie_bdf_table_list_flag = 1;
-    val_print(ERROR, "Pcie device list doesn't match \
-                with platform pcie device hierarchy\n");
+    val_print(ERROR, "\n       Pcie device list doesn't match \
+                with platform pcie device hierarchy");
   }
 
   val_pcie_print_device_info();
@@ -500,13 +500,13 @@ uint32_t val_pcie_populate_device_rootport(void)
   for (tbl_index = 0; tbl_index < bdf_tbl_ptr->num_entries; tbl_index++)
   {
       bdf = bdf_tbl_ptr->device[tbl_index].bdf;
-      val_print(DEBUG, "  Dev bdf 0x%06x", bdf);
+      val_print(DEBUG, "\n       Dev bdf 0x%06x", bdf);
 
       /* Checks if the BDF has RootPort */
       val_pcie_get_rootport(bdf, &rp_bdf);
 
       bdf_tbl_ptr->device[tbl_index].rp_bdf = rp_bdf;
-      val_print(DEBUG, " RP bdf 0x%06x\n", rp_bdf);
+      val_print(DEBUG, "\n       RP bdf 0x%06x", rp_bdf);
   }
   return 0;
 }
@@ -547,7 +547,7 @@ val_pcie_create_device_bdf_table()
   if (!g_pcie_bdf_table)
   {
       val_print(ERROR,
-        "       PCIe BDF table memory allocation failed\n");
+        "\n       PCIe BDF table memory allocation failed");
       return 1;
   }
 
@@ -557,7 +557,7 @@ val_pcie_create_device_bdf_table()
   num_ecam = (uint32_t)val_pcie_get_info(PCIE_INFO_NUM_ECAM, 0);
   if (num_ecam == 0)
   {
-      val_print(ERROR, "       No ECAMs discovered\n ");
+      val_print(ERROR, "\n       No ECAMs discovered");
       return 1;
   }
 
@@ -573,7 +573,7 @@ val_pcie_create_device_bdf_table()
       {
           if (pal_pcie_check_bus_valid(bus_index)) {
               val_print(DEBUG,
-               "       Bus 0x%x marked as invalid in Platform API...Skipping\n", bus_index);
+               "\n       Bus 0x%x marked as invalid in Platform API...Skipping", bus_index);
               continue;
           }
 
@@ -598,7 +598,7 @@ val_pcie_create_device_bdf_table()
                       /* Skip if the device is a host bridge */
                       if (val_pcie_is_host_bridge(bdf)) {
                           val_print(DEBUG,
-                                     "       BDF 0x%x is a Host Bridge...Skipping\n", bdf);
+                                     "\n       BDF 0x%x is a Host Bridge...Skipping", bdf);
                           continue;
                       }
 
@@ -620,14 +620,14 @@ val_pcie_create_device_bdf_table()
 
                       if (p_cap != PCIE_SUCCESS) {
                           val_print(DEBUG,
-                          "       BDF 0x%x PCI Express capability not present...Skipping\n", bdf);
+                          "\n       BDF 0x%x PCI Express capability not present...Skipping", bdf);
                           continue;
                       }
 
                       status = pal_pcie_check_device_valid(bdf);
                       if (status) {
                           val_print(DEBUG,
-                           "       BDF 0x%x Marked as invalid in Platform API...Skipping\n", bdf);
+                           "\n       BDF 0x%x Marked as invalid in Platform API...Skipping", bdf);
                           continue;
                       }
 
@@ -657,7 +657,7 @@ val_pcie_create_device_bdf_table()
   val_pcie_populate_device_rootport();
 
   val_print(INFO,
-    " PCIE_INFO: Number of BDFs found      :    %d\n", g_pcie_bdf_table->num_entries);
+    "\nPCIE_INFO: Number of BDFs found      :    %d", g_pcie_bdf_table->num_entries);
 
   return 0;
 }
@@ -765,13 +765,13 @@ val_pcie_get_info(PCIE_INFO_e type, uint32_t index)
 {
 
   if (g_pcie_info_table == NULL) {
-      val_print(ERROR, "GET_PCIe_INFO: PCIE info table is not created\n");
+      val_print(ERROR, "\n       GET_PCIe_INFO: PCIE info table is not created");
       return 0;
   }
 
   if (index >= g_pcie_info_table->num_entries) {
       if (g_pcie_info_table->num_entries != 0)
-          val_print(ERROR, "Invalid index %d > num of entries\n", index);
+          val_print(ERROR, "\n       Invalid index %d > num of entries", index);
       return 0;
   }
 
@@ -787,7 +787,7 @@ val_pcie_get_info(PCIE_INFO_e type, uint32_t index)
       case PCIE_INFO_SEGMENT:
           return g_pcie_info_table->block[index].segment_num;
       default:
-          val_print(ERROR, "This PCIE info option not supported %d\n", type);
+          val_print(ERROR, "\n       This PCIE info option not supported %d", type);
           break;
   }
 
@@ -1156,7 +1156,7 @@ val_pcie_enable_dpc(uint32_t bdf, uint32_t err_type)
   status = val_pcie_find_capability(bdf, PCIE_ECAP, ECID_DPC, &dpc_cap_base);
   if (status == PCIE_CAP_NOT_FOUND)
   {
-      val_print(DEBUG, "DPC Capability not supported \n");
+      val_print(DEBUG, "\n       DPC Capability not supported");
       return;
   }
 
@@ -1183,7 +1183,7 @@ val_pcie_disable_dpc(uint32_t bdf)
   status = val_pcie_find_capability(bdf, PCIE_ECAP, ECID_DPC, &dpc_cap_base);
   if (status == PCIE_CAP_NOT_FOUND)
   {
-      val_print(DEBUG, "DPC Capability not supported \n");
+      val_print(DEBUG, "\n       DPC Capability not supported");
       return;
   }
 
@@ -1369,7 +1369,7 @@ uint32_t val_pcie_bitfield_check(uint32_t bdf, uint64_t *bitfield_entry)
           id = bf_entry->ecap_id;
           break;
       default:
-          val_print(ERROR, "\n       Invalid reg_type  0x%x  ", bf_entry->reg_type);
+          val_print(ERROR, "\n       Invalid reg_type  0x%x", bf_entry->reg_type);
           return 1;
   }
 
@@ -1742,7 +1742,7 @@ val_pcie_get_rootport(uint32_t bdf, uint32_t *rp_bdf)
 
   dp_type = val_pcie_device_port_type(bdf);
 
-  val_print(TRACE, " type 0x%02x", dp_type);
+  val_print(TRACE, "\n       type 0x%02x", dp_type);
 
   /* If the device is RP or iEP_RP, set its rootport value to same */
   if ((dp_type == RP) || (dp_type == iEP_RP))
@@ -1781,7 +1781,7 @@ val_pcie_get_rootport(uint32_t bdf, uint32_t *rp_bdf)
   }
 
   /* Return failure */
-  val_print(ERROR, "   PCIe Hierarchy fail: RP of bdf 0x%x not found\n", bdf);
+  val_print(ERROR, "\n       PCIe Hierarchy fail: RP of bdf 0x%x not found", bdf);
   *rp_bdf = 0;
   return 1;
 

--- a/val/src/acs_pe.c
+++ b/val/src/acs_pe.c
@@ -523,7 +523,7 @@ void
 val_cache_create_info_table(uint64_t *cache_info_table)
 {
   if (cache_info_table == NULL) {
-      val_print(ERROR, "\n   Pre-allocated memory pointer is NULL\n");
+      val_print(ERROR, "\n       Pre-allocated memory pointer is NULL");
       return;
   }
 
@@ -533,7 +533,7 @@ val_cache_create_info_table(uint64_t *cache_info_table)
 
   if (g_cache_info_table->num_of_cache != 0) {
       val_print(INFO,
-                " CACHE_INFO: Number of cache nodes    : %4d\n",
+                "\n    CACHE_INFO: Number of cache nodes    : %4d",
                 g_cache_info_table->num_of_cache);
   }
 
@@ -554,7 +554,7 @@ val_cache_free_info_table(void)
     }
     else {
       val_print(ERROR,
-                  "\n WARNING: g_cache_info_table pointer is already NULL");
+                  "\n       g_cache_info_table pointer is already NULL");
     }
 }
 
@@ -606,7 +606,7 @@ val_cache_get_info(CACHE_INFO_e type, uint32_t cache_index)
       return entry->is_private;
   default:
       val_print(ERROR,
-                "\n      cache option not supported %d\n", type);
+                "\n       cache option not supported %d", type);
       return INVALID_CACHE_INFO;
   }
 
@@ -672,7 +672,7 @@ val_cache_get_pe_l1_cache_res(uint32_t res_index)
       return entry->level_1_res[res_index];
   else {
       val_print(ERROR,
-               "\n   Requested resource index exceeds maximum index value %d\n", MAX_L1_CACHE_RES);
+               "\n       Requested resource index exceeds maximum value %d", MAX_L1_CACHE_RES);
       return DEFAULT_CACHE_IDX;
   }
 }

--- a/val/src/acs_pe_infra.c
+++ b/val/src/acs_pe_infra.c
@@ -57,22 +57,22 @@ val_pe_create_info_table(uint64_t *pe_info_table)
       return ACS_STATUS_ERR;
 
   if (gPsciConduit == CONDUIT_UNKNOWN) {
-      val_print(WARN, " FADT not found, assuming SMC as PSCI conduit\n");
+      val_print(WARN, "\n       FADT not found, assuming SMC as PSCI conduit");
       gPsciConduit = CONDUIT_SMC;
   } else if (gPsciConduit == CONDUIT_NONE) {
-      val_print(WARN, " PSCI not supported, assuming SMC as conduit for tests\n");
-      val_print(WARN, " Multi-PE and wakeup tests likely to fail\n");
+      val_print(WARN, "\n       PSCI not supported, assuming SMC as conduit for tests");
+      val_print(WARN, "\n       Multi-PE and wakeup tests likely to fail");
       gPsciConduit = CONDUIT_SMC;
   } else if (gPsciConduit == CONDUIT_HVC) {
-      val_print(TRACE, " Using HVC as PSCI conduit\n");
+      val_print(TRACE, "\n       Using HVC as PSCI conduit");
   } else {
-      val_print(TRACE, " Using SMC as PSCI conduit\n");
+      val_print(TRACE, "\n       Using SMC as PSCI conduit");
   }
 
-  val_print(TRACE, " Creating PE INFO table\n");
+  val_print(TRACE, "\n       Creating PE INFO table");
 
   if (pe_info_table == NULL) {
-      val_print(ERROR, "Input memory for PE Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input memory for PE Info table cannot be NULL");
       return ACS_STATUS_ERR;
   }
 
@@ -81,7 +81,7 @@ val_pe_create_info_table(uint64_t *pe_info_table)
   pal_pe_create_info_table(g_pe_info_table);
   val_data_cache_ops_by_va((addr_t)&g_pe_info_table, CLEAN_AND_INVALIDATE);
 
-  val_print(INFO, " PE_INFO: Number of PE detected       : %4d\n", val_pe_get_num());
+  val_print(INFO, "\nPE_INFO: Number of PE detected       : %4d", val_pe_get_num());
 
   if (val_pe_get_num() == 0) {
       val_print(ERROR, "\n *** CRITICAL ERROR: Num PE is 0x0 ***\n");
@@ -89,7 +89,7 @@ val_pe_create_info_table(uint64_t *pe_info_table)
   }
 
 #ifndef TARGET_LINUX
-val_print(INFO, " Primary PE: MIDR_EL1                 :    0x%llx \n",
+val_print(INFO, "\nPrimary PE: MIDR_EL1                 :    0x%llx",
                                                                      val_pe_reg_read(MIDR_EL1));
 #endif
 
@@ -101,7 +101,7 @@ val_print(INFO, " Primary PE: MIDR_EL1                 :    0x%llx \n",
 
       g_primary_pe_index = val_pe_get_index_mpid(g_primary_mpidr);
   }
-  val_print(DEBUG, " PE_INFO: Primary PE index       : %4d\n",
+  val_print(DEBUG, "\nPE_INFO: Primary PE index       : %4d",
             g_primary_pe_index);
 
   return ACS_STATUS_PASS;
@@ -266,7 +266,7 @@ val_execute_on_pe(uint32_t index, void (*payload)(void), uint64_t test_input)
 
   int timeout = TIMEOUT_LARGE;
   if (index > g_pe_info_table->header.num_of_pe) {
-      val_print(ERROR, "Input Index exceeds Num of PE %x\n", index);
+      val_print(ERROR, "\n       Input Index exceeds Num of PE %x", index);
       val_report_status(index, RESULT_FAIL(0xFF), NULL);
       return;
   }
@@ -317,7 +317,7 @@ val_pe_install_esr(uint32_t exception_type, void (*esr)(uint64_t, void *))
 {
 
   if (exception_type > 3) {
-      val_print(ERROR, "Invalid Exception type %x\n", exception_type);
+      val_print(ERROR, "\n       Invalid Exception type %x", exception_type);
       return ACS_STATUS_ERR;
   }
 #ifndef TARGET_LINUX
@@ -505,17 +505,17 @@ val_pe_get_primary_index(void)
 void
 val_smbios_create_info_table(uint64_t *smbios_info_table)
 {
-  val_print(TRACE, " Creating SMBIOS INFO table\n");
+  val_print(TRACE, "\n       Creating SMBIOS INFO table");
 
   if (smbios_info_table == NULL) {
-    val_print(ERROR, "Input memory for SMBIOS Info table cannot be NULL\n");
+    val_print(ERROR, "\n       Input memory for SMBIOS Info table cannot be NULL");
     return;
   }
 
   g_smbios_info_table = (PE_SMBIOS_PROCESSOR_INFO_TABLE *)smbios_info_table;
 
   pal_smbios_create_info_table(g_smbios_info_table);
-  val_print(INFO, " SMBIOS: Num of slots                 : %4d\n",
+  val_print(INFO, "\nSMBIOS: Num of slots                 : %4d",
             g_smbios_info_table->slot_count);
 }
 

--- a/val/src/acs_peripherals.c
+++ b/val/src/acs_peripherals.c
@@ -232,7 +232,7 @@ val_peripheral_dump_info(void)
       {
           if (pal_pcie_check_bus_valid(bus)) {
               val_print(DEBUG,
-               "       Bus 0x%x marked as invalid in Platform API...Skipping\n", bus);
+               "\n       Bus 0x%x marked as invalid in Platform API...Skipping", bus);
               continue;
           }
 
@@ -262,9 +262,9 @@ val_peripheral_dump_info(void)
   }
 
 
-  val_print(DEBUG, "\n Peripheral: Num of Network ctrl      :    %d\n", ntwk);
-  val_print(DEBUG, " Peripheral: Num of Storage ctrl      :    %d\n", strg);
-  val_print(DEBUG, " Peripheral: Num of Display ctrl      :    %d\n", dply);
+  val_print(DEBUG, "\nPeripheral: Num of Network ctrl      :    %d", ntwk);
+  val_print(DEBUG, "\nPeripheral: Num of Storage ctrl      :    %d", strg);
+  val_print(DEBUG, "\nPeripheral: Num of Display ctrl      :    %d", dply);
 
 }
 
@@ -290,15 +290,15 @@ val_peripheral_create_info_table(uint64_t *peripheral_info_table)
 {
 
   g_peripheral_info_table = (PERIPHERAL_INFO_TABLE *)peripheral_info_table;
-  val_print(TRACE, " Creating PERIPHERAL INFO table\n");
+  val_print(TRACE, "\n       Creating PERIPHERAL INFO table");
 
   pal_peripheral_create_info_table(g_peripheral_info_table);
 
-  val_print(INFO, " Peripheral: Num of USB controllers   :    %d\n",
+  val_print(INFO, "\nPeripheral: Num of USB controllers   :    %d",
     val_peripheral_get_info(NUM_USB, 0));
-  val_print(INFO, " Peripheral: Num of SATA controllers  :    %d\n",
+  val_print(INFO, "\nPeripheral: Num of SATA controllers  :    %d",
     val_peripheral_get_info(NUM_SATA, 0));
-  val_print(INFO, " Peripheral: Num of UART controllers  :    %d\n",
+  val_print(INFO, "\nPeripheral: Num of UART controllers  :    %d",
     val_peripheral_get_info(NUM_UART, 0));
 
   if (acs_policy_get_print_level() <= TRACE)

--- a/val/src/acs_pgt.c
+++ b/val/src/acs_pgt.c
@@ -309,18 +309,18 @@ uint64_t *val_find_pte(pgt_descriptor_t pgt_desc, uint64_t virtual_address)
         val64 = tt_base_virt[index];
 
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: this_level = %d     ",
+                  "\n       val_pgt_get_attributes: this_level = %d",
                   this_level);
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: index = %d     ",
+                  "\n       val_pgt_get_attributes: index = %d",
                   index);
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: bits_remaining = %d     ",
+                  "\n       val_pgt_get_attributes: bits_remaining = %d",
                   bits_remaining);
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: tt_base_virt = %x     ",
+                  "\n       val_pgt_get_attributes: tt_base_virt = %x",
                   (uint64_t)tt_base_virt);
-        val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_get_attributes: val64 = %x     ", val64);
+        val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_get_attributes: val64 = %x", val64);
         if (this_level == 3)
         {
             if (!IS_PGT_ENTRY_PAGE(val64))
@@ -371,7 +371,7 @@ uint64_t val_pgt_ioremap_attr(pgt_descriptor_t pgt_desc,
         uint64_t *pte = val_find_pte(pgt_desc, a);
 
         if (!pte) {
-            val_print(TRACE, "Cannot find PTE for 0x%lx\n", a);
+            val_print(TRACE, "\n       Cannot find PTE for 0x%lx", a);
             continue;
         }
         flag = 1;
@@ -439,12 +439,12 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
     uint64_t prefill_val;
     uint32_t i, max_entries;
 
-    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.level: %d     ", tt_desc.level);
-    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.input_base: 0x%llx     ", tt_desc.input_base);
-    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.input_top: 0x%llx     ", tt_desc.input_top);
-    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.output_base: 0x%llx     ", tt_desc.output_base);
-    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.size_log2: %d     ", tt_desc.size_log2);
-    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.nbits: %d     ", tt_desc.nbits);
+    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.level: %d", tt_desc.level);
+    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.input_base: 0x%llx", tt_desc.input_base);
+    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.input_top: 0x%llx", tt_desc.input_top);
+    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.output_base: 0x%llx", tt_desc.output_base);
+    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.size_log2: %d", tt_desc.size_log2);
+    val_print(PGT_DEBUG_LEVEL, "\n       tt_desc.nbits: %d", tt_desc.nbits);
 
     if (!is_values_init) {
         setup_acs_pgt_values();
@@ -458,7 +458,7 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
         table_index = input_address >> tt_desc.size_log2 & ((0x1ull << tt_desc.nbits) - 1);
         table_desc = &tt_desc.tt_base[table_index];
 
-        val_print(PGT_DEBUG_LEVEL, "\n       table_index = %d     ", table_index);
+        val_print(PGT_DEBUG_LEVEL, "\n       table_index = %d", table_index);
         /* Compute parent block bounds for this level, thereby prevent any overflows */
         parent_block_start = (input_address & ~(block_size - 1));
         parent_block_end   = parent_block_start + block_size - 1;
@@ -470,7 +470,7 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
             *table_desc = PGT_ENTRY_PAGE_MASK | PGT_ENTRY_VALID_MASK;
             *table_desc |= (output_address & ~(uint64_t)(page_size - 1));
             *table_desc |= mem_desc->attributes;
-            val_print(PGT_DEBUG_LEVEL, "\n       page_descriptor = 0x%llx     ", *table_desc);
+            val_print(PGT_DEBUG_LEVEL, "\n       page_descriptor = 0x%llx", *table_desc);
             /* Keep a count of number of L3 tables filled. If the number exceedes the limit, move
                to next L2 table and continue.  */
             increment_pgt_index(tt_desc.level, get_entries_per_level(page_size));
@@ -486,7 +486,7 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
             *table_desc = PGT_ENTRY_BLOCK_MASK | PGT_ENTRY_VALID_MASK;
             *table_desc |= (output_address & ~(block_size - 1));
             *table_desc |= mem_desc->attributes;
-            val_print(PGT_DEBUG_LEVEL, "\n       block_descriptor = 0x%llx     ", *table_desc);
+            val_print(PGT_DEBUG_LEVEL, "\n       block_descriptor = 0x%llx", *table_desc);
             increment_pgt_index(tt_desc.level, get_entries_per_level(page_size));
             offset = 0;
             continue;
@@ -502,7 +502,7 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
             if (tt_base_next_level == NULL)
             {
                 val_print(ERROR,
-                "\n       fill_translation_table: page allocation failed     ");
+                "\n       fill_translation_table: page allocation failed");
                 return ACS_STATUS_ERR;
             }
             val_memory_set(tt_base_next_level, page_size, 0);
@@ -550,8 +550,8 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
         filled_tables                 = get_pgt_index(tt_desc.level + 1);
         offset                        = filled_tables * get_block_size(tt_desc.level + 1);
 
-        val_print(PGT_DEBUG_LEVEL, "       filled_tables in next level = 0x%llx", filled_tables);
-        val_print(PGT_DEBUG_LEVEL, "       offset = 0x%llx", offset);
+        val_print(PGT_DEBUG_LEVEL, "\n       filled_tables in next level = 0x%llx", filled_tables);
+        val_print(PGT_DEBUG_LEVEL, "\n       offset = 0x%llx", offset);
 
         tt_desc_next_level.input_top   = get_min(tt_desc.input_top, parent_block_end);
         tt_desc_next_level.output_base = output_address;
@@ -569,7 +569,7 @@ uint32_t fill_translation_table(tt_descriptor_t tt_desc, memory_region_descripto
         *table_desc = PGT_ENTRY_TABLE_MASK | PGT_ENTRY_VALID_MASK;
         *table_desc |= (uint64_t)val_memory_virt_to_phys(tt_base_next_level) &
                        ~(uint64_t)(page_size - 1);
-        val_print(PGT_DEBUG_LEVEL, "\n      table_descriptor = 0x%llx     ", *table_desc);
+        val_print(PGT_DEBUG_LEVEL, "\n       table_descriptor = 0x%llx", *table_desc);
 
         /* Ensure outer loop advances to next parent block boundary */
         if (step_to_next_parent <= block_size)
@@ -620,8 +620,8 @@ uint32_t val_pgt_create(memory_region_descriptor_t *mem_desc, pgt_descriptor_t *
     bits_per_level = page_size_log2 - 3;
     num_pgt_levels = (pgt_desc->ias - page_size_log2 + bits_per_level - 1)/bits_per_level;
     num_pgt_levels = (num_pgt_levels > 4)?4:num_pgt_levels;
-    val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_create: nbits_per_level = %d    ", bits_per_level);
-    val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_create: page_size_log2 = %d     ", page_size_log2);
+    val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_create: nbits_per_level = %d", bits_per_level);
+    val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_create: page_size_log2 = %d", page_size_log2);
 
     /* check whether input page descriptor has base addr of translation table
        to use. If the pgt_base member is NULL allocate a page to create a new
@@ -629,7 +629,7 @@ uint32_t val_pgt_create(memory_region_descriptor_t *mem_desc, pgt_descriptor_t *
     if (pgt_desc->pgt_base == (uint64_t) NULL) {
         tt_base = (uint64_t *) val_memory_alloc_pages(1);
         if (tt_base == NULL) {
-            val_print(ERROR, "\n      val_pgt_create: page allocation failed     ");
+            val_print(ERROR, "\n       val_pgt_create: page allocation failed");
             return ACS_STATUS_ERR;
         }
         val_memory_set(tt_base, page_size, 0);
@@ -643,23 +643,23 @@ uint32_t val_pgt_create(memory_region_descriptor_t *mem_desc, pgt_descriptor_t *
     for (mem_desc_iter = mem_desc; mem_desc_iter->length != 0; ++mem_desc_iter)
     {
         val_print(PGT_DEBUG_LEVEL,
-                  "      val_pgt_create: input addr = 0x%x     ",
+                  "\n       val_pgt_create: input addr = 0x%x",
                   mem_desc->virtual_address);
         val_print(PGT_DEBUG_LEVEL,
-                  "      val_pgt_create: output addr = 0x%x     ",
+                  "\n       val_pgt_create: output addr = 0x%x",
                   mem_desc->physical_address);
-        val_print(PGT_DEBUG_LEVEL, "      val_pgt_create: length = 0x%x\n     ", mem_desc->length);
+        val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_create: length = 0x%x", mem_desc->length);
         if ((mem_desc->virtual_address & (uint64_t)(page_size - 1)) != 0 ||
             (mem_desc->physical_address & (uint64_t)(page_size - 1)) != 0)
             {
-                val_print(ERROR, "\n       val_pgt_create: addr alignment err     ");
+                val_print(ERROR, "\n       val_pgt_create: addr alignment err");
                 return ACS_STATUS_ERR;
             }
 
         if (mem_desc->physical_address >= (0x1ull << pgt_desc->oas))
         {
             val_print(ERROR,
-                      "\n       val_pgt_create: output address size error     ");
+                      "\n       val_pgt_create: output address size error");
             return ACS_STATUS_ERR;
         }
 
@@ -667,7 +667,7 @@ uint32_t val_pgt_create(memory_region_descriptor_t *mem_desc, pgt_descriptor_t *
         {
             val_print(WARN,
                       "\n       val_pgt_create: input address size error, "
-                      "truncating to %d-bits     ",
+                      "truncating to %d-bits",
                       pgt_desc->ias);
             mem_desc->virtual_address &= ((0x1ull << pgt_desc->ias) - 1);
         }
@@ -730,18 +730,18 @@ uint64_t val_pgt_get_attributes(pgt_descriptor_t pgt_desc, uint64_t virtual_addr
 
         val64 = tt_base_virt[index];
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: this_level = %d     ",
+                  "\n       val_pgt_get_attributes: this_level = %d",
                   this_level);
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: index = %d     ",
+                  "\n       val_pgt_get_attributes: index = %d",
                   index);
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: bits_remaining = %d     ",
+                  "\n       val_pgt_get_attributes: bits_remaining = %d",
                   bits_remaining);
         val_print(PGT_DEBUG_LEVEL,
-                  "\n       val_pgt_get_attributes: tt_base_virt = %x     ",
+                  "\n       val_pgt_get_attributes: tt_base_virt = %x",
                   (uint64_t)tt_base_virt);
-        val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_get_attributes: val64 = %x     ", val64);
+        val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_get_attributes: val64 = %x", val64);
         if (this_level == 3)
         {
             if (!IS_PGT_ENTRY_PAGE(val64))
@@ -808,7 +808,7 @@ void val_pgt_destroy(pgt_descriptor_t pgt_desc)
     if (!pgt_desc.pgt_base)
         return;
 
-    val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_destroy: pgt_base = %llx     ", pgt_desc.pgt_base);
+    val_print(PGT_DEBUG_LEVEL, "\n       val_pgt_destroy: pgt_base = %llx", pgt_desc.pgt_base);
     page_size = val_memory_page_size();
     page_size_log2 = log2_page_size(page_size);
     bits_per_level =  page_size_log2 - 3;

--- a/val/src/acs_pmu.c
+++ b/val/src/acs_pmu.c
@@ -50,7 +50,7 @@ val_pmu_reg_read (
     case PMCNTENSET_EL0:
         return read_pmcntenset_el0();
     default:
-        val_print(ERROR, "\n FATAL - Unsupported PMU register read \n");
+        val_print(ERROR, "\n       FATAL - Unsupported PMU register read");
     }
 
     return 0x0;
@@ -84,7 +84,7 @@ val_pmu_reg_write (
         write_pmcntenset_el0(WriteData);
         break;
     default:
-        val_print(ERROR, "\n FATAL - Unsupported PMU register read \n");
+        val_print(ERROR, "\n       FATAL - Unsupported PMU register read");
     }
 }
 
@@ -176,14 +176,14 @@ val_pmu_create_info_table(uint64_t *pmu_info_table)
 
   pal_pmu_create_info_table(g_pmu_info_table);
 
-  val_print(INFO, " PMU_INFO: Number of PMU units        : %4d\n",
+  val_print(INFO, "\n    PMU_INFO: Number of PMU units        : %4d",
             g_pmu_info_table->pmu_count);
 
   for (node_index = 0; node_index < g_pmu_info_table->pmu_count; node_index++) {
-      val_print(TRACE, " PMU node index: %4d\n", node_index);
+      val_print(TRACE, "\n       PMU node index: %4d", node_index);
       base = val_pmu_get_info(PMU_NODE_BASE0, node_index);
       val_mmu_update_entry(base, 0x1000, DEVICE_nGnRnE);
-      val_print(TRACE, " PMU node mapped \n");
+      val_print(TRACE, "\n       PMU node mapped");
       reg_value = BITFIELD_READ(PMDEVARCH_ARCHITECT, val_mmio_read(base + REG_PMDEVARCH));
       /* 0x23B is value for Arm Limited */
       if (reg_value == 0x23B)
@@ -231,7 +231,7 @@ val_pmu_free_info_table(void)
     }
     else {
       val_print(ERROR,
-                  "\n WARNING: g_pmu_info_table pointer is already NULL");
+                  "\n       g_pmu_info_table pointer is already NULL");
     }
 }
 
@@ -279,7 +279,7 @@ val_pmu_get_info(PMU_INFO_e type, uint32_t node_index)
   case PMU_NODE_CS_COM:
       return entry->coresight_compliant;
   default:
-        val_print(ERROR, "\n   This PMU info option is not supported : %d ", type);
+        val_print(ERROR, "\n       PMU info option is not supported : %d ", type);
         return 0;
   }
 }
@@ -553,7 +553,7 @@ val_pmu_get_node_index(uint64_t node_instance_primary, PMU_NODE_INFO_TYPE node_t
             return node_index;
         }
     }
-    val_print(DEBUG, "\n   PMU node for given node primary instance not found ");
+    val_print(DEBUG, "\n       PMU node for given primary instance not found ");
     return PMU_INVALID_INDEX;
 }
 

--- a/val/src/acs_ras.c
+++ b/val/src/acs_ras.c
@@ -38,7 +38,7 @@ val_ras_create_info_table(uint64_t *ras_info_table)
 {
 
   if (ras_info_table == NULL) {
-      val_print(ERROR, "Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return ACS_STATUS_ERR;
   }
 
@@ -46,7 +46,7 @@ val_ras_create_info_table(uint64_t *ras_info_table)
 
   pal_ras_create_info_table(g_ras_info_table);
 
-  val_print(INFO, " RAS_INFO: Number of RAS nodes        : %4d\n",
+  val_print(INFO, "\n    RAS_INFO: Number of RAS nodes        : %4d",
                            g_ras_info_table->num_nodes);
 
   return ACS_STATUS_PASS;
@@ -64,7 +64,7 @@ val_ras_free_info_table(void)
     }
     else {
       val_print(ERROR,
-                  "\n WARNING: g_ras_info_table pointer is already NULL");
+                  "\n       g_ras_info_table pointer is already NULL");
     }
 }
 
@@ -81,7 +81,7 @@ val_ras2_create_info_table(uint64_t *ras2_info_table)
 {
 
   if (ras2_info_table == NULL) {
-      val_print(ERROR, "\nInput for RAS2 feat create info table cannot be NULL\n");
+      val_print(ERROR, "\n       RAS2 feat info table cannot be NULL");
       return;
   }
 
@@ -90,9 +90,9 @@ val_ras2_create_info_table(uint64_t *ras2_info_table)
 
   pal_ras2_create_info_table(g_ras2_info_table);
 
-  val_print(INFO, " RAS2_INFO: Number of RAS2 entries    : %4d\n",
+  val_print(INFO, "\n    RAS2_INFO: Number of RAS2 entries    : %4d",
                            g_ras2_info_table->num_all_block);
-  val_print(INFO, " RAS2_INFO: Num of RAS2 memory entries: %4d\n",
+  val_print(INFO, "\n    RAS2_INFO: Num of RAS2 memory entries: %4d",
                            g_ras2_info_table->num_of_mem_block);
 #endif
 return;
@@ -315,7 +315,7 @@ val_ras2_get_mem_info(RAS2_MEM_INFO_e type, uint32_t index)
   RAS2_BLOCK *block;
 
   if (g_ras2_info_table == NULL) {
-      val_print(ERROR, "\nRAS2_GET_MEM_INFO : ras2 info table is not created\n");
+      val_print(ERROR, "\n       RAS2 : ras2 table not created\n");
       return 0; /* imply no ras2_info entries */
   }
 
@@ -325,7 +325,7 @@ val_ras2_get_mem_info(RAS2_MEM_INFO_e type, uint32_t index)
   /* check if index in range */
   if (index > g_ras2_info_table->num_of_mem_block - 1) {
       val_print(ERROR,
-                "\nRAS2_GET_MEM_INFO: Index (%d) is greater than num of RAS2 mem blocks\n",
+                "\n       RAS2: Index (%d) greater than num of RAS2 mem blocks\n",
                  index);
       return INVALID_RAS2_INFO;
   }
@@ -343,7 +343,7 @@ val_ras2_get_mem_info(RAS2_MEM_INFO_e type, uint32_t index)
                   return block->block_info.mem_feat_info.patrol_scrub_support;
               default:
                   val_print(ERROR,
-                            "\nThis RAS2 memory info option not supported: %d\n", type);
+                            "\n       RAS2 memory info option not supported: %d\n", type);
                   return INVALID_RAS2_INFO;
               }
           }
@@ -710,7 +710,7 @@ ras_pfg_access_node(uint32_t node_index)
                 node_index);
   }
 
-  val_print(TRACE, "      Access RAS Node, CTLR : 0x%llx\n", reg_value);
+  val_print(TRACE, "\n       Access RAS Node, CTLR : 0x%llx", reg_value);
 }
 
 /**

--- a/val/src/acs_smmu.c
+++ b/val/src/acs_smmu.c
@@ -60,7 +60,7 @@ val_smmu_start_monitor_dev(uint32_t ctrl_index)
 
   ap = (void *)val_dma_get_info(DMA_PORT_INFO, ctrl_index);
   if (ap == NULL) {
-      val_print(ERROR, "Invalid Controller index %d\n", ctrl_index);
+      val_print(ERROR, "\n       Invalid Controller index %d", ctrl_index);
       return ACS_STATUS_ERR;
   }
 
@@ -84,7 +84,7 @@ val_smmu_stop_monitor_dev(uint32_t ctrl_index)
 
   ap = (void *)val_dma_get_info(DMA_PORT_INFO, ctrl_index);
   if (ap == NULL) {
-      val_print(ERROR, "Invalid Controller index %d\n", ctrl_index);
+      val_print(ERROR, "\n       Invalid Controller index %d", ctrl_index);
       return ACS_STATUS_ERR;
   }
 
@@ -114,10 +114,10 @@ val_smmu_check_device_iova(uint32_t ctrl_index, addr_t dma_addr)
 
   ap = (void *)val_dma_get_info(DMA_PORT_INFO, ctrl_index);
   if (ap == NULL) {
-      val_print(ERROR, "Invalid Controller index %d\n", ctrl_index);
+      val_print(ERROR, "\n       Invalid Controller index %d", ctrl_index);
       return ACS_STATUS_ERR;
   }
-  val_print(DEBUG, "Input dma addr = %lx\n", dma_addr);
+  val_print(DEBUG, "\n       Input dma addr = %lx", dma_addr);
 
   status = pal_smmu_check_device_iova(ap, dma_addr);
 

--- a/val/src/acs_test_infra.c
+++ b/val/src/acs_test_infra.c
@@ -597,7 +597,7 @@ val_wait_for_test_completion(uint32_t test_num, uint32_t num_pe, uint32_t timeou
 
   uint32_t i = 0, j = 0;
 
-  val_print(TRACE, "Test_num= %d\n", test_num);
+  val_print(TRACE, "\n       Test_num= %d", test_num);
 
   //For single PE tests, there is no need to wait for the results
   if (num_pe == 1)

--- a/val/src/acs_timer.c
+++ b/val/src/acs_timer.c
@@ -50,7 +50,7 @@ uint8_t get_effective_e2h(void)
   else
     effective_e2h = hcr_e2h;
 
-  val_print(DEBUG, "\n       effective e2h : 0x%x\n", effective_e2h);
+  val_print(DEBUG, "\n       effective e2h : 0x%x", effective_e2h);
   return effective_e2h;
 }
 
@@ -77,8 +77,8 @@ static uint8_t timer_reg_el2_access_allowed(ARM_ARCH_TIMER_REGS Reg)
     return 1;
 
   if (val_pe_reg_read(CurrentEL) == AARCH64_EL1) {
-    val_print(INFO, "The register is related to Hypervisor Mode. "
-                    "Can't perform requested operation\n");
+    val_print(INFO, "\n       The register is related to Hypervisor Mode. "
+                    "Can't perform requested operation");
     return 0;
   }
 
@@ -163,7 +163,7 @@ ArmArchTimerReadReg (
       return read_cnthv_cval_el2();
 
     default:
-      val_print(INFO, "Unknown ARM Generic Timer register %x.\n ", Reg);
+      val_print(INFO, "\n       Unknown ARM Generic Timer register %x", Reg);
     }
 
     return 0xFFFFFFFF;
@@ -194,7 +194,7 @@ ArmArchTimerWriteReg (
     switch (Reg) {
 
     case CntPct:
-      val_print(INFO, "Can't write to Read Only Register: CNTPCT\n");
+      val_print(INFO, "\n       Can't write to Read Only Register: CNTPCT");
       break;
 
     case CntkCtl:
@@ -233,7 +233,7 @@ ArmArchTimerWriteReg (
       break;
 
     case CntvCt:
-       val_print(INFO, "Can't write to Read Only Register: CNTVCT\n");
+       val_print(INFO, "\n       Can't write to Read Only Register: CNTVCT");
       break;
 
     case CntpCval:
@@ -277,7 +277,7 @@ ArmArchTimerWriteReg (
       break;
 
     default:
-      val_print(INFO, "Unknown ARM Generic Timer register %x.\n ", Reg);
+      val_print(INFO, "\n       Unknown ARM Generic Timer register %x", Reg);
     }
 }
 

--- a/val/src/acs_timer_infra.c
+++ b/val/src/acs_timer_infra.c
@@ -136,10 +136,10 @@ val_timer_create_info_table(uint64_t *timer_info_table)
   uint64_t freq_mhz;
 
   if (timer_info_table == NULL) {
-      val_print(ERROR, "Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return;
   }
-  val_print(TRACE, " Creating TIMER INFO table\n");
+  val_print(TRACE, "\n       Creating TIMER INFO table");
 
   g_timer_info_table = (TIMER_INFO_TABLE *)timer_info_table;
 
@@ -158,13 +158,13 @@ val_timer_create_info_table(uint64_t *timer_info_table)
     freq_mhz = freq_mhz/1000;
     if (freq_mhz > 1000) {
       freq_mhz = freq_mhz/1000;
-      val_print(INFO, " TIMER_INFO: System Counter frequency :    %ld MHz\n", freq_mhz);
+      val_print(INFO, "\nTIMER_INFO: System Counter frequency :    %ld MHz", freq_mhz);
     } else {
-      val_print(INFO, " TIMER_INFO: System Counter frequency :    %ld KHz\n", freq_mhz);
+      val_print(INFO, "\nTIMER_INFO: System Counter frequency :    %ld KHz", freq_mhz);
     }
   }
 
-  val_print(INFO, " TIMER_INFO: Number of system timers  : %4d\n",
+  val_print(INFO, "\nTIMER_INFO: Number of system timers  : %4d",
                                             g_timer_info_table->header.num_platform_timer);
   timer_num = val_timer_get_info(TIMER_INFO_NUM_PLATFORM_TIMERS, 0);
 
@@ -177,7 +177,7 @@ val_timer_create_info_table(uint64_t *timer_info_table)
       gt_entry = val_timer_get_info(TIMER_INFO_SYS_CNTL_BASE, timer_num);
       timer_entry = val_timer_get_info(TIMER_INFO_SYS_CNT_BASE_N, timer_num);
 
-      val_print(DEBUG, "   Add entry %lx entry in memmap", gt_entry);
+      val_print(DEBUG, "\n       Add entry %lx entry in memmap", gt_entry);
       if (val_mmu_update_entry(gt_entry, 0x10000, DEVICE_nGnRnE))
           val_print(WARN, "\n   Adding %lx entry failed", gt_entry);
 

--- a/val/src/acs_tpm.c
+++ b/val/src/acs_tpm.c
@@ -52,7 +52,7 @@ val_tpm2_get_info(TPM2_INFO_e info_type)
   case TPM2_INFO_INTERFACE_TYPE:
       return g_tpm2_info_table->tpm_interface;
   default:
-      val_print(ERROR, " Invalid TPM2 info_type: %d\n", info_type);
+      val_print(ERROR, "\n       Invalid TPM2 info_type: %d", info_type);
       return TPM2_INFO_INVALID;
   }
 
@@ -71,10 +71,10 @@ void
 val_tpm2_create_info_table(uint64_t *tpm2_info_table)
 {
   if (tpm2_info_table == NULL) {
-    val_print(ERROR, "\n Pre-allocated memory pointer is NULL\n");
+    val_print(ERROR, "\n       Pre-allocated memory pointer is NULL");
     return;
   }
-  val_print(TRACE, " Creating TPM2 INFO table\n");
+  val_print(TRACE, "\n       Creating TPM2 INFO table");
 
   g_tpm2_info_table = (TPM2_INFO_TABLE *)tpm2_info_table;
 

--- a/val/src/acs_wd.c
+++ b/val/src/acs_wd.c
@@ -70,16 +70,16 @@ val_wd_create_info_table(uint64_t *wd_info_table)
 {
 
   if (wd_info_table == NULL) {
-      val_print(ERROR, "Input for Create Info table cannot be NULL\n");
+      val_print(ERROR, "\n       Input for Create Info table cannot be NULL");
       return;
   }
-  val_print(TRACE, " Creating WATCHDOG INFO table\n");
+  val_print(TRACE, "\n       Creating WATCHDOG INFO table");
 
   g_wd_info_table = (WD_INFO_TABLE *)wd_info_table;
 
   pal_wd_create_info_table(g_wd_info_table);
 
-  val_print(INFO, " WATCHDOG_INFO: Number of Watchdogs   : %4d\n",
+  val_print(INFO, "\nWATCHDOG_INFO: Number of Watchdogs   : %4d",
                                                             val_wd_get_info(0, WD_INFO_COUNT));
 }
 

--- a/val/src/bsa_execute_test.c
+++ b/val/src/bsa_execute_test.c
@@ -867,7 +867,7 @@ val_bsa_exerciser_execute_tests(uint32_t num_pe, uint32_t *g_sw_view)
       return ACS_STATUS_SKIP;
   }
 
-  val_print(TRACE, "  Initializing SMMU\n");
+  val_print(TRACE, "\n       Initializing SMMU\n");
 
   num_smmu = (uint32_t)val_iovirt_get_smmu_info(SMMU_NUM_CTRL, 0);
   val_smmu_init();

--- a/val/src/drtm_execute_test.c
+++ b/val/src/drtm_execute_test.c
@@ -53,7 +53,7 @@ val_drtm_execute_interface_tests(uint32_t num_pe)
   }
 
 
-  val_print(TRACE, "  Initializing ITS\n");
+  val_print(TRACE, "\n       Initializing ITS");
   val_gic_its_configure();
 
   status = ACS_STATUS_PASS;

--- a/val/src/mpam_execute_test.c
+++ b/val/src/mpam_execute_test.c
@@ -73,9 +73,9 @@ val_mpam_execute_error_tests(void)
 
   /* Setup ITS for MSI Tests */
   if (g_its_init != 1) {
-      val_print(TRACE, "\n      Initializing ITS\n");
+      val_print(TRACE, "\n       Initializing ITS");
       if (val_gic_its_configure() == ACS_STATUS_ERR) {
-          val_print(ERROR, "\n     val_gic_its_configure() failed \n");
+          val_print(ERROR, "\n       val_gic_its_configure() failed");
           status = ACS_STATUS_SKIP;
           return status;
       }

--- a/val/src/pc_bsa_execute_test.c
+++ b/val/src/pc_bsa_execute_test.c
@@ -117,7 +117,7 @@ val_pcbsa_gic_execute_tests(uint32_t level, uint32_t num_pe)
   val_print_test_start("GIC");
   g_curr_module = 1 << GIC_MODULE;
 
-  val_print(TRACE, "  Initializing ITS\n");
+  val_print(TRACE, "\n       Initializing ITS");
   val_gic_its_configure();
 
   if (((level >= 1) && (g_pcbsa_only_level == 0)) || (g_pcbsa_only_level == 1)) {
@@ -173,7 +173,7 @@ val_pcbsa_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       status |= i025_entry(num_pe);
 
       if (status != ACS_STATUS_PASS) {
-         val_print(WARN, "\n     SMMU Compatibility Check Failed, ");
+         val_print(WARN, "\n       SMMU Compatibility Check Failed,");
          val_print(WARN, "Skipping SMMU tests...\n");
          val_print_test_end(status, "SMMU");
          return ACS_STATUS_FAIL;
@@ -249,7 +249,7 @@ val_pcbsa_wd_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_WD_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all Watchdog tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all Watchdog tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -293,7 +293,7 @@ val_pcbsa_tpm2_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_TPM2_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all TPM2 tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all TPM2 tests\n");
           return ACS_STATUS_SKIP;
       }
   }

--- a/val/src/rule_based_execution_helpers.c
+++ b/val/src/rule_based_execution_helpers.c
@@ -249,7 +249,7 @@ print_rule_test_start(uint32_t rule_enum, uint32_t indent)
         val_print(INFO, "\n\n    ");
         if (indent)
             val_print(INFO, "    ");
-        val_print(INFO, "*** Running ");
+        val_print(INFO, "   *** Running ");
         val_print(INFO, module_name_string[curr_module]);
         val_print(INFO, " tests ***");
 

--- a/val/src/rule_based_orchestrator.c
+++ b/val/src/rule_based_orchestrator.c
@@ -41,7 +41,7 @@ static uint32_t check_rule_support(RULE_ID_e rule_id)
 {
     uint8_t plat_bitmask = rule_test_map[rule_id].platform_bitmask;
 
-   // val_print(ERROR, "\n plat_bitmask %x", plat_bitmask);
+   // val_print(ERROR, "\n       plat_bitmask %x", plat_bitmask);
 
     if (!(g_current_pal & plat_bitmask)) {
         /* Report if rule is not supported by ACS across all available PALs*/
@@ -192,18 +192,19 @@ static uint32_t execute_rule_recursive(const acs_run_request_t *ctx,
     uint32_t child_rule_status;
     uint32_t precheck_status;
     uint32_t rule_support_status;
+    uint32_t old_log_indent;
     RULE_ID_e child_rule_id;
     const RULE_ID_e *child_rule_list;
 
     /* Detect accidental alias cycles such as A -> B -> A before descending */
     if (rule_reference_path_contains(rule_id)) {
-        val_print(ERROR, " Recursive alias reference detected for rule: ");
+        val_print(ERROR, "\n       Recursive alias reference detected for rule: ");
         val_print(ERROR, rule_id_string[rule_id]);
         return RESULT_FAIL(1);
     }
 
     if (!rule_reference_path_push(rule_id)) {
-        val_print(ERROR, " Rule reference path depth exceeded for rule: ");
+        val_print(ERROR, "\n       Rule reference path depth exceeded for rule: ");
         val_print(ERROR, rule_id_string[rule_id]);
         return RESULT_FAIL(1);
     }
@@ -233,15 +234,18 @@ static uint32_t execute_rule_recursive(const acs_run_request_t *ctx,
     if (rule_test_map[rule_id].flag == ALIAS_RULE) {
         alias_rule_map_index = alias_rule_map_get_index(rule_id);
         if (alias_rule_map_index == INVALID_IDX) {
-            val_print(ERROR, " alias map index not found for rule id: 0x%x", rule_id);
+            val_print(ERROR, "\n       alias map index not found for rule id: 0x%x", rule_id);
             rule_test_status = RESULT_FAIL(1);
             goto exit_rule;
         }
 
         /* Execute any precheck required by the alias rule */
         if (rule_test_map[rule_id].test_entry_id != NULL_ENTRY) {
+            old_log_indent = val_log_get_indent();
+            val_log_set_indent(indent);
             precheck_status =
                 test_entry_func_table[rule_test_map[rule_id].test_entry_id](num_pe);
+            val_log_set_indent(old_log_indent);
 
             if (GET_STATE(precheck_status) == TEST_FAIL) {
                 rule_test_status = RESULT_SKIP(0);
@@ -300,8 +304,11 @@ static uint32_t execute_rule_recursive(const acs_run_request_t *ctx,
         print_alias_walk_banner(rule_id, indent, 0);
     } else if (rule_test_map[rule_id].flag == BASE_RULE) {
         if (test_entry_func_table[rule_test_map[rule_id].test_entry_id] != NULL) {
+            old_log_indent = val_log_get_indent();
+            val_log_set_indent(indent);
             rule_test_status =
                 test_entry_func_table[rule_test_map[rule_id].test_entry_id](num_pe);
+            val_log_set_indent(old_log_indent);
         } else {
             val_print(ERROR, "\n\n  Rule failed due to NULL entry \n\r ", 0);
             rule_test_status = RESULT_FAIL(1);

--- a/val/src/sbsa_execute_test.c
+++ b/val/src/sbsa_execute_test.c
@@ -152,7 +152,7 @@ val_sbsa_gic_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_GIC_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all GIC tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all GIC tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -205,7 +205,7 @@ val_sbsa_wd_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_WD_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all Watchdog tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all Watchdog tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -246,7 +246,7 @@ val_sbsa_timer_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_TIMER_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all Timer tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all Timer tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -461,7 +461,7 @@ val_sbsa_smmu_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_SMMU_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all SMMU tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all SMMU tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -482,7 +482,7 @@ val_sbsa_smmu_execute_tests(uint32_t level, uint32_t num_pe)
       status |= i025_entry(num_pe);
 
       if (status != ACS_STATUS_PASS) {
-         val_print(WARN, "\n     SMMU Compatibility Check Failed, ");
+         val_print(WARN, "\n       SMMU Compatibility Check Failed,");
          val_print(WARN, "Skipping SMMU tests...\n");
          return ACS_STATUS_FAIL;
       }
@@ -549,7 +549,7 @@ val_sbsa_memory_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0 ; i < g_num_skip ; i++) {
       if (g_skip_test_num[i] == ACS_MEMORY_MAP_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all memory tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all memory tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -705,7 +705,7 @@ val_sbsa_pmu_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_PMU_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all PMU tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all PMU tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -765,7 +765,7 @@ val_sbsa_mpam_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_MPAM_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all MPAM tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all MPAM tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -900,7 +900,7 @@ val_sbsa_ete_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_ETE_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all ETE tests \n");
+          val_print(TRACE, "\n       USER Override - Skipping all ETE tests\n");
           return ACS_STATUS_SKIP;
       }
   }
@@ -908,7 +908,7 @@ val_sbsa_ete_execute_tests(uint32_t level, uint32_t num_pe)
   /* Check if there are any tests to be executed in current module with user override options*/
   status = val_check_skip_module(ACS_ETE_TEST_NUM_BASE);
   if (status) {
-      val_print(TRACE, "\n USER Override - Skipping all ETE tests \n");
+      val_print(TRACE, "\n       USER Override - Skipping all ETE tests\n");
       return ACS_STATUS_SKIP;
   }
 
@@ -919,7 +919,7 @@ val_sbsa_ete_execute_tests(uint32_t level, uint32_t num_pe)
       ete_status = ete001_entry(num_pe);
 
       if (ete_status == ACS_STATUS_FAIL) {
-          val_print(ERROR, "\n FEAT_ETE Not Supported, Skipping FEAT_ETE tests \n");
+          val_print(ERROR, "\n       FEAT_ETE Not Supported, Skipping FEAT_ETE tests\n");
       } else {
           ete_status |= ete002_entry(num_pe);
           ete_status |= ete003_entry(num_pe);
@@ -929,7 +929,7 @@ val_sbsa_ete_execute_tests(uint32_t level, uint32_t num_pe)
       trbe_status = ete005_entry(num_pe);
 
       if (trbe_status == ACS_STATUS_FAIL) {
-          val_print(ERROR, "\n FEAT_TRBE Not Supported, Skipping FEAT_TRBE tests \n");
+          val_print(ERROR, "\n       FEAT_TRBE Not Supported, Skipping FEAT_TRBE tests\n");
       } else {
           trbe_status |= ete006_entry(num_pe);
           trbe_status |= ete007_entry(num_pe);
@@ -958,7 +958,7 @@ val_sbsa_nist_execute_tests(uint32_t level, uint32_t num_pe)
 
   for (i = 0; i < g_num_skip; i++) {
       if (g_skip_test_num[i] == ACS_NIST_TEST_NUM_BASE) {
-          val_print(TRACE, "      USER Override - Skipping all NIST tests\n");
+          val_print(TRACE, "\n USER Override - Skipping all NIST tests\n");
           return ACS_STATUS_SKIP;
       }
   }

--- a/val/src/val_logger.c
+++ b/val/src/val_logger.c
@@ -6,8 +6,11 @@
  */
 
 #include "val_logger.h"
+#include "acs_execution_policy.h"
 
 enum { LOG_MAX_STRING_LENGTH = 90 };
+enum { LOG_MSG_INDENT = 7 };
+enum { LOG_INDENT_WIDTH = 4 };
 
 static bool collect_log_output;
 static char collected_log[LOG_MAX_STRING_LENGTH * 2];
@@ -148,6 +151,37 @@ static size_t print_raw_string(const char *str)
     }
 
     return (size_t)(c - str);
+}
+
+static void skip_log_indent(const char **msg)
+{
+    uint32_t i;
+
+    for (i = 0; i < LOG_MSG_INDENT && **msg == ' '; i++)
+        (*msg)++;
+}
+
+uint32_t val_log_get_indent(void)
+{
+    return acs_policy_get_log_indent();
+}
+
+void val_log_set_indent(uint32_t indent)
+{
+    acs_policy_set_log_indent(indent);
+}
+
+static size_t print_log_indent(void)
+{
+    static const char indent_unit[LOG_INDENT_WIDTH + 1] = "    ";
+    size_t chars_written = 0;
+    uint32_t i;
+    uint32_t indent = acs_policy_get_log_indent();
+
+    for (i = 0; i < indent; i++)
+        chars_written += print_raw_string(indent_unit);
+
+    return chars_written;
 }
 
 /**
@@ -682,27 +716,29 @@ out:
 uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 {
     int chars_written = 0;
-    static bool lastWasNewline = true;
-    static bool prefixPrinted;
+    int log_result;
     char formatted_msg[LOG_MAX_STRING_LENGTH];
+    bool new_log_record;
     va_list args;
 
     if (msg == NULL)
+        return 0;
+
+    if (*msg == '\0')
         return 0;
 
     collect_log_output = true;
     collected_log_len = 0;
     collected_log[0] = '\0';
 
-    /* New line => allow prefix again */
-    if (lastWasNewline)
-        prefixPrinted = false;
+    new_log_record = (*msg == '\n');
 
-    /* Emit any leading blank lines cleanly (and don't prefix blank lines) */
+    /*
+     * Keep the legacy leading-newline convention. Caller-supplied newlines
+     * are explicit spacing; do not synthesize a leading newline for callers.
+     */
     while (*msg == '\n') {
-        print_raw_string("\r\n");
-        lastWasNewline = true;
-        prefixPrinted  = false;
+        chars_written += (int)print_raw_string("\r\n");
         msg++;
     }
 
@@ -714,32 +750,33 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
         return 0;
     }
 
-    /* Print prefix exactly once per logical line (supports multi-call line assembly) */
-    if (!prefixPrinted) {
+    /* Only messages that start with a caller-supplied newline start a log record. */
+    if (new_log_record) {
+        skip_log_indent(&msg);
+        chars_written += (int)print_log_indent();
+
         switch (verbosity)
         {
             case TRACE:
-                 print_raw_string("\t");
+                 chars_written += (int)print_raw_string("   ");
                  break;
             case DEBUG:
-                 print_raw_string("\t");
+                 chars_written += (int)print_raw_string("   ");
                  break;
             case INFO:
-                 print_raw_string("");
                  break;
             case WARN:
-                 print_raw_string("\tWARN : ");
+                 chars_written += (int)print_raw_string("   WARN : ");
                  break;
             case ERROR:
-                 print_raw_string("\tERROR: ");
+                 chars_written += (int)print_raw_string("   ERROR: ");
                  break;
             case FATAL:
-                 print_raw_string("\tFATAL: ");
+                 chars_written += (int)print_raw_string("   FATAL: ");
                  break;
             default:
                  break;
         }
-        prefixPrinted = true;
     }
 
     /* Bounded scan: we only safely inspect up to N-2 chars */
@@ -750,7 +787,7 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 
     /*
      * 3 cases:
-     *  A) msg ends with '\n' convert final LF to CRLF
+     *  A) msg ends with '\n', convert final LF to CRLF
      *  B) msg is likely longer than buffer size => truncate to N-3 and force CRLF
      *  C) short msg without '\n'
      */
@@ -763,9 +800,12 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
         formatted_msg[len]     = '\n';
         formatted_msg[len + 1] = '\0';
 
-        chars_written = val_log(formatted_msg, args);
-        lastWasNewline = true;
-        prefixPrinted  = false;
+        log_result = val_log(formatted_msg, args);
+        if (log_result < 0) {
+            chars_written = log_result;
+        } else {
+            chars_written += log_result;
+        }
     }
     /* Case B: likely truncated (no '\0' found within max_scan) */
     else if (len == max_scan)
@@ -786,15 +826,17 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 
         chars_written += (int)print_raw_string(trunc_msg);
 
-        lastWasNewline = true;
-        prefixPrinted  = false;  /* next line should get prefix */
      }
 
     /* Case C: short, no trailing '\n' */
     else
     {
-        chars_written = val_log(msg, args);
-        lastWasNewline = false;
+        log_result = val_log(msg, args);
+        if (log_result < 0) {
+            chars_written = log_result;
+        } else {
+            chars_written += log_result;
+        }
     }
 
     va_end(args);

--- a/val/src/val_status.c
+++ b/val/src/val_status.c
@@ -38,7 +38,7 @@ void val_set_status(uint32_t index, uint32_t test_res)
     volatile val_test_status_t *mem = val_get_shared_address();
 
     if (index >= val_pe_get_num()) {
-        val_print(ERROR, "val_set_status: invalid PE index %u\n",
+        val_print(ERROR, "\n       val_set_status: invalid PE index %u",
                   (unsigned int)index);
         return;
     }
@@ -63,7 +63,7 @@ uint32_t val_get_status(uint32_t index)
     volatile val_test_status_t *mem = val_get_shared_address();
 
     if (index >= val_pe_get_num()) {
-        val_print(ERROR, "val_get_status: invalid PE index %u\n",
+        val_print(ERROR, "\n       val_get_status: invalid PE index %u",
                   (unsigned int)index);
         return RESULT_UNKNOWN;
     }


### PR DESCRIPTION
  Treat a leading newline as the marker for a new log record, and keep
  strings without a leading newline as continuation prints.

  Move common indentation handling into the VAL logger and PAL print paths.
  For new log records, skip existing caller-side indentation after '\n',
  apply the active rule indent, and emit severity prefixes consistently.

  Clean up legacy call sites that would otherwise bypass the common handling,
  including trailing-newline-only prints, embedded newline formatting, and
  direct banner/header prints.

  No functional test logic changes are intended; this change is limited to
  logging behavior and output formatting cleanup.

Change-Id: I9ee7e226fccbedcc432a6f72f8fa38e8885ad86c