### PR TITLE
fix(uefi_dt): Initialize PMU GSIV values

### DIFF
--- a/pal/uefi_dt/src/pal_pe.c
+++ b/pal/uefi_dt/src/pal_pe.c
@@ -613,6 +613,12 @@ pal_pe_info_table_pmu_gsiv_dt(PE_INFO_TABLE *PeTable)
   }
 
   Ptr = PeTable->pe_info;
+  for (i = 0; i < PeTable->header.num_of_pe; i++) {
+    Ptr->pmu_gsiv = 0;
+    Ptr++;
+  }
+
+  Ptr = PeTable->pe_info;
 
   for (arr_idx = 0; arr_idx < (sizeof(pmu_dt_arr)/PMU_COMPATIBLE_STR_LEN); arr_idx++) {
 


### PR DESCRIPTION
* Initialize PMU GSIV entries to zero before parsing PMU DT nodes.
* Prevent stale PE table data from being reported as interrupt IDs.


Change-Id: I981cad98df7248edb5ecf103018dade57ee13a77