### PR TITLE
Feat: Add B_PER_10 to UEFI execution

### DIFF
--- a/apps/uefi/acs_helpers.c
+++ b/apps/uefi/acs_helpers.c
@@ -1215,9 +1215,10 @@ createDmaInfoTable(
     UINT64  *DmaInfoTable;
 
     DmaInfoTable = val_aligned_alloc(SIZE_4K, sizeof(DMA_INFO_TABLE)
-                                    + sizeof(DMA_INFO_BLOCK));
+                                    + (2 * sizeof(DMA_INFO_BLOCK)));
     val_dma_create_info_table(DmaInfoTable);
 }
+
 VOID
 createPeripheralInfoTable(
 )

--- a/pal/uefi_acpi/src/pal_dma.c
+++ b/pal/uefi_acpi/src/pal_dma.c
@@ -118,13 +118,19 @@ pal_dma_create_info_table(DMA_INFO_TABLE *dma_info_table)
     return;
   }
 
-  /* Expose a single coherent DMA-capable instance so the test can run. */
-  dma_info_table->num_dma_ctrls = 1;
+ /* Expose two DMA-capable instances so the test can exercise both coherent and non-coherent. */
+  dma_info_table->num_dma_ctrls = 2;
   dma_info_table->info[0].host = NULL;
   dma_info_table->info[0].port = gPalDmaPciIo;
   dma_info_table->info[0].target = NULL;
   dma_info_table->info[0].flags = DMA_COHERENT;
   dma_info_table->info[0].type = DMA_TYPE_OTHER;
+
+  dma_info_table->info[1].host = NULL;
+  dma_info_table->info[1].port = gPalDmaPciIo;
+  dma_info_table->info[1].target = NULL;
+  dma_info_table->info[1].flags = DMA_NOT_COHERENT;
+  dma_info_table->info[1].type = DMA_TYPE_OTHER;
 }
 
 /**

--- a/pal/uefi_dt/src/pal_dma.c
+++ b/pal/uefi_dt/src/pal_dma.c
@@ -114,13 +114,19 @@ pal_dma_create_info_table(DMA_INFO_TABLE *dma_info_table)
     return;
   }
 
-  /* Expose a single coherent DMA-capable instance so the test can run. */
-  dma_info_table->num_dma_ctrls = 1;
+ /* Expose two DMA-capable instances so the test can exercise both coherent and non-coherent. */
+  dma_info_table->num_dma_ctrls = 2;
   dma_info_table->info[0].host = NULL;
   dma_info_table->info[0].port = gPalDmaPciIo;
   dma_info_table->info[0].target = NULL;
   dma_info_table->info[0].flags = DMA_COHERENT;
   dma_info_table->info[0].type = DMA_TYPE_OTHER;
+
+  dma_info_table->info[1].host = NULL;
+  dma_info_table->info[1].port = gPalDmaPciIo;
+  dma_info_table->info[1].target = NULL;
+  dma_info_table->info[1].flags = 0;
+  dma_info_table->info[1].type = DMA_TYPE_OTHER;
 }
 
 /**

--- a/test_pool/peripherals/d004.c
+++ b/test_pool/peripherals/d004.c
@@ -64,7 +64,7 @@ payload_check_dma_mem_attribute(void)
   {
       target_dev_index--; /* Index is zero based */
       /* Allocate DMA memory based on coherency */
-      if (val_dma_get_info(DMA_HOST_COHERENT, target_dev_index))
+      if (val_dma_get_info(DMA_HOST_COHERENT, target_dev_index) & DMA_COHERENT)
       {
           dma_flags = DMA_COHERENT;
           status = val_dma_mem_alloc(&buffer, 512, target_dev_index, DMA_COHERENT, &dma_addr);
@@ -165,8 +165,15 @@ payload_check_io_coherent_dma_mem_attribute(void)
             if (status == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
                 goto test_warn_unimplemented;
             }
+            else if (status) {
+                val_print(WARN, "\n       Error during DMA alloc. %x", status);
+                val_set_status(index, RESULT_FAIL(1));
+                flag_fail = 1;
+                continue;
+            }
             ret = val_dma_mem_get_attrs(buffer, &attr, &sh);
             if (ret == ACS_STATUS_PAL_NOT_IMPLEMENTED) {
+                val_dma_mem_free(buffer, dma_addr, 512, target_dev_index, DMA_COHERENT);
                 goto test_warn_unimplemented;
             } else if (ret) {
                 val_print(ERROR,
@@ -174,6 +181,7 @@ payload_check_io_coherent_dma_mem_attribute(void)
                             target_dev_index);
                 val_set_status(index, RESULT_FAIL(1));
                 flag_fail = 1;
+                val_dma_mem_free(buffer, dma_addr, 512, target_dev_index, DMA_COHERENT);
                 continue;
             }
             /* Check Inner Write-Back, Outer Write-Back, Inner Shareable */
@@ -187,6 +195,7 @@ payload_check_io_coherent_dma_mem_attribute(void)
                 val_set_status(index, RESULT_FAIL(2));
                 flag_fail = 1;
             }
+            val_dma_mem_free(buffer, dma_addr, 512, target_dev_index, DMA_COHERENT);
         }
     }
     /* PASS the test if no fail conditions hit */

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -847,7 +847,7 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .test_entry_id    = D007_ENTRY,
             .module_id        = PERIPHERAL,
             .rule_desc        = "Check DMA for I/O coherency",
-            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_LINUX,
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI | PLATFORM_LINUX,
             .flag             = BASE_RULE,
             .test_num         = ACS_PER_TEST_NUM_BASE + 7,
         },
@@ -3520,6 +3520,7 @@ test_entry_fn_t test_entry_func_table[TEST_ENTRY_SENTINEL] = {
     [D006_ENTRY] = d006_entry,
     [D008_ENTRY] = d008_entry,
     [D004_ENTRY] = d004_entry,
+    [D007_ENTRY] = d007_entry,
     [E001_ENTRY] = e001_entry, // used in wrapper.
     [E002_ENTRY] = e002_entry, // used in wrapper.
     [E003_ENTRY] = e003_entry,


### PR DESCRIPTION
    - Used existing PAL and VAL implementations to add B_PER_10 to UEFI execution
    - Added a non-coherent buffer for full coverage of the rule


Change-Id: Iadaac6ce2189a4fff10422d678407cc1c9b31ef7