### PR TITLE
fix(sbsa): avoid duplicate PMU_PE_01 execution

### DIFF
--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -4739,10 +4739,10 @@ const RULE_ID_e s_l7pmu_rule_list[]   = {
                                     PMU_SYS_2, PMU_SYS_5, PMU_SYS_6, PMU_MEM_1,
                                     PMU_BM_1, PMU_BM_2,  PMU_EV_11, PMU_SPE,
                                     /* Not covered or Not implemented*/
-                                    PMU_PE_01, PMU_EV_01, PMU_EV_02, PMU_EV_03,
-                                    PMU_EV_04, PMU_EV_05, PMU_EV_06, PMU_EV_07,
-                                    PMU_EV_08, PMU_EV_09, PMU_EV_10, PMU_BM_3,
-                                    PMU_BM_4, PMU_SYS_7, PMU_SEC_1,
+                                    PMU_EV_01, PMU_EV_02, PMU_EV_03, PMU_EV_04,
+                                    PMU_EV_05, PMU_EV_06, PMU_EV_07, PMU_EV_08,
+                                    PMU_EV_09, PMU_EV_10, PMU_BM_3, PMU_BM_4,
+                                    PMU_SYS_7, PMU_SEC_1,
                                     /********/
                                     RULE_ID_SENTINEL};
 


### PR DESCRIPTION
Remove the duplicate PMU_PE_01 entry from the S_L7PMU alias rule list so the test is executed only once.


Change-Id: I41b7780f9559d46004d57fcf5621db9575767647