### PR TITLE
Errata #902(pc-bsa): Add HBCCD rule coverage

### DIFF
--- a/test_pool/pe/pe040.c
+++ b/test_pool/pe/pe040.c
@@ -21,7 +21,11 @@
 
 
 #define TEST_NUM   (ACS_PE_TEST_NUM_BASE  +  40)
+#ifdef PC_BSA
+#define TEST_RULE  "HBCCD"
+#else
 #define TEST_RULE  "S_L6PE_04"
+#endif
 #define TEST_DESC  "Check PMU Version v3.5 or higher      "
 
 #define TEST_NUM1   (ACS_PE_TEST_NUM_BASE  +  64)

--- a/tools/cmake/infra/pc_bsa_test.txt
+++ b/tools/cmake/infra/pc_bsa_test.txt
@@ -25,6 +25,7 @@ pe028.c
 pe029.c
 pe030.c
 pe036.c
+pe040.c
 pe048.c
 pe049.c
 g001.c

--- a/val/include/rule_based_execution_enum.h
+++ b/val/include/rule_based_execution_enum.h
@@ -110,6 +110,7 @@ typedef enum {
     YKRHG,
     CNBRV,
     PBCRQ,
+    HBCCD,
 
     /* GIC rules */
     B_GIC_01,

--- a/val/src/rule_enum_string_map.c
+++ b/val/src/rule_enum_string_map.c
@@ -486,6 +486,7 @@ char *rule_id_string[RULE_ID_SENTINEL] = {
     [YKRHG]       = "YKRHG",
     [CNBRV]       = "CNBRV",
     [PBCRQ]       = "PBCRQ",
+    [HBCCD]       = "HBCCD",
     [P_L1MM_01]   = "P_L1MM_01",
     [P_L1GI_01]   = "P_L1GI_01",
     [P_L1GI_03]   = "P_L1GI_03",

--- a/val/src/rule_metadata.c
+++ b/val/src/rule_metadata.c
@@ -2555,6 +2555,14 @@ rule_test_map_t rule_test_map[RULE_ID_SENTINEL] = {
             .flag             = BASE_RULE,
             .test_num         = ACS_PE_TEST_NUM_BASE  + 49,
         },
+        [HBCCD] = {
+            .test_entry_id    = PE040_ENTRY,
+            .module_id        = PE,
+            .rule_desc        = "Check PMU Version v3.5 or higher",
+            .platform_bitmask = PLATFORM_BAREMETAL | PLATFORM_UEFI,
+            .flag             = BASE_RULE,
+            .test_num         = ACS_PE_TEST_NUM_BASE  + 40,
+        },
         [P_L1SM_02] = {
             .test_entry_id    = I008_ENTRY,
             .module_id        = SMMU,
@@ -3974,6 +3982,7 @@ test_entry_fn_t test_entry_func_table[TEST_ENTRY_SENTINEL] = {
     [PE029_ENTRY] = pe029_entry,
     [PE030_ENTRY] = pe030_entry,
     [PE036_ENTRY] = pe036_entry,
+    [PE040_ENTRY] = pe040_entry,
     [PE048_ENTRY] = pe048_entry,
     [PE049_ENTRY] = pe049_entry,
     [PE063_ENTRY] = pe063_entry,


### PR DESCRIPTION
- Add HBCCD as a PC-BSA rule
- Did not add HBCCD to any PC-BSA level list so it runs only when explicitly selected using -r as the checklist in spec is not updated.
- Update PC-BSA baremetal source list and selected test entry table to include PE040_ENTRY coverage.


Change-Id: I35903e02feb45a85e8e47efa11f783b7a4ca8497