### PR TITLE
docs: remove device remarks from ITS topology tests

### DIFF
--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -813,7 +813,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP, iEP EP</td>
+      <td></td>
     </tr>
     <tr>
       <td>ITS_02</td>
@@ -822,7 +822,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP, iEP EP</td>
+      <td></td>
     </tr>
     <tr>
       <td>ITS_03</td>
@@ -1589,7 +1589,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP, iEP EP</td>
+      <td></td>
     </tr>
     <tr>
       <td>ITS_02</td>
@@ -1598,7 +1598,7 @@ The checklist provides information about:
       <td>Yes</td>
       <td>Yes</td>
       <td>No</td>
-      <td>RCiEP, iEP EP</td>
+      <td></td>
     </tr>
     <tr>
       <td>ITS_03</td>


### PR DESCRIPTION
 - ITS_01 and ITS_02 do not depend on RCiEP, iEP or EP devices.
 - Remove the misleading device remarks from both SBSA checklist sections.

Change-Id: Ib21ebd1d8ea3faac3f732d7fe23ef197f5567c6a