### PR TITLE
fix(smmu): Added checks for SMMU_IDR0.HTTU ==  (0b10 or 0b11)

### DIFF
--- a/test_pool/smmu/i013.c
+++ b/test_pool/smmu/i013.c
@@ -51,8 +51,8 @@ payload(void)
 
       data = VAL_EXTRACT_BITS(val_smmu_read_cfg(SMMUv3_IDR0, num_smmu), 6, 7);
 
-      /* Check If SMMU_IDR0.HTTU == 0b10 */
-      if (data != 2) {
+      /* Check If SMMU_IDR0.HTTU == (0b10 or 0b11) */
+      if ((data != 2) && (data != 3)) {
           val_set_status(index, RESULT_FAIL(01));
           return;
       }


### PR DESCRIPTION
   S_L6SM_02 - SMMU v3.4 spec added new value 0b11 to SMMU_IDR0.HTTU, which indicates,
    Access flag + Dirty State + Access Flag for table descriptors supported. This value needs to be supported in ACS code.

Fixes #524 , #522 

Change-Id: I6e799002b39497501824e835118fd0853a7b4f0a