### PR TITLE
sbsa: update ACS release version to 8.0.3

### DIFF
--- a/docs/sbsa/README.md
+++ b/docs/sbsa/README.md
@@ -56,6 +56,8 @@ The tests can also be executed in a Bare-metal environment. The initialization o
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 |   SBSA Spec Version   |   ACS Coverage Mapping   |   SBSA ACS Version   |        SBSA Tag ID         |   BSA ACS Version   |          BSA Tag ID         |    Pre-Si Support    |
 |-----------------------|:------------------------:|:--------------------:|:--------------------------:|:-------------------:|:---------------------------:|:--------------------:|
+|       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.3          |   v26.08_SBSA_8.0.3        |        v1.2.1       |       v26.03_BSA_1.2.1      |       Yes            |
+|       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.2          |   v26.06_SBSA_8.0.2        |        v1.2.1       |       v26.03_BSA_1.2.1      |       Yes            |
 |       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.1          |   v26.03_SBSA_8.0.1        |        v1.2.1       |       v26.03_BSA_1.2.1      |       Yes            |
 |       SBSA v8.0       |    BSA ACS + SBSA ACS    |      v8.0.0          |   v25.12_SBSA_8.0.0        |        v1.2.0       |       v25.12_BSA_1.2.0      |       Yes            |
 |       SBSA v7.2       |    BSA ACS + SBSA ACS    |      v7.2.2          |   v25.03_REL7.2.2          |        v1.1.0       |       v25.03_REL1.1.0       |       Yes            |

--- a/docs/sbsa/arm_sbsa_testcase_checklist.md
+++ b/docs/sbsa/arm_sbsa_testcase_checklist.md
@@ -1,6 +1,6 @@
 ## SBSA ACS Testcase checklist
 
-The SBSA ACS test checklist is based on **SBSA 8.0 specification** and **SBSA ACS 8.0.1** tag.
+The SBSA ACS test checklist is based on **SBSA 8.0 specification** and **SBSA ACS 8.0.3** tag.
 
 The checklist provides information about:
 
@@ -3676,12 +3676,15 @@ The checklist provides information about:
 </table>
 
 ## Latest Checklist Changes
+### v26.08_SBSA_8.0.3
 - Updated S_L3_01 platform coverage.
 - Synced covered checklist descriptions and S_L7ENT_1 platform coverage with rule_metadata.c.
+- Updated ITS_08, ITS_DEV_5
+
+### v26.06_SBSA_8.0.2
 - Updated PCI_MM_02 coverage with test 907.
 - Updated S_L5SM_04, S_L6PE_08, S_L6SM_04
 - Added rule S_L5PE_03
-- Updated ITS_08, ITS_DEV_5
 
 ### v26.03_SBSA_8.0.1
 - **FR Added:** LVQBC, KBRZG

--- a/val/include/acs_app_versions.h
+++ b/val/include/acs_app_versions.h
@@ -26,7 +26,7 @@
 /* SBSA Release versions */
 #define SBSA_ACS_MAJOR_VER         8
 #define SBSA_ACS_MINOR_VER         0
-#define SBSA_ACS_SUBMINOR_VER      1
+#define SBSA_ACS_SUBMINOR_VER      3
 
 /* PC BSA Release versions */
 #define PC_BSA_ACS_MAJOR_VER       1


### PR DESCRIPTION
- Update SBSA ACS version metadata from 8.0.1 to 8.0.3 and refresh the corresponding release tag references to v26.08_SBSA_8.0.3.

Change-Id: Ia6d492f8582532918347f2a44b3ff31c27277eda